### PR TITLE
Allow html for columnpicker labels

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -44,7 +44,7 @@
         }
 
         $("<label />")
-            .text(columns[i].name)
+            .html(columns[i].name)
             .prepend($input)
             .appendTo($li);
       }

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -362,12 +362,6 @@
       updateIdxById(idx);
       refresh();
     }
-    
-    function clearItems() {      
-      idxById = {};
-      items = [];
-      refresh();
-    }
 
     function getLength() {
       return rows.length;
@@ -1033,7 +1027,6 @@
       "deleteItem": deleteItem,
       "syncGridSelection": syncGridSelection,
       "syncGridCellCssStyles": syncGridCellCssStyles,
-      "clearItems": clearItems,
 
       // data provider methods
       "getLength": getLength,

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -362,6 +362,12 @@
       updateIdxById(idx);
       refresh();
     }
+    
+    function clearItems() {      
+      idxById = {};
+      items = [];
+      refresh();
+    }
 
     function getLength() {
       return rows.length;
@@ -1027,6 +1033,7 @@
       "deleteItem": deleteItem,
       "syncGridSelection": syncGridSelection,
       "syncGridCellCssStyles": syncGridCellCssStyles,
+      "clearItems": clearItems,
 
       // data provider methods
       "getLength": getLength,


### PR DESCRIPTION
Added the possibility to use HTML for the column picker labels.
Today, it is possible to use html for header labels within SlickGrid however the column picker doesn't support it. The result is an ugly html tag with content instead of a nicely formatted DOM.

This commit/pull request allows to have header labels as html while using the column picker.