### PR TITLE
Changes to support jQuery 3

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -14,10 +14,10 @@
 
       $menu = $("<span class='slick-columnpicker' style='display:none;position:absolute;z-index:20;' />").appendTo(document.body);
 
-      $menu.bind("mouseleave", function (e) {
+      $menu.on("mouseleave", function (e) {
         $(this).fadeOut(options.fadeSpeed)
       });
-      $menu.bind("click", updateColumn);
+      $menu.on("click", updateColumn);
 
     }
 

--- a/examples/example-header-row.html
+++ b/examples/example-header-row.html
@@ -111,7 +111,7 @@
     });
 
 
-    $(grid.getHeaderRow()).delegate(":input", "change keyup", function (e) {
+    $(grid.getHeaderRow()).on("change keyup", ":input", function (e) {
       var columnId = $(this).data("columnId");
       if (columnId != null) {
         columnFilters[columnId] = $.trim($(this).val());

--- a/examples/example3a-compound-editors.html
+++ b/examples/example3a-compound-editors.html
@@ -71,13 +71,13 @@
     this.init = function () {
       $from = $("<INPUT type=text style='width:40px' />")
           .appendTo(args.container)
-          .bind("keydown", scope.handleKeyDown);
+          .on("keydown", scope.handleKeyDown);
 
       $(args.container).append("&nbsp; to &nbsp;");
 
       $to = $("<INPUT type=text style='width:40px' />")
           .appendTo(args.container)
-          .bind("keydown", scope.handleKeyDown);
+          .on("keydown", scope.handleKeyDown);
 
       scope.focus();
     };

--- a/examples/example9-row-reordering.html
+++ b/examples/example9-row-reordering.html
@@ -282,19 +282,19 @@ $(function () {
 
   $.drop({mode: "mouse"});
   $("#dropzone")
-      .bind("dropstart", function (e, dd) {
+      .on("dropstart", function (e, dd) {
         if (dd.mode != "recycle") {
           return;
         }
         $(this).css("background", "yellow");
       })
-      .bind("dropend", function (e, dd) {
+      .on("dropend", function (e, dd) {
         if (dd.mode != "recycle") {
           return;
         }
         $(dd.available).css("background", "pink");
       })
-      .bind("drop", function (e, dd) {
+      .on("drop", function (e, dd) {
         if (dd.mode != "recycle") {
           return;
         }

--- a/plugins/slick.headerbuttons.js
+++ b/plugins/slick.headerbuttons.js
@@ -122,11 +122,11 @@
           }
 
           if (button.handler) {
-            btn.bind("click", button.handler);
+            btn.on("click", button.handler);
           }
 
           btn
-            .bind("click", handleButtonClick)
+            .on("click", handleButtonClick)
             .appendTo(args.node);
         }
       }

--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -100,13 +100,13 @@
       _grid.setColumns(_grid.getColumns());
 
       // Hide the menu on outside click.
-      $(document.body).bind("mousedown", handleBodyMouseDown);
+      $(document.body).on("mousedown", handleBodyMouseDown);
     }
 
 
     function destroy() {
       _handler.unsubscribeAll();
-      $(document.body).unbind("mousedown", handleBodyMouseDown);
+      $(document.body).off("mousedown", handleBodyMouseDown);
     }
 
 
@@ -149,7 +149,7 @@
         }
 
         $el
-          .bind("click", showMenu)
+          .on("click", showMenu)
           .appendTo(args.node);
       }
     }
@@ -195,7 +195,7 @@
           .data("command", item.command || '')
           .data("column", columnDef)
           .data("item", item)
-          .bind("click", handleMenuItemClick)
+          .on("click", handleMenuItemClick)
           .appendTo($menu);
 
         if (item.disabled) {

--- a/slick.editors.js
+++ b/slick.editors.js
@@ -29,7 +29,7 @@
     this.init = function () {
       $input = $("<INPUT type=text class='editor-text' />")
           .appendTo(args.container)
-          .bind("keydown.nav", function (e) {
+          .on("keydown.nav", function (e) {
             if (e.keyCode === $.ui.keyCode.LEFT || e.keyCode === $.ui.keyCode.RIGHT) {
               e.stopImmediatePropagation();
             }
@@ -98,7 +98,7 @@
     this.init = function () {
       $input = $("<INPUT type=text class='editor-text' />");
 
-      $input.bind("keydown.nav", function (e) {
+      $input.on("keydown.nav", function (e) {
         if (e.keyCode === $.ui.keyCode.LEFT || e.keyCode === $.ui.keyCode.RIGHT) {
           e.stopImmediatePropagation();
         }
@@ -167,7 +167,7 @@
     this.init = function () {
       $input = $("<INPUT type=text class='editor-text' />");
 
-      $input.bind("keydown.nav", function (e) {
+      $input.on("keydown.nav", function (e) {
         if (e.keyCode === $.ui.keyCode.LEFT || e.keyCode === $.ui.keyCode.RIGHT) {
           e.stopImmediatePropagation();
         }
@@ -188,22 +188,22 @@
 	function getDecimalPlaces() {
 		// returns the number of fixed decimal places or null
 		var rtn = args.column.editorFixedDecimalPlaces;
-		if (typeof rtn == 'undefined') { 
+		if (typeof rtn == 'undefined') {
 			rtn = FloatEditor.DefaultDecimalPlaces;
 		}
 		return (!rtn && rtn!==0 ? null : rtn);
 	}
-	
+
     this.loadValue = function (item) {
       defaultValue = item[args.column.field];
-	  
+
 	  var decPlaces = getDecimalPlaces();
-	  if (decPlaces !== null 
-	  && (defaultValue || defaultValue===0) 
-	  && defaultValue.toFixed) { 
+	  if (decPlaces !== null
+	  && (defaultValue || defaultValue===0)
+	  && defaultValue.toFixed) {
 		defaultValue = defaultValue.toFixed(decPlaces);
 	  }
-	  
+
       $input.val(defaultValue);
       $input[0].defaultValue = defaultValue;
       $input.select();
@@ -213,12 +213,12 @@
 	  var rtn = parseFloat($input.val()) || 0;
 
 	  var decPlaces = getDecimalPlaces();
-	  if (decPlaces !== null 
-	  && (rtn || rtn===0) 
-	  && rtn.toFixed) { 
+	  if (decPlaces !== null
+	  && (rtn || rtn===0)
+	  && rtn.toFixed) {
 		rtn = parseFloat(rtn.toFixed(decPlaces));
 	  }
-	  
+
       return rtn;
     };
 
@@ -255,7 +255,7 @@
   }
 
   FloatEditor.DefaultDecimalPlaces = null;
-  
+
   function DateEditor(args) {
     var $input;
     var defaultValue;
@@ -470,7 +470,7 @@
         }
       });
 
-      $picker.find(".editor-percentcomplete-buttons button").bind("click", function (e) {
+      $picker.find(".editor-percentcomplete-buttons button").on("click", function (e) {
         $input.val($(this).attr("val"));
         $picker.find(".editor-percentcomplete-slider").slider("value", $(this).attr("val"));
       })
@@ -541,9 +541,9 @@
       $("<DIV style='text-align:right'><BUTTON>Save</BUTTON><BUTTON>Cancel</BUTTON></DIV>")
           .appendTo($wrapper);
 
-      $wrapper.find("button:first").bind("click", this.save);
-      $wrapper.find("button:last").bind("click", this.cancel);
-      $input.bind("keydown", this.handleKeyDown);
+      $wrapper.find("button:first").on("click", this.save);
+      $wrapper.find("button:last").on("click", this.cancel);
+      $input.on("keydown", this.handleKeyDown);
 
       scope.position(args.position);
       $input.focus().select();

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -318,7 +318,7 @@ if (typeof Slick === "undefined") {
         if (!options.enableTextSelectionOnCells) {
           // disable text selection in grid cells except in input and textarea elements
           // (this is IE-specific, because selectstart event will only fire in IE)
-          $viewport.bind("selectstart.ui", function (event) {
+          $viewport.on("selectstart.ui", function (event) {
             return $(event.target).is("input,textarea");
           });
         }
@@ -331,41 +331,41 @@ if (typeof Slick === "undefined") {
         bindAncestorScrollEvents();
 
         $container
-            .bind("resize.slickgrid", resizeCanvas);
+            .on("resize.slickgrid", resizeCanvas);
         $viewport
-            //.bind("click", handleClick)
-            .bind("scroll", handleScroll);
+            //.on("click", handleClick)
+            .on("scroll", handleScroll);
         $headerScroller
-            .bind("contextmenu", handleHeaderContextMenu)
-            .bind("click", handleHeaderClick)
+            .on("contextmenu", handleHeaderContextMenu)
+            .on("click", handleHeaderClick)
             .delegate(".slick-header-column", "mouseenter", handleHeaderMouseEnter)
             .delegate(".slick-header-column", "mouseleave", handleHeaderMouseLeave);
         $headerRowScroller
-            .bind("scroll", handleHeaderRowScroll);
+            .on("scroll", handleHeaderRowScroll);
 
         if (options.createFooterRow) {
           $footerRowScroller
-              .bind("scroll", handleFooterRowScroll);
+              .on("scroll", handleFooterRowScroll);
         }
 
         $focusSink.add($focusSink2)
-            .bind("keydown", handleKeyDown);
+            .on("keydown", handleKeyDown);
         $canvas
-            .bind("keydown", handleKeyDown)
-            .bind("click", handleClick)
-            .bind("dblclick", handleDblClick)
-            .bind("contextmenu", handleContextMenu)
-            .bind("draginit", handleDragInit)
-            .bind("dragstart", {distance: 3}, handleDragStart)
-            .bind("drag", handleDrag)
-            .bind("dragend", handleDragEnd)
+            .on("keydown", handleKeyDown)
+            .on("click", handleClick)
+            .on("dblclick", handleDblClick)
+            .on("contextmenu", handleContextMenu)
+            .on("draginit", handleDragInit)
+            .on("dragstart", {distance: 3}, handleDragStart)
+            .on("drag", handleDrag)
+            .on("dragend", handleDragEnd)
             .delegate(".slick-cell", "mouseenter", handleMouseEnter)
             .delegate(".slick-cell", "mouseleave", handleMouseLeave);
 
         // Work around http://crbug.com/312427.
         if (navigator.userAgent.toLowerCase().match(/webkit/) &&
             navigator.userAgent.toLowerCase().match(/macintosh/)) {
-          $canvas.bind("mousewheel", handleMouseWheel);
+          $canvas.on("mousewheel", handleMouseWheel);
         }
         restoreCssFromHiddenInit();
       }
@@ -491,7 +491,7 @@ if (typeof Slick === "undefined") {
         $target
             .attr("unselectable", "on")
             .css("MozUserSelect", "none")
-            .bind("selectstart.ui", function () {
+            .on("selectstart.ui", function () {
               return false;
             }); // from jquery:ui.core.js 1.7.2
       }
@@ -529,7 +529,7 @@ if (typeof Slick === "undefined") {
           } else {
             $boundAncestors = $boundAncestors.add($elem);
           }
-          $elem.bind("scroll." + uid, handleActiveCellPositionChange);
+          $elem.on("scroll." + uid, handleActiveCellPositionChange);
         }
       }
     }
@@ -538,7 +538,7 @@ if (typeof Slick === "undefined") {
       if (!$boundAncestors) {
         return;
       }
-      $boundAncestors.unbind("scroll." + uid);
+      $boundAncestors.off("scroll." + uid);
       $boundAncestors = null;
     }
 
@@ -646,7 +646,7 @@ if (typeof Slick === "undefined") {
           });
         $footerRow.empty();
 	  }
- 
+
       for (var i = 0; i < columns.length; i++) {
         var m = columns[i];
 
@@ -833,7 +833,7 @@ if (typeof Slick === "undefined") {
         $col = $(e);
         $("<div class='slick-resizable-handle' />")
             .appendTo(e)
-            .bind("dragstart", function (e, dd) {
+            .on("dragstart", function (e, dd) {
               if (!getEditorLock().commitCurrentEdit()) {
                 return false;
               }
@@ -892,7 +892,7 @@ if (typeof Slick === "undefined") {
               maxPageX = pageX + Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft);
               minPageX = pageX - Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight);
             })
-            .bind("drag", function (e, dd) {
+            .on("drag", function (e, dd) {
               var actualMinWidth, d = Math.min(maxPageX, Math.max(minPageX, e.pageX)) - pageX, x;
               if (d < 0) { // shrink column
                 x = d;
@@ -962,7 +962,7 @@ if (typeof Slick === "undefined") {
                 applyColumnWidths();
               }
             })
-            .bind("dragend", function (e, dd) {
+            .on("dragend", function (e, dd) {
               var newWidth;
               $(this).parent().removeClass("slick-header-column-active");
               for (j = 0; j < columnElements.length; j++) {
@@ -999,7 +999,7 @@ if (typeof Slick === "undefined") {
 	  // so for equivalent functionality, prior to 1.8 use .width, and after use .outerWidth
 	  var verArray = $.fn.jquery.split('.');
 	  jQueryNewWidthBehaviour = (verArray[0]==1 && verArray[1]>=8) ||  verArray[0] >=2;
-	  
+
       el = $("<div class='ui-state-default slick-header-column' style='visibility:hidden'>-</div>").appendTo($headers);
       headerColumnWidthDiff = headerColumnHeightDiff = 0;
       if (el.css("box-sizing") != "border-box" && el.css("-moz-box-sizing") != "border-box" && el.css("-webkit-box-sizing") != "border-box") {
@@ -1109,10 +1109,10 @@ if (typeof Slick === "undefined") {
       }
 
       unbindAncestorScrollEvents();
-      $container.unbind(".slickgrid");
+      $container.off(".slickgrid");
       removeCssRules();
 
-      $canvas.unbind("draginit dragstart dragend drag");
+      $canvas.off("draginit dragstart dragend drag");
       $container.empty().removeClass(uid);
     }
 
@@ -2408,7 +2408,7 @@ if (typeof Slick === "undefined") {
 
           if (options.enableAsyncPostRenderCleanup) { startPostProcessingCleanup(); }
         }
-        rowNodeFromLastMouseWheelEvent = rowNode;      
+        rowNodeFromLastMouseWheelEvent = rowNode;
       }
     }
 
@@ -2459,7 +2459,7 @@ if (typeof Slick === "undefined") {
         if (!e.shiftKey && !e.altKey && !e.ctrlKey) {
 		  // editor may specify an array of keys to bubble
           if (options.editable && currentEditor && currentEditor.keyCaptureList) {
-            if (currentEditor.keyCaptureList.indexOf( e.which ) > -1) { 
+            if (currentEditor.keyCaptureList.indexOf( e.which ) > -1) {
                 return;
             }
           }
@@ -2470,7 +2470,7 @@ if (typeof Slick === "undefined") {
             cancelEditAndSetFocus();
           } else if (e.which == keyCode.PAGE_DOWN) {
             navigatePageDown();
-            handled = true;           
+            handled = true;
           } else if (e.which == keyCode.PAGE_UP) {
             navigatePageUp();
             handled = true;
@@ -2860,12 +2860,12 @@ if (typeof Slick === "undefined") {
       $(activeCellNode).addClass("editable");
 
 	  var useEditor = editor || getEditor(activeRow, activeCell);
-	  
+
       // don't clear the cell if a custom editor is passed through
       if (!editor && !useEditor.suppressClearOnEdit) {
         activeCellNode.innerHTML = "";
       }
- 
+
       currentEditor = new useEditor({
         grid: self,
         gridPosition: absBox($container[0]),
@@ -2921,7 +2921,7 @@ if (typeof Slick === "undefined") {
       var offsetParent = elem.offsetParent;
       while ((elem = elem.parentNode) != document.body) {
 		if (elem == null) break;
-		
+
         if (box.visible && elem.scrollHeight != elem.offsetHeight && $(elem).css("overflowY") != "visible") {
           box.visible = box.bottom > elem.scrollTop && box.top < elem.scrollTop + elem.clientHeight;
         }
@@ -3033,7 +3033,7 @@ if (typeof Slick === "undefined") {
         var prevActivePosX = activePosX;
         while (cell <= activePosX) {
           if (canCellBeActive(row, cell)) {
-            prevCell = cell;  
+            prevCell = cell;
           }
           cell += getColspan(row, cell);
         }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -373,7 +373,7 @@ if (typeof Slick === "undefined") {
 
     function cacheCssForHiddenInit() {
       // handle display:none on container or container parents
-      $hiddenParents = $container.parents().andSelf().not(':visible');
+      $hiddenParents = $container.parents().addBack().not(':visible');
       $hiddenParents.each(function() {
         var old = {};
         for ( var name in cssShow ) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -338,8 +338,8 @@ if (typeof Slick === "undefined") {
         $headerScroller
             .on("contextmenu", handleHeaderContextMenu)
             .on("click", handleHeaderClick)
-            .delegate(".slick-header-column", "mouseenter", handleHeaderMouseEnter)
-            .delegate(".slick-header-column", "mouseleave", handleHeaderMouseLeave);
+            .on("mouseenter", ".slick-header-column", handleHeaderMouseEnter)
+            .on("mouseleave", ".slick-header-column", handleHeaderMouseLeave);
         $headerRowScroller
             .on("scroll", handleHeaderRowScroll);
 
@@ -359,8 +359,8 @@ if (typeof Slick === "undefined") {
             .on("dragstart", {distance: 3}, handleDragStart)
             .on("drag", handleDrag)
             .on("dragend", handleDragEnd)
-            .delegate(".slick-cell", "mouseenter", handleMouseEnter)
-            .delegate(".slick-cell", "mouseleave", handleMouseLeave);
+            .on("mouseenter", ".slick-cell", handleMouseEnter)
+            .on("mouseleave", ".slick-cell", handleMouseLeave);
 
         // Work around http://crbug.com/312427.
         if (navigator.userAgent.toLowerCase().match(/webkit/) &&


### PR DESCRIPTION
Hey @6pac, thanks for your work in keeping this.

This PR is a set of harmless changes in order to provide compatibility with jQuery 3.

The changes were based on running the jQuery Migration plugin for version 3. They are supposed to be harmless and were doubled checked by running the tests (nothing broke) and also did some basic manual testing.

For more details on each change see:
- https://jquery.com/upgrade-guide/3.0/
And more specifically:
- https://github.com/jquery/jquery-migrate/blob/master/warnings.md#jqmigrate-jqueryfnandself-replaced-by-jqueryfnaddback
- https://github.com/jquery/jquery-migrate/blob/master/warnings.md#jqmigrate-jqueryfnbind-is-deprecated

I also removed trailing whitespace, so feel free to [view the diff without whitespace diffs](https://github.com/6pac/SlickGrid/pull/39/files?w=1). Thanks