### PR TITLE
Add support for adding extra rows at bottom if paste overflows

### DIFF
--- a/examples/example-excel-compatible-spreadsheet.html
+++ b/examples/example-excel-compatible-spreadsheet.html
@@ -34,7 +34,8 @@
     <ul>
       <li>Copy a range of cells to clipboard in Excel</li>
       <li>Select a cell on slickgrid</li> 
-      <li>Use Ctrl-V keyboard shortcut to paste from the clipboard</li> 
+      <li>Use Ctrl-V keyboard shortcut to paste from the clipboard</li>
+      <li>Adds rows to bottom of grid if paste overflows</li>
     </ul>
     <h2>Copy for Excel-compatible:</h2>
     <ul>
@@ -132,9 +133,26 @@
     }
   });
 
+  var newRowIds = 0;
+
   var pluginOptions = {
     clipboardCommandHandler: function(editCommand){ undoRedoBuffer.queueAndExecuteCommand.call(undoRedoBuffer,editCommand); },
-    includeHeaderWhenCopying : false
+    includeHeaderWhenCopying : false,
+    newRowCreator: function(count) {
+
+      for (var i = 0; i < count; i++) {
+
+        var item = {
+
+          id: "newRow_" + newRowIds++
+
+        }
+
+        grid.getData().addItem(item);
+
+      }
+
+    }
   };
 
   var columns = [

--- a/plugins/slick.cellexternalcopymanager.js
+++ b/plugins/slick.cellexternalcopymanager.js
@@ -26,6 +26,7 @@
         bodyElement: option to specify a custom DOM element which to will be added the hidden textbox. It's useful if the grid is inside a modal dialog.
         onCopyInit: optional handler to run when copy action initializes
         onCopySuccess: optional handler to run when copy action is complete
+        newRowCreator: function to add rows to table if paste overflows bottom of table
     */
     var _grid;
     var _self = this;
@@ -179,7 +180,18 @@
           d.push({});
         _grid.setData(d);
         _grid.render();
-      }  
+      }
+
+      var overflowsBottomOfGrid = activeRow + destH > _grid.getDataLength();
+
+      if (_options.newRowCreator && overflowsBottomOfGrid) {
+
+        var newRowsNeeded = activeRow + destH - _grid.getDataLength();
+
+        _options.newRowCreator(newRowsNeeded);
+
+      }
+
       var clipCommand = {
 
         isClipboardCommand: true,


### PR DESCRIPTION
I think this is a common use-case: copy a chunk of data from Excel then paste into an empty SlickGrid. It's a pain to have to insert the appropriate number of blank rows beforehand.