### PR TITLE
fix - better row diffs when rows have been filtered out

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -787,7 +787,7 @@
 
     function getRowDiffs(rows, newRows) {
       var item, r, eitherIsNonData, diff = [];
-      var from = 0, to = newRows.length;
+      var from = 0, to = Math.max(newRows.length, rows.length);
 
       if (refreshHints && refreshHints.ignoreDiffsBefore) {
         from = Math.max(0,
@@ -799,8 +799,9 @@
             Math.max(0, refreshHints.ignoreDiffsAfter));
       }
 
-      for (var i = from, rl = rows.length; i < to; i++) {
-        if (i >= rl) {
+	  var maxIndex = Math.min(rows.length, newRows.length) - 1;
+      for (var i = from; i < to; i++) {
+        if (i > maxIndex) {
           diff[diff.length] = i;
         } else {
           item = newRows[i];


### PR DESCRIPTION
This should address issue #91 

This change ensures that `dataView.getRowDiffs()` reports diffs when `rows` and `newRows` are not the same length.