### PR TITLE
Allow retrieval of the default filter on a dataView

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -210,6 +210,11 @@
       }
     }
 
+    function getFilteredItems(){
+      return filteredItems;
+    }
+
+
     function getFilter(){
       return filter;
     }
@@ -1005,6 +1010,7 @@
       "setItems": setItems,
       "setFilter": setFilter,
       "getFilter": getFilter,
+      "getFilteredItems": getFilteredItems,
       "sort": sort,
       "fastSort": fastSort,
       "reSort": reSort,

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -210,6 +210,10 @@
       }
     }
 
+    function getFilter(){
+      return filter;
+    }
+    
     function setFilter(filterFn) {
       filter = filterFn;
       if (options.inlineFilters) {
@@ -1000,6 +1004,7 @@
       "getItems": getItems,
       "setItems": setItems,
       "setFilter": setFilter,
+      "getFilter": getFilter,
       "sort": sort,
       "fastSort": fastSort,
       "reSort": reSort,


### PR DESCRIPTION
 * This allows using the original default filter in a custom filter
 * Means I dont have to rewrite the full default filter to add a new
   addition
 * Should allow multiple passes of replacing a filter with one that
   extends the previous one.