### PR TITLE
Added functions sortedAddItem() and sortedUpdateItem() to DataView

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -355,6 +355,45 @@
       refresh();
     }
 
+    function sortedAddItem(item) {
+      // NOTE: assumes 'items' are sorted!
+      if(!sortComparer) {
+        throw new Error("sortedAddItem() requires a sort comparer, use sort()");
+      }
+	    insertItem(sortedIndex(item), item);
+    }
+
+    function sortedUpdateItem(item) {
+      // NOTE: assumes 'items' are sorted!
+      if(!sortComparer) {
+        throw new Error("sortedUpdateItem() requires a sort comparer, use sort()");
+      }
+      var old_item = getItemById(item.id);
+      if(sortComparer(old_item, item) !== 0) {
+        // item affects sorting -> must use sorted add
+        deleteItem(item.id);
+        sortedAddItem(item);
+      }
+      else { // update does not affect sorting -> regular update works fine
+        updateItem(item.id, item);
+      }
+    }
+
+    function sortedIndex(searchItem) {
+    var low = 0, high = items.length;
+
+      while (low < high) {
+        var mid = low + high >>> 1;
+        if (sortComparer(items[mid], searchItem) === -1) {
+          low = mid + 1;
+        }
+        else {
+          high = mid;
+        }
+      }
+      return low;
+    }
+      
     function addItem(item) {
       items.push(item);
       updateIdxById(items.length - 1);
@@ -1039,6 +1078,8 @@
       "updateItem": updateItem,
       "insertItem": insertItem,
       "addItem": addItem,
+      "sortedAddItem": sortedAddItem,
+      "sortedUpdateItem": sortedUpdateItem,
       "deleteItem": deleteItem,
       "syncGridSelection": syncGridSelection,
       "syncGridCellCssStyles": syncGridCellCssStyles,


### PR DESCRIPTION
They allow for very high performance when the data changes a lot.

Data must be initially sorted (the regular way: `dataView.sort(comparer)`), then items can be added, updated and removed without continuous sorting, which is otherwise required.