### PR TITLE
Fix scrollbar width calculation

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -98,7 +98,8 @@ if (typeof Slick === "undefined") {
       forceSyncScrolling: false,
       addNewRowCssClass: "new-row",
       preserveCopiedSelectionOnPaste: false,
-      showCellSelection: true
+      showCellSelection: true,
+      viewportClass: null
     };
 
     var columnDefaults = {
@@ -227,7 +228,6 @@ if (typeof Slick === "undefined") {
 
       // calculate these only once and share between grid instances
       maxSupportedCssHeight = maxSupportedCssHeight || getMaxSupportedCssHeight();
-      scrollbarDimensions = scrollbarDimensions || measureScrollbar();
 
       options = $.extend({}, defaults, options);
       validateAndEnforceOptions();
@@ -273,7 +273,6 @@ if (typeof Slick === "undefined") {
         $preHeaderPanelScroller = $("<div class='slick-preheader-panel ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($container);
         $preHeaderPanel = $("<div />").appendTo($preHeaderPanelScroller);
         $preHeaderPanelSpacer = $("<div style='display:block;height:1px;position:absolute;top:0;left:0;'></div>")
-            .css("width", getCanvasWidth() + scrollbarDimensions.width + "px")
             .appendTo($preHeaderPanelScroller);
 
         if (!options.showPreHeaderPanel) {
@@ -283,12 +282,10 @@ if (typeof Slick === "undefined") {
 
       $headerScroller = $("<div class='slick-header ui-state-default' />").appendTo($container);
       $headers = $("<div class='slick-header-columns' style='left:-1000px' />").appendTo($headerScroller);
-      $headers.width(getHeadersWidth());
 
       $headerRowScroller = $("<div class='slick-headerrow ui-state-default' />").appendTo($container);
       $headerRow = $("<div class='slick-headerrow-columns' />").appendTo($headerRowScroller);
       $headerRowSpacer = $("<div style='display:block;height:1px;position:absolute;top:0;left:0;'></div>")
-          .css("width", getCanvasWidth() + scrollbarDimensions.width + "px")
           .appendTo($headerRowScroller);
 
       $topPanelScroller = $("<div class='slick-top-panel-scroller ui-state-default' />").appendTo($container);
@@ -304,8 +301,17 @@ if (typeof Slick === "undefined") {
 
       $viewport = $("<div class='slick-viewport' style='width:100%;overflow:auto;outline:0;position:relative;;'>").appendTo($container);
       $viewport.css("overflow-y", options.autoHeight ? "hidden" : "auto");
+      if (options.viewportClass) $viewport.toggleClass(options.viewportClass, true);
 
       $canvas = $("<div class='grid-canvas' />").appendTo($viewport);
+
+      scrollbarDimensions = scrollbarDimensions || measureScrollbar();
+
+      if ($preHeaderPanelSpacer) $preHeaderPanelSpacer.css("width", getCanvasWidth() + scrollbarDimensions.width + "px");
+      $headers.width(getHeadersWidth());
+      $headerRowSpacer.css("width", getCanvasWidth() + scrollbarDimensions.width + "px");
+
+
 
       if (options.createFooterRow) {
         $footerRowScroller = $("<div class='slick-footerrow ui-state-default' />").appendTo($container);
@@ -472,12 +478,14 @@ if (typeof Slick === "undefined") {
     }
 
     function measureScrollbar() {
-      var $c = $("<div style='position:absolute; top:-10000px; left:-10000px; width:100px; height:100px; overflow:scroll;'></div>").appendTo("body");
+      var $outerdiv = $('<div class="' + $('.slick-viewport')[0].className + '" style="position:absolute; top:-10000px; left:-10000px; overflow:auto; width:100px; height:100px;"></div>').appendTo($('.slick-viewport'));
+      var $innerdiv = $('<div style="width:200px; height:200px; overflow:auto;"></div>').appendTo($outerdiv);
       var dim = {
-        width: $c.width() - $c[0].clientWidth,
-        height: $c.height() - $c[0].clientHeight
+	width: $outerdiv[0].offsetWidth - $outerdiv[0].clientWidth,
+	height: $outerdiv[0].offsetHeight - $outerdiv[0].clientHeight
       };
-      $c.remove();
+      $innerdiv.remove();
+      $outerdiv.remove();
       return dim;
     }
 


### PR DESCRIPTION
This PR does a few things:

- fix the code in `measureScrollbar()` which was broken (always returned 0 on latest chrome). I replaced it with code from the Google Closure Library (see https://stackoverflow.com/a/21046991/460084), the new code creates an outer element and places a bigger inner elements and then calculate the scrollbar dimentions.

- added options.viewportClass to allow styling the viewport. This allows changing the scrollbar appearance (in chrome & IE) for example:

```
		.visibleScrollbar::-webkit-scrollbar {
			width: 14px;
			background-color: #F5F5F5;
			border-left: 1px dotted silver;
		}
		.visibleScrollbar::-webkit-scrollbar-thumb {
			background: #D3D3D3;
			border: 2px solid #F5F5F5;
			border-radius: 0px;
		}

		.invisibleScrollbar::-webkit-scrollbar {
			display: none;
		}
		.invisibleScrollbar::-webkit-scrollbar-button {
			display: none;
		}
		.invisibleScrollbar {
			-ms-overflow-style: none;
		}
```

and then use it in the grid:
```
options.viewportClass: isMobile ? 'invisibleScrollbar' : 'visibleScrollbar' ,
```

- some code in `init()` that relied on `measureScrollbar()` needed to be moved till after the viewport is created and `scrollbarDimensions` calculated