### PR TITLE
fix bug - do not remove last row from cache

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1639,7 +1639,7 @@ if (typeof Slick === "undefined") {
       // this helps avoid redundant calls to .removeRow() when the size of the data decreased by thousands of rows
       var l = dataLengthIncludingAddNew - 1;
       for (var i in rowsCache) {
-        if (i >= l) {
+        if (i > l) {
           removeRowFromCache(i);
         }
       }


### PR DESCRIPTION
It seems an obvious boundary check mistake, comparing the 2 condition check in https://github.com/6pac/SlickGrid/blob/2.1/slick.grid.js#L1601-L1610.