### PR TITLE
made column picker more functional

### DIFF
--- a/controls/slick.columnpicker.css
+++ b/controls/slick.columnpicker.css
@@ -7,6 +7,24 @@
   box-shadow: 2px 2px 2px silver;
   min-width: 100px;
   cursor: default;
+  position:absolute;
+  z-index:20;
+
+  width: 200px;
+  max-height: 300px;
+	overflow:auto;
+  resize: both;
+}
+
+.slick-columnpicker > .close {
+  float: right;
+}
+
+.slick-columnpicker .title {
+  font-size: 16px;
+  width: 60%;
+  border-bottom: solid 1px #d6d6d6;
+  margin-bottom: 10px;
 }
 
 .slick-columnpicker li {

--- a/controls/slick.columnpicker.css
+++ b/controls/slick.columnpicker.css
@@ -5,13 +5,10 @@
   -moz-box-shadow: 2px 2px 2px silver;
   -webkit-box-shadow: 2px 2px 2px silver;
   box-shadow: 2px 2px 2px silver;
-  min-width: 100px;
+  min-width: 150px;
   cursor: default;
   position:absolute;
   z-index:20;
-
-  width: 200px;
-  max-height: 300px;
 	overflow:auto;
   resize: both;
 }

--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -1,10 +1,11 @@
 (function ($) {
   function SlickColumnPicker(columns, grid, options) {
+    var $list;
     var $menu;
     var columnCheckboxes;
 
     var defaults = {
-      fadeSpeed:250
+      fadeSpeed: 250
     };
 
     function init() {
@@ -12,30 +13,47 @@
       grid.onColumnsReordered.subscribe(updateColumnOrder);
       options = $.extend({}, defaults, options);
 
-      $menu = $("<span class='slick-columnpicker' style='display:none;position:absolute;z-index:20;overflow-y:scroll;' />").appendTo(document.body);
+      $menu = $("<div class='slick-columnpicker' style='display:none' />").appendTo(document.body);
+      $close = $("<button type='button' class='close' data-dismiss='slick-columnpicker' aria-label='Close'><span class='close' aria-hidden='true'>&times;</span></button>").appendTo($menu);
 
-      $menu.on("mouseleave", function (e) {
-        $(this).fadeOut(options.fadeSpeed)
+      // user could pass a title on top of the columns list
+      if(options.columnPickerTitle) {
+        $title = $("<div class='title'/>").append(options.columnPickerTitle);
+        $title.appendTo($menu);
+      }
+
+      // hide if is not withing the picker div or if user click on the close button
+      $(document).on("click.columnpicker", function(e) {
+        var $parent = $(e.target).closest("div.slick-columnpicker");
+        if((e.target.className != "slick-columnpicker" && $parent.length === 0) || e.target.className == "close") {
+          $("div.slick-columnpicker").hide(options.fadeSpeed);
+        }
       });
+      
       $menu.on("click", updateColumn);
+      $list = $("<span class='slick-columnpicker-list' />");
 
+      // destroy the picker if user leaves the page
+      $(window).on("beforeunload", destroy);
     }
 
     function destroy() {
       grid.onHeaderContextMenu.unsubscribe(handleHeaderContextMenu);
       grid.onColumnsReordered.unsubscribe(updateColumnOrder);
+      $(document).off("click.columnpicker");
+      $("div.slick-columnpicker").hide(options.fadeSpeed);
       $menu.remove();
     }
 
     function handleHeaderContextMenu(e, args) {
       e.preventDefault();
-      $menu.empty();
+      $list.empty();
       updateColumnOrder();
       columnCheckboxes = [];
 
       var $li, $input;
       for (var i = 0; i < columns.length; i++) {
-        $li = $("<li />").appendTo($menu);
+        $li = $("<li />").appendTo($list);
         $input = $("<input type='checkbox' />").data("column-id", columns[i].id);
         columnCheckboxes.push($input);
 
@@ -49,8 +67,8 @@
             .appendTo($li);
       }
 
-      $("<hr/>").appendTo($menu);
-      $li = $("<li />").appendTo($menu);
+      $("<hr/>").appendTo($list);
+      $li = $("<li />").appendTo($list);
       $input = $("<input type='checkbox' />").data("option", "autoresize");
       $("<label />")
           .text("Force fit columns")
@@ -60,7 +78,7 @@
         $input.attr("checked", "checked");
       }
 
-      $li = $("<li />").appendTo($menu);
+      $li = $("<li />").appendTo($list);
       $input = $("<input type='checkbox' />").data("option", "syncresize");
       $("<label />")
           .text("Synchronous resize")
@@ -75,6 +93,8 @@
           .css("left", e.pageX - 10)
           .css("max-height", $(window).height() - e.pageY -10)
           .fadeIn(options.fadeSpeed);
+
+      $list.appendTo($menu);
     }
 
     function updateColumnOrder() {

--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -22,16 +22,11 @@
         $title.appendTo($menu);
       }
 
-      // hide if is not withing the picker div or if user click on the close button
-      $(document).on("click.columnpicker", function(e) {
-        var $parent = $(e.target).closest("div.slick-columnpicker");
-        if((e.target.className != "slick-columnpicker" && $parent.length === 0) || e.target.className == "close") {
-          $("div.slick-columnpicker").hide(options.fadeSpeed);
-        }
-      });
-      
       $menu.on("click", updateColumn);
       $list = $("<span class='slick-columnpicker-list' />");
+
+      // Hide the menu on outside click.
+      $(document.body).on("mousedown", handleBodyMouseDown);
 
       // destroy the picker if user leaves the page
       $(window).on("beforeunload", destroy);
@@ -40,9 +35,15 @@
     function destroy() {
       grid.onHeaderContextMenu.unsubscribe(handleHeaderContextMenu);
       grid.onColumnsReordered.unsubscribe(updateColumnOrder);
-      $(document).off("click.columnpicker");
+      $(document.body).off("mousedown", handleBodyMouseDown);
       $("div.slick-columnpicker").hide(options.fadeSpeed);
       $menu.remove();
+    }
+
+    function handleBodyMouseDown(e) {
+      if (($menu && $menu[0] != e.target && !$.contains($menu[0], e.target)) || e.target.className == "close") {
+        $menu.hide(options.fadeSpeed);
+      }
     }
 
     function handleHeaderContextMenu(e, args) {

--- a/examples/example4-model.html
+++ b/examples/example4-model.html
@@ -125,6 +125,7 @@ var columns = [
 ];
 
 var options = {
+  columnPickerTitle: "Columns",
   editable: true,
   enableAddRow: true,
   enableCellNavigation: true,


### PR DESCRIPTION
This PR brings the following functionalities
- Added a new grid option `columnPickerTitle` to provide an **optional** title
  - in the example shown below, I used: `var options = { columnPickerTitle: "Columns" }`
- Added a close (x) button shown on top right (floating right)
- Hiding the picker is now much more user friendly
   - Picker now ONLY hides if user clicks outside of the picker OR clicks on the new close button
   - Removed `onMouseLeave` which used to hides the picker as soon as user mouses away from the picker (which was not very user friendly).
- Also added css `resize: both` so that user can choose to expand picker `div` (x, y)

See animated gif for before and after

BEFORE
![2017-09-23_00-16-50](https://user-images.githubusercontent.com/643976/30770156-7d21ea00-9ff7-11e7-9e13-f07ff402ade1.gif)

**AFTER**
_now the picker stays open unless user **clicks outside** of the picker **or** on the new **close button**_
![2017-09-23_00-23-54](https://user-images.githubusercontent.com/643976/30770159-8fd24fbe-9ff7-11e7-8d1f-d2a14738813c.gif)
