### PR TITLE
Fix bug where can't navigate by cursor keys after paste

### DIFF
--- a/plugins/slick.cellexternalcopymanager.js
+++ b/plugins/slick.cellexternalcopymanager.js
@@ -352,7 +352,8 @@
                 return true;
             }
             else {
-                var $focus = $(_grid.getActiveCellNode());
+                var focusEl = document.activeElement;
+
                 var ta = _createTextBox(clipText);
 
                 ta.focus();
@@ -360,11 +361,11 @@
                 setTimeout(function(){
                      _bodyElement.removeChild(ta);
                     // restore focus
-                    if ($focus && $focus.length>0) {
-                        $focus.attr('tabIndex', '-1');
-                        $focus.focus();
-                        $focus.removeAttr('tabIndex');
-                    }
+                    if (focusEl)
+                        focusEl.focus();
+                    else
+                        console.log("Not element to restore focus to after copy?");
+
                 }, 100);
 
                 if (_onCopySuccess) {


### PR DESCRIPTION
If you copy something from the SlickGrid by shortcut key, you can't then use the cursor keys to navigate afterwards. It seems to me that the old code to restore the focused component never worked?