### PR TITLE
Scroll on Y overflow when using column picker

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -73,7 +73,7 @@
       $menu
           .css("top", e.pageY - 10)
           .css("left", e.pageX - 10)
-          .css("max-height", jQuery(window).height() - e.pageY -10)
+          .css("max-height", $(window).height() - e.pageY -10)
           .fadeIn(options.fadeSpeed);
     }
 

--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -12,7 +12,7 @@
       grid.onColumnsReordered.subscribe(updateColumnOrder);
       options = $.extend({}, defaults, options);
 
-      $menu = $("<span class='slick-columnpicker' style='display:none;position:absolute;z-index:20;' />").appendTo(document.body);
+      $menu = $("<span class='slick-columnpicker' style='display:none;position:absolute;z-index:20;overflow-y:scroll;' />").appendTo(document.body);
 
       $menu.on("mouseleave", function (e) {
         $(this).fadeOut(options.fadeSpeed)
@@ -73,6 +73,7 @@
       $menu
           .css("top", e.pageY - 10)
           .css("left", e.pageX - 10)
+          .css("max-height", jQuery(window).height() - e.pageY -10)
           .fadeIn(options.fadeSpeed);
     }
 


### PR DESCRIPTION
Added a scroll on Y overflow to the column picker. Useful with large quantity of columns when not all column fit into the browser window.