### PR TITLE
Update slick.dataview.js

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -775,7 +775,7 @@
 
     function getRowDiffs(rows, newRows) {
       var item, r, eitherIsNonData, diff = [];
-      var from = 0, to = newRows.length;
+      var from = 0, to = Math.max(newRows.length, rows.length);
 
       if (refreshHints && refreshHints.ignoreDiffsBefore) {
         from = Math.max(0,
@@ -783,11 +783,11 @@
       }
 
       if (refreshHints && refreshHints.ignoreDiffsAfter) {
-        to = Math.min(newRows.length,
+        to = Math.min(to,
             Math.max(0, refreshHints.ignoreDiffsAfter));
       }
 
-      for (var i = from, rl = rows.length; i < to; i++) {
+      for (var i = from, rl = Math.min(newRows.length, rows.length); i < to; i++) {
         if (i >= rl) {
           diff[diff.length] = i;
         } else {


### PR DESCRIPTION
Fix filtering issue if the n new rows are identicals to the n current rows.
See the [fiddle] (http://jsfiddle.net/hLf0d5mL/3/)  :
* Filter with 'abcd'
* The first row is not filtered
* Filter with 'zzzz'
* The last row is filtered