### PR TITLE
Bugfix on applyFormatResultToCellNode()

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1839,10 +1839,10 @@ if (typeof Slick === "undefined") {
         }
         cellNode.innerHTML = formatterResult.text;
         if (formatterResult.removeClasses && !suppressRemove) { 
-            cellNode.removeClass(formatterResult.removeClasses); 
+            $(cellNode).removeClass(formatterResult.removeClasses); 
         }
         if (formatterResult.addClasses) { 
-            cellNode.addClass(formatterResult.addClasses); 
+            $(cellNode).addClass(formatterResult.addClasses); 
         }
     }
 


### PR DESCRIPTION
I don't know if I'm doing something wrong but I'm getting the following error:

```
slick.grid.js:1844 Uncaught TypeError: cellNode.addClass is not a function
    at applyFormatResultToCellNode (slick.grid.js:1844)
    at makeActiveCellNormal (slick.grid.js:2979)
    at Object.commitCurrentEdit (slick.grid.js:3632)
    at EditorLock.commitCurrentEdit (slick.core.js:476)
    at commitEditAndSetFocus (slick.grid.js:3054)
    at HTMLDivElement.handleKeyDown (slick.grid.js:2637)
    at HTMLDivElement.dispatch (jquery-1.11.2.min.js:3)
    at HTMLDivElement.i.dispatch (jquery.event.drag.min.js:6)
    at HTMLDivElement.r.handle (jquery-1.11.2.min.js:3)
```

`removeClass` and `addClass` are Jquery functions and they were being called on a raw html element

I've just wrapped `cellNode` into the corresponding `$()`