### PR TITLE
Change selection box boundary

### DIFF
--- a/plugins/slick.cellrangedecorator.js
+++ b/plugins/slick.cellrangedecorator.js
@@ -42,10 +42,10 @@
       var to = grid.getCellNodeBox(range.toRow, range.toCell);
 
       _elem.css({
-        top: from.top - 1,
+        top: from.top,
         left: from.left - 1,
-        height: to.bottom - from.top - 2,
-        width: to.right - from.left - 2
+        height: to.bottom - from.top + 2,
+        width: to.right - from.left + 1
       });
 
       return _elem;

--- a/plugins/slick.cellrangedecorator.js
+++ b/plugins/slick.cellrangedecorator.js
@@ -24,6 +24,12 @@
       selectionCss: {
         "zIndex": "9999",
         "border": "2px dashed red"
+      },
+      offset: {
+        top: -1,
+        left: -1,
+        height: -2,
+        width: -2
       }
     };
 
@@ -33,19 +39,19 @@
     function show(range) {
       if (!_elem) {
         _elem = $("<div></div>", {css: options.selectionCss})
-            .addClass(options.selectionCssClass)
-            .css("position", "absolute")
-            .appendTo(grid.getCanvasNode());
+          .addClass(options.selectionCssClass)
+          .css("position", "absolute")
+          .appendTo(grid.getCanvasNode());
       }
 
       var from = grid.getCellNodeBox(range.fromRow, range.fromCell);
       var to = grid.getCellNodeBox(range.toRow, range.toCell);
 
       _elem.css({
-        top: from.top,
-        left: from.left - 1,
-        height: to.bottom - from.top + 2,
-        width: to.right - from.left + 1
+        top: from.top + options.offset.top,
+        left: from.left + options.offset.left,
+        height: to.bottom - from.top + options.offset.height,
+        width: to.right - from.left + options.offset.width
       });
 
       return _elem;

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -22,7 +22,7 @@
 
     function init(grid) {
       options = $.extend(true, {}, _defaults, options);
-      _decorator = options.cellDecorator ? options.cellDecorator : new Slick.CellRangeDecorator(grid, options);
+      _decorator = options.cellDecorator || new Slick.CellRangeDecorator(grid, options);
       _grid = grid;
       _canvas = _grid.getCanvasNode();
       _handler

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -6,7 +6,6 @@
     }
   });
 
-
   function CellRangeSelector(options) {
     var _grid;
     var _currentlySelectedRange;
@@ -21,10 +20,9 @@
       }
     };
 
-
     function init(grid) {
       options = $.extend(true, {}, _defaults, options);
-      _decorator = new Slick.CellRangeDecorator(grid, options);
+      _decorator = options.cellDecorator ? options.cellDecorator : new Slick.CellRangeDecorator(grid, options);
       _grid = grid;
       _canvas = _grid.getCanvasNode();
       _handler
@@ -36,6 +34,10 @@
 
     function destroy() {
       _handler.unsubscribeAll();
+    }
+
+    function getCellDecorator() {
+      return _decorator;
     }
 
     function handleDragInit(e, dd) {
@@ -58,8 +60,8 @@
       _grid.focus();
 
       var start = _grid.getCellFromPoint(
-          dd.startX - $(_canvas).offset().left,
-          dd.startY - $(_canvas).offset().top);
+        dd.startX - $(_canvas).offset().left,
+        dd.startY - $(_canvas).offset().top);
 
       dd.range = {start: start, end: {}};
       _currentlySelectedRange = dd.range;
@@ -73,8 +75,8 @@
       e.stopImmediatePropagation();
 
       var end = _grid.getCellFromPoint(
-          e.pageX - $(_canvas).offset().left,
-          e.pageY - $(_canvas).offset().top);
+        e.pageX - $(_canvas).offset().left,
+        e.pageY - $(_canvas).offset().top);
 
       if (!_grid.canCellBeSelected(end.row, end.cell)) {
         return;
@@ -96,10 +98,10 @@
       _decorator.hide();
       _self.onCellRangeSelected.notify({
         range: new Slick.Range(
-            dd.range.start.row,
-            dd.range.start.cell,
-            dd.range.end.row,
-            dd.range.end.cell
+          dd.range.start.row,
+          dd.range.start.cell,
+          dd.range.end.row,
+          dd.range.end.cell
         )
       });
     }
@@ -111,6 +113,7 @@
     $.extend(this, {
       "init": init,
       "destroy": destroy,
+      "getCellDecorator": getCellDecorator,
       "getCurrentRange": getCurrentRange,
 
       "onBeforeCellRangeSelected": new Slick.Event(),

--- a/plugins/slick.cellselectionmodel.js
+++ b/plugins/slick.cellselectionmodel.js
@@ -13,7 +13,7 @@
     var _self = this;
     var _selector;
 
-    if (options === undefined || options.cellRangeSelector === undefined) {
+    if (typeof options === "undefined" || typeof options.cellRangeSelector === "undefined") {    
       _selector = new Slick.CellRangeSelector({
         "selectionCss": {
           "border": "2px solid black"

--- a/plugins/slick.cellselectionmodel.js
+++ b/plugins/slick.cellselectionmodel.js
@@ -6,14 +6,14 @@
     }
   });
 
-
   function CellSelectionModel(options) {
     var _grid;
     var _canvas;
     var _ranges = [];
     var _self = this;
     var _selector;
-    if ( typeof options === "undefined" || typeof options.cellRangeSelector === "undefined") {
+
+    if (options === undefined || options.cellRangeSelector === undefined) {
       _selector = new Slick.CellRangeSelector({
         "selectionCss": {
           "border": "2px solid black"
@@ -27,7 +27,6 @@
     var _defaults = {
       selectActiveCell: true
     };
-
 
     function init(grid) {
       _options = $.extend(true, {}, _defaults, options);

--- a/tests/plugins/cellrangedecorator.html
+++ b/tests/plugins/cellrangedecorator.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<title>SlickGrid - Cell Range Selector plugin tests</title>
+	<title>SlickGrid - Cell Selection Model plugin tests</title>
 	<link rel="stylesheet" href="../../lib/qunit.css" type="text/css"/>
 	<link rel="stylesheet" href="../../slick.grid.css" type="text/css"/>
-	<link rel="stylesheet" href="../../slick-default-theme.css" type="text/css"/>
+	<link rel="stylesheet" href="../../slick-default-theme.css" type="text/css" />
 </head>
 <body>
-	<h1 id="qunit-header">SlickGrid - Cell Range Selector Test Suite</h1>
+	<h1 id="qunit-header">SlickGrid - Cell Selection Model Test Suite</h1>
 	<h2 id="qunit-banner"></h2>
 	<div id="qunit-testrunner-toolbar"></div>
 	<h2 id="qunit-userAgent"></h2>
@@ -29,7 +29,7 @@
 	<script type="text/javascript" src="../../plugins/slick.cellrangedecorator.js"></script>
 	<script type="text/javascript" src="../../plugins/slick.cellrangeselector.js"></script>
 	<script type="text/javascript" src="../../plugins/slick.cellselectionmodel.js"></script>
-	<script type="text/javascript" src="cellrangeselector_spec.js"></script>
+	<script type="text/javascript" src="cellrangedecorator_spec.js"></script>
 
 </body>
 </html>

--- a/tests/plugins/cellrangedecorator_spec.js
+++ b/tests/plugins/cellrangedecorator_spec.js
@@ -1,0 +1,96 @@
+(function ($) {
+
+  var grid,         // The SlickGrid instance
+    cols = [      // The column definitions
+      {name: "Header", field: "header", width: 100},
+      {name: "Another Header", field: "another-header", width: 100},
+      {name: "Yet another header", field: "y-a-header", width: 100},
+    ],
+    data = [], // The grid data
+    $container = $("#container");
+
+  var $canvas, cellSelector, cellDecorator;
+
+  // Create data
+  for (var i = 0; i < 10; i++) {
+    data.push({
+      "id": "row" + i,
+      "header": "some data",
+      "another-header": "more data",
+      "y-a-header": "data data"
+    });
+  }
+
+  function setupGridWithValues() {
+    var $testgrid = $('<div id="grid" />');
+    $testgrid.height(600);
+
+    $("#container").append($testgrid);
+    grid = new Slick.Grid("#grid", data, cols);
+    cellDecorator = new Slick.CellRangeDecorator(grid, {
+      offset: {
+        top: 1,
+        left: 1,
+        height: 1,
+        width: 1
+      }
+    });
+    cellSelector = new Slick.CellRangeSelector({cellDecorator: cellDecorator});
+    grid.setSelectionModel(new Slick.CellSelectionModel({cellRangeSelector: cellSelector}));
+    grid.render();
+    $canvas = $(".grid-canvas");
+  }
+
+  function setupGridWithoutValues() {
+    var $testgrid = $('<div id="grid" />');
+    $testgrid.height(600);
+
+    $("#container").append($testgrid);
+    grid = new Slick.Grid("#grid", data, cols);
+    cellDecorator = new Slick.CellRangeDecorator(grid);
+    cellSelector = new Slick.CellRangeSelector({cellDecorator: cellDecorator});
+    grid.setSelectionModel(new Slick.CellSelectionModel({cellRangeSelector: cellSelector}));
+    grid.render();
+    $canvas = $(".grid-canvas");
+  }
+
+  function teardownGrid() {
+    $container.empty();
+  }
+
+  module("plugins - cellrangemodel receives a prebuilt decorator -", {
+    setup: function () {
+      setupGridWithValues();
+    },
+    teardown: teardownGrid
+  });
+
+  test("check the values passed on options are used", function () {
+    var element = cellDecorator.show(new Slick.Range(1, 1, 2, 2));
+    var resultCss = element[0].style;
+
+    deepEqual(resultCss.top, "26px", "CSS Property Top");
+    deepEqual(resultCss.left, "101px", "CSS Property Left");
+    deepEqual(resultCss.height, "50px", "CSS Property Height");
+    deepEqual(resultCss.width, "201px", "CSS Property Width");
+  });
+
+  module("plugins - cellrangemodel uses a default decorator -", {
+    setup: function () {
+      setupGridWithoutValues();
+    },
+    teardown: teardownGrid
+  });
+
+  test("check the values passed on options are used", function () {
+    var element = cellDecorator.show(new Slick.Range(1, 1, 2, 2));
+    var resultCss = element[0].style;
+
+    deepEqual(resultCss.top, "24px", "CSS Property Top");
+    deepEqual(resultCss.left, "99px", "CSS Property Left");
+    deepEqual(resultCss.height, "47px", "CSS Property Height");
+    deepEqual(resultCss.width, "198px", "CSS Property Width");
+  });
+
+
+})(jQuery);

--- a/tests/plugins/cellrangeselector_spec.js
+++ b/tests/plugins/cellrangeselector_spec.js
@@ -9,7 +9,7 @@
     data = [], // The grid data
     $container = $("#container");
 
-  var $canvas, dragRangeContainer, cellSelector;
+  var $canvas, cellSelector;
 
   // Create data
   for (var i = 0; i < 10; i++) {
@@ -101,5 +101,18 @@
     grid = new Slick.Grid("#grid", data, cols);
     grid.setSelectionModel(new Slick.CellSelectionModel({}));
     grid.render();
+  });
+
+  module("plugins - cellrangeselector without options", {
+    setup: function () {
+      setupGrid();
+    },
+    teardown: teardownGrid
+  });
+
+  test("constructs decorator correctly", function () {
+    cellSelector.init(grid);
+    notEqual(cellSelector.getCellDecorator(), undefined, "Grid Cell Decorator");
+    cellSelector.destroy();
   });
 })(jQuery);


### PR DESCRIPTION
Mainly the right and bottom bounds seemed misaligned from the column and row gridlines.

**We were seeing:**
![screen shot 2017-05-24 at 11 15 10 am](https://cloud.githubusercontent.com/assets/16085413/26411361/b9900c44-4073-11e7-945c-63ec7adf16f9.png)

**our changes leave us with:**
![screen shot 2017-05-24 at 11 16 51 am](https://cloud.githubusercontent.com/assets/16085413/26411370/bdb25b10-4073-11e7-9fc7-bc189479ffee.png)

Please try the modified cellrangedecorator and let us know if it looks good.
