### PR TITLE
Remove variable from global status

### DIFF
--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -6,10 +6,10 @@
     }
   });
 
-  var currentlySelectedRange;
 
   function CellRangeSelector(options) {
     var _grid;
+    var _currentlySelectedRange;
     var _canvas;
     var _dragging;
     var _decorator;
@@ -62,7 +62,7 @@
           dd.startY - $(_canvas).offset().top);
 
       dd.range = {start: start, end: {}};
-      currentlySelectedRange = dd.range;
+      _currentlySelectedRange = dd.range;
       return _decorator.show(new Slick.Range(start.row, start.cell));
     }
 
@@ -81,7 +81,7 @@
       }
 
       dd.range.end = end;
-      currentlySelectedRange = dd.range;
+      _currentlySelectedRange = dd.range;
       _decorator.show(new Slick.Range(dd.range.start.row, dd.range.start.cell, end.row, end.cell));
     }
 
@@ -105,7 +105,7 @@
     }
 
     function getCurrentRange() {
-      return currentlySelectedRange;
+      return _currentlySelectedRange;
     }
 
     $.extend(this, {

--- a/plugins/slick.cellselectionmodel.js
+++ b/plugins/slick.cellselectionmodel.js
@@ -12,11 +12,17 @@
     var _canvas;
     var _ranges = [];
     var _self = this;
-    var _selector = new Slick.CellRangeSelector({
-      "selectionCss": {
-        "border": "2px solid black"
-      }
-    });
+    var _selector;
+    if ( typeof options === "undefined" || typeof options.cellRangeSelector === "undefined") {
+      _selector = new Slick.CellRangeSelector({
+        "selectionCss": {
+          "border": "2px solid black"
+        }
+      });
+    } else {
+      _selector = options.cellRangeSelector;
+    }
+
     var _options;
     var _defaults = {
       selectActiveCell: true
@@ -84,66 +90,66 @@
         setSelectedRanges([new Slick.Range(args.row, args.cell)]);
       }
     }
-    
+
     function handleKeyDown(e) {
       /***
        * Кey codes
        * 37 left
        * 38 up
        * 39 right
-       * 40 down                     
-       */                                         
+       * 40 down
+       */
       var ranges, last;
       var active = _grid.getActiveCell();
       var metaKey = e.ctrlKey || e.metaKey;
 
-      if ( active && e.shiftKey && !metaKey && !e.altKey &&
-          (e.which == 37 || e.which == 39 || e.which == 38 || e.which == 40) ) {
-      
+      if (active && e.shiftKey && !metaKey && !e.altKey &&
+        (e.which == 37 || e.which == 39 || e.which == 38 || e.which == 40)) {
+
         ranges = getSelectedRanges();
         if (!ranges.length)
-         ranges.push(new Slick.Range(active.row, active.cell));
-         
+          ranges.push(new Slick.Range(active.row, active.cell));
+
         // keyboard can work with last range only          
         last = ranges.pop();
-        
+
         // can't handle selection out of active cell
         if (!last.contains(active.row, active.cell))
           last = new Slick.Range(active.row, active.cell);
-        
+
         var dRow = last.toRow - last.fromRow,
-            dCell = last.toCell - last.fromCell,
-            // walking direction
-            dirRow = active.row == last.fromRow ? 1 : -1,
-            dirCell = active.cell == last.fromCell ? 1 : -1;
-                 
+          dCell = last.toCell - last.fromCell,
+          // walking direction
+          dirRow = active.row == last.fromRow ? 1 : -1,
+          dirCell = active.cell == last.fromCell ? 1 : -1;
+
         if (e.which == 37) {
-          dCell -= dirCell; 
+          dCell -= dirCell;
         } else if (e.which == 39) {
-          dCell += dirCell ; 
+          dCell += dirCell;
         } else if (e.which == 38) {
-          dRow -= dirRow; 
+          dRow -= dirRow;
         } else if (e.which == 40) {
-          dRow += dirRow; 
+          dRow += dirRow;
         }
-        
+
         // define new selection range 
-        var new_last = new Slick.Range(active.row, active.cell, active.row + dirRow*dRow, active.cell + dirCell*dCell);
+        var new_last = new Slick.Range(active.row, active.cell, active.row + dirRow * dRow, active.cell + dirCell * dCell);
         if (removeInvalidRanges([new_last]).length) {
           ranges.push(new_last);
           var viewRow = dirRow > 0 ? new_last.toRow : new_last.fromRow;
           var viewCell = dirCell > 0 ? new_last.toCell : new_last.fromCell;
-         _grid.scrollRowIntoView(viewRow);
-         _grid.scrollCellIntoView(viewRow, viewCell);
+          _grid.scrollRowIntoView(viewRow);
+          _grid.scrollCellIntoView(viewRow, viewCell);
         }
-        else 
+        else
           ranges.push(last);
 
-        setSelectedRanges(ranges);  
-       
+        setSelectedRanges(ranges);
+
         e.preventDefault();
-        e.stopPropagation();        
-      }           
+        e.stopPropagation();
+      }
     }
 
     $.extend(this, {

--- a/tests/plugins/cellrangeselector_spec.js
+++ b/tests/plugins/cellrangeselector_spec.js
@@ -9,7 +9,7 @@
     data = [], // The grid data
     $container = $("#container");
 
-  var $canvas, dragRangeContainer;
+  var $canvas, dragRangeContainer, cellSelector;
 
   // Create data
   for (var i = 0; i < 10; i++) {
@@ -27,7 +27,8 @@
 
     $("#container").append($testgrid);
     grid = new Slick.Grid("#grid", data, cols);
-    grid.setSelectionModel(new Slick.CellSelectionModel());
+    cellSelector = new Slick.CellRangeSelector();
+    grid.setSelectionModel(new Slick.CellSelectionModel({cellRangeSelector: cellSelector}));
     grid.render();
     $canvas = $(".grid-canvas");
   }
@@ -71,7 +72,6 @@
   }
 
   test("getCurrentRange returns the current range", function () {
-    var cellSelector = new Slick.CellRangeSelector();
     startDragging(getCell(0, 0));
     dragDown();
 
@@ -79,5 +79,27 @@
 
     var expectedRange = {"start": {"row": 0, "cell": 0}, "end": {"row": 1, "cell": 0}};
     deepEqual(selectedRange, expectedRange, "currently mouse-dragged range");
+  });
+
+  module("plugins - cellrangeselector when no options are passed");
+  test("should be created successfully", function () {
+    var $testgrid = $('<div id="grid" />');
+    $testgrid.height(600);
+
+    $("#container").append($testgrid);
+    grid = new Slick.Grid("#grid", data, cols);
+    grid.setSelectionModel(new Slick.CellSelectionModel());
+    grid.render();
+  });
+
+  module("plugins - cellrangeselector when options are passed, but not cellRangeSelector");
+  test("should be created successfully", function () {
+    var $testgrid = $('<div id="grid" />');
+    $testgrid.height(600);
+
+    $("#container").append($testgrid);
+    grid = new Slick.Grid("#grid", data, cols);
+    grid.setSelectionModel(new Slick.CellSelectionModel({}));
+    grid.render();
   });
 })(jQuery);


### PR DESCRIPTION
Allow dependency injection on CellSelectionModel, by receiving via options a instance of CellRangeSelector. Kept backward compatibility by ensuring the object is created if not provided