### PR TITLE
Add new Slick Control Grid Menu (hamburger menu)

### DIFF
--- a/controls/slick.gridmenu.css
+++ b/controls/slick.gridmenu.css
@@ -13,7 +13,7 @@
   resize: both;
 }
 
-.slick-gridmenu-button > button {
+.slick-gridmenu-button {
   position: absolute;
   cursor: pointer;
   right: 0;

--- a/controls/slick.gridmenu.css
+++ b/controls/slick.gridmenu.css
@@ -1,0 +1,113 @@
+.slick-gridmenu {
+  border: 1px solid #718BB7;
+  background: #f0f0f0;
+  padding: 6px;
+  -moz-box-shadow: 2px 2px 2px silver;
+  -webkit-box-shadow: 2px 2px 2px silver;
+  box-shadow: 2px 2px 2px silver;
+  min-width: 180px;
+  cursor: default;
+  position:absolute;
+  z-index:20;
+	overflow:auto;
+  resize: both;
+}
+
+.slick-gridmenu-button > input {
+  position: absolute;
+  cursor: pointer;
+  right: 3px;
+  top: 0;
+  background-image: url(../images/drag-handle.png);
+  background-repeat: no-repeat;
+  background-color: transparent;
+  cursor: pointer;
+  border: 0;
+  margin-top: 5px;
+}
+
+.slick-gridmenu > .close {
+  float: right;
+}
+
+.slick-gridmenu .title {
+  font-size: 16px;
+  width: calc(100% - 30px);
+  border-bottom: solid 1px #d6d6d6;
+  margin-bottom: 5px;
+}
+
+.slick-gridmenu li {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background: none;
+}
+
+.slick-gridmenu input {
+  margin: 4px;
+}
+
+.slick-gridmenu li a {
+  display: block;
+  padding: 4px;
+  font-weight: bold;
+}
+
+.slick-gridmenu li a:hover {
+  background: white;
+}
+
+
+.slick-gridmenu-custom {
+  margin-bottom: 10px;
+}
+
+/* Menu */
+.slick-gridmenu- {
+  position: absolute;
+  display: inline-block;
+  margin: 0;
+  padding: 2px;
+  cursor: default;
+}
+
+
+/* Menu items */
+.slick-gridmenu-item {
+  list-style: none;
+  margin: 0;
+  cursor: pointer;
+  padding: 2px 4px;
+  border: 1px solid transparent;
+  border-radius: 3px;
+}
+.slick-gridmenu-item:hover {
+  border-color: silver;
+  background: white;
+}
+.slick-gridmenu-item-disabled {
+  border-color: transparent !important;
+  background: inherit !important;
+}
+
+.slick-gridmenu-icon {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  vertical-align: middle;
+  margin-right: 4px;
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+
+.slick-gridmenu-content {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+
+/* Disabled */
+.slick-gridmenu-item-disabled {
+  color: silver;
+}

--- a/controls/slick.gridmenu.css
+++ b/controls/slick.gridmenu.css
@@ -13,17 +13,17 @@
   resize: both;
 }
 
-.slick-gridmenu-button > input {
+.slick-gridmenu-button > button {
   position: absolute;
   cursor: pointer;
-  right: 3px;
+  right: 0;
+  padding: 0 2px;
   top: 0;
-  background-image: url(../images/drag-handle.png);
-  background-repeat: no-repeat;
   background-color: transparent;
   cursor: pointer;
   border: 0;
   margin-top: 5px;
+  width: 16px;
 }
 
 .slick-gridmenu > .close {
@@ -93,8 +93,8 @@
 
 .slick-gridmenu-icon {
   display: inline-block;
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   vertical-align: middle;
   margin-right: 4px;
   background-repeat: no-repeat;

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -84,18 +84,19 @@
       var $list;
       var $menu;
       var columnCheckboxes;
-
-      var defaults = {
-        fadeSpeed: 250
+      var _defaults = {
+        fadeSpeed: 250,
+        menuWidth: 18,
+        resizeOnShowHeaderRow: true
       };
 
       function init(grid) {
-        var gridMenuWidth = (_options.gridMenu && _options.gridMenu.menuWidth) || 18;
+        var gridMenuWidth = (_options.gridMenu && _options.gridMenu.menuWidth) || _defaults.menuWidth;
         $header = $('.slick-header');
         $header.attr('style', 'width: calc(100% - ' + gridMenuWidth +'px)');
 
         // if header row is enabled, we need to resize it's width also
-        var enableResizeHeaderRow = (_options.gridMenu && _options.gridMenu.resizeOnShowHeaderRow != undefined) ? _options.gridMenu.resizeOnShowHeaderRow : true;
+        var enableResizeHeaderRow = (_options.gridMenu && _options.gridMenu.resizeOnShowHeaderRow != undefined) ? _options.gridMenu.resizeOnShowHeaderRow : _defaults.resizeOnShowHeaderRow;
         if(enableResizeHeaderRow) {
           $headerrow = $('.slick-headerrow');
           $headerrow.attr('style', 'width: calc(100% - ' + gridMenuWidth +'px)');
@@ -185,7 +186,7 @@
       /** Build the column picker, the code comes almost untouched from the file "slick.columnpicker.js" */
       function populateColumnPicker() {
         _grid.onColumnsReordered.subscribe(updateColumnOrder);
-        _options = $.extend({}, defaults, _options);
+        _options = $.extend({}, _defaults, _options);
 
         // user could pass a title on top of the columns list
         if(_options.gridMenu && _options.gridMenu.columnTitle) {

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -15,6 +15,7 @@
    *      columnTitle: "Columns",
    *      iconImage: "../images/drag-handle.png",   // this is the Grid Menu icon (hamburger icon)
    *      iconCssClass: "fa fa-bars",               // you can provide iconImage OR iconCssClass
+   *      leaveOpen: false,                         // do we want to leave the Grid Menu open after a command execution? (false by default)
    *      menuWidth: 18,                            // width that will be use to resize the column header container (18 by default)
    *      resizeOnShowHeaderRow: true,              // true by default
    *      resizeOnShowTopPanel: true,               // true by default
@@ -289,7 +290,11 @@
           return;
         }
 
-        hideMenu();
+        // does the user want to leave open the Grid Menu after executing a command?
+        var leaveOpen = (_options.gridMenu && _options.gridMenu.leaveOpen) ? true : false;
+        if(!leaveOpen) {
+          hideMenu();
+        }
 
         if (command != null && command != '') {
           _self.onCommand.notify({

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -1,0 +1,377 @@
+  /***
+   * A control to add a Grid Menu (hambuger menu on top-right of the grid)
+   *
+   * USAGE:
+   *
+   * Add the slick.gridmenu.(js|css) files and register it with the grid.
+   *
+   * To specify a menu in a column header, extend the column definition like so:
+   * var gridMenuControl = new Slick.Controls.GridMenu(columns, grid, options);
+   *
+   *  var options = {
+   *    enableCellNavigation: true,
+   *    gridMenu: {
+   *      customTitle: "Custom Menus",
+   *      columnTitle: "Columns",
+   *      resizeOnShowHeaderRow: true, // true by default
+   *      resizeOnShowTopPanel: true, // true by default
+   *      customItems: [
+   *        {
+   *          // custom menu item options
+   *        },
+   *        {
+   *          // custom menu item options
+   *        }
+   *      ]
+   *    }
+   *  };
+   *
+   *
+   * Available grid options, by defining a gridMenu object:
+   *    customTitle:            an optional title for the custom menu list
+   *    columnTitle:            an optional title for the column list
+   *    resizeOnShowHeaderRow:  do we want to resize the header row (minus the hamburger icon width)? true by default
+   *    resizeOnShowTopPanel:   do we want to resize the top panel (minus the hamburger icon width)? true by default
+   *    customItems:            list of custom menu items
+   *
+   * Available custom menu item options:
+   *    title:        Menu item text.
+   *    disabled:     Whether the item is disabled.
+   *    tooltip:      Item tooltip.
+   *    command:      A command identifier to be passed to the onCommand event handlers.
+   *    iconCssClass: A CSS class to be added to the menu item icon.
+   *    iconImage:    A url to the icon image.
+   *
+   *
+   * The plugin exposes the following events:
+   *    onBeforeMenuShow:   Fired before the menu is shown.  You can customize the menu or dismiss it by returning false.
+   *      * ONLY works with a jQuery event (as per slick.core code), so we cannot notify when it's a button event (when grid menu is attached to an external button, not the hamburger menu)
+   *        Event args:
+   *            grid:     Reference to the grid.
+   *            column:   Column definition.
+   *            menu:     Menu options.  Note that you can change the menu items here.
+   *
+   *    onCommand:    Fired on menu item click for buttons with 'command' specified.
+   *        Event args:
+   *            grid:     Reference to the grid.
+   *            column:   Column definition.
+   *            command:  Button command identified.
+   *            button:   Button options.  Note that you can change the button options in your
+   *                      event handler, and the column header will be automatically updated to
+   *                      reflect them.  This is useful if you want to implement something like a
+   *                      toggle button.
+   *
+   *
+   * @param options {Object} Options:
+   *    buttonCssClass:   an extra CSS class to add to the menu button
+   *    buttonImage:      a url to the menu button image (default '../images/down.gif')
+   * @class Slick.Controls.GridMenu
+   * @constructor
+   */
+
+(function ($) {
+  // register namespace
+  $.extend(true, window, {
+    "Slick": {
+      "Controls": {
+        "GridMenu": SlickGridMenu
+      }
+    }
+  });
+
+  function SlickGridMenu(columns, grid, options) {
+    var _grid = grid;
+    var _self = this;
+    var $list;
+    var $menu;
+    var columnCheckboxes;
+
+    if(!options.gridMenu) {
+      return;
+    }
+
+    var defaults = {
+      fadeSpeed: 250
+    };
+
+    function init(grid) {
+      var gridMenuWidth = 18;
+      $header = $('.slick-header');
+      $header.width($header.width() - gridMenuWidth);
+
+      // if header row is enabled, we need to resize it's width also
+      var enableResizeHeaderRow = options.gridMenu.resizeOnShowHeaderRow !== undefined ? options.gridMenu.resizeOnShowHeaderRow : options.showHeaderRow;
+      if(options.showHeaderRow && enableResizeHeaderRow) {
+        $headerrow = $('.slick-headerrow');
+        $headerrow.width($headerrow.width() - gridMenuWidth);
+      }
+
+      // if top panel is enabled, we need to resize width also
+      var enableResizeTopPanel = options.gridMenu.resizeOnShowTopPanel !== undefined ? options.gridMenu.resizeOnShowTopPanel : options.showTopPanel;
+      if(options.showTopPanel && enableResizeTopPanel) {
+        $toppanel = $('.slick-top-panel');
+        $toppanel.width($toppanel.width() - gridMenuWidth);
+      }
+
+      $button = $('<span class="slick-gridmenu-button"><input type="button"/></span>');
+      $button.insertBefore($header);
+
+      $menu = $('<div class="slick-gridmenu" style="display: none" />').appendTo(document.body);
+      $close = $('<button type="button" class="close" data-dismiss="slick-gridmenu" aria-label="Close"><span class="close" aria-hidden="true">&times;</span></button>').appendTo($menu);
+
+      $customMenu = $('<div class="slick-gridmenu-custom" />');
+      $customMenu.appendTo($menu);
+
+      // user could pass a title on top of the custom section
+      if(options.gridMenu.customTitle) {
+        $title = $('<div class="title"/>').append(options.gridMenu.customTitle);
+        $title.appendTo($customMenu);
+      }
+
+      populateCustomMenus(options, $customMenu);
+      populateColumnPicker();
+
+      // Hide the menu on outside click.
+      $(document.body).on("mousedown", handleBodyMouseDown);
+
+      // destroy the picker if user leaves the page
+      $(window).on("beforeunload", destroy);
+
+      // add on click handler for the Grid Menu itself
+      $button.on("click", showGridMenu);
+    }
+
+    function destroy() {
+      grid.onColumnsReordered.unsubscribe(updateColumnOrder);
+      $(document.body).off("mousedown", handleBodyMouseDown);
+      $("div.slick-gridmenu").hide(options.fadeSpeed);
+      $menu.remove();
+    }
+
+    function populateCustomMenus(options, $customMenu) {
+      // Construct the custom menu items.
+      for (var i = 0, ln = options.gridMenu.customItems.length; i < ln; i++) {
+        var item = options.gridMenu.customItems[i];
+
+        var $li = $("<div class='slick-gridmenu-item'></div>")
+          .data("command", item.command || '')
+          .data("item", item)
+          .on("click", handleMenuItemClick)
+          .appendTo($customMenu);
+
+        if (item.disabled) {
+          $li.addClass("slick-gridmenu-item-disabled");
+        }
+
+        if (item.tooltip) {
+          $li.attr("title", item.tooltip);
+        }
+
+        var $icon = $("<div class='slick-gridmenu-icon'></div>")
+          .appendTo($li);
+
+        if (item.iconCssClass) {
+          $icon.addClass(item.iconCssClass);
+        }
+
+        if (item.iconImage) {
+          $icon.css("background-image", "url(" + item.iconImage + ")");
+        }
+
+        $content = $("<span class='slick-gridmenu-content'></span>")
+          .text(item.title)
+          .appendTo($li);
+      }
+    }
+
+    /** Build the column picker, the code comes almost untouched from the file "slick.columnpicker.js" */
+    function populateColumnPicker() {
+      grid.onColumnsReordered.subscribe(updateColumnOrder);
+      options = $.extend({}, defaults, options);
+
+      // user could pass a title on top of the columns list
+      if(options.gridMenu.columnTitle) {
+        $title = $('<div class="title"/>').append(options.gridMenu.columnTitle);
+        $title.appendTo($menu);
+      }
+
+      $menu.on("click", updateColumn);
+      $list = $('<span class="slick-gridmenu-list" />');
+    }
+
+    function showGridMenu(e) {
+      e.preventDefault();
+      $list.empty();
+
+      updateColumnOrder();
+      columnCheckboxes = [];
+
+      // notify of the onBeforeMenuShow only works when it's a jQuery event (as per slick.core code)
+      // this mean that we cannot notify when the grid menu is attach to a button event
+      if(typeof e.isPropagationStopped === "function") {
+        if (_self.onBeforeMenuShow.notify({
+          "grid": _grid,
+          "menu": $menu
+        }, e, _self) == false) {
+          return;
+        }
+      }
+
+      var $li, $input;
+      for (var i = 0; i < columns.length; i++) {
+        $li = $("<li />").appendTo($list);
+        $input = $("<input type='checkbox' />").data("column-id", columns[i].id);
+        columnCheckboxes.push($input);
+
+        if (grid.getColumnIndex(columns[i].id) != null) {
+          $input.attr("checked", "checked");
+        }
+
+        $("<label />")
+            .html(columns[i].name)
+            .prepend($input)
+            .appendTo($li);
+      }
+
+      $("<hr/>").appendTo($list);
+      $li = $("<li />").appendTo($list);
+      $input = $("<input type='checkbox' />").data("option", "autoresize");
+      $("<label />")
+          .text("Force fit columns")
+          .prepend($input)
+          .appendTo($li);
+      if (grid.getOptions().forceFitColumns) {
+        $input.attr("checked", "checked");
+      }
+
+      $li = $("<li />").appendTo($list);
+      $input = $("<input type='checkbox' />").data("option", "syncresize");
+      $("<label />")
+          .text("Synchronous resize")
+          .prepend($input)
+          .appendTo($li);
+      if (grid.getOptions().syncColumnCellResize) {
+        $input.attr("checked", "checked");
+      }
+
+      var gridMenuWidth = $menu.width();
+
+      $menu
+          .css("top", e.pageY + 10)
+          .css("left", e.pageX - $menu.width())
+          .css("max-height", $(window).height() - e.pageY -10)
+          .fadeIn(options.fadeSpeed);
+
+      $list.appendTo($menu);
+    }
+
+    function handleBodyMouseDown(e) {
+      if (($menu && $menu[0] != e.target && !$.contains($menu[0], e.target)) || e.target.className == "close") {
+        hideMenu();
+      }
+    }
+
+    function handleMenuItemClick(e) {
+      var command = $(this).data("command");
+      var item = $(this).data("item");
+
+      if (item.disabled) {
+        return;
+      }
+
+      hideMenu();
+
+      if (command != null && command != '') {
+        _self.onCommand.notify({
+            "grid": _grid,
+            "command": command,
+            "item": item
+          }, e, _self);
+      }
+
+      // Stop propagation so that it doesn't register as a header click event.
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
+    function hideMenu() {
+      if ($menu) {
+        $menu.hide(options.fadeSpeed);
+      }
+    }
+
+    function updateColumnOrder() {
+      // Because columns can be reordered, we have to update the `columns`
+      // to reflect the new order, however we can't just take `grid.getColumns()`,
+      // as it does not include columns currently hidden by the picker.
+      // We create a new `columns` structure by leaving currently-hidden
+      // columns in their original ordinal position and interleaving the results
+      // of the current column sort.
+      var current = grid.getColumns().slice(0);
+      var ordered = new Array(columns.length);
+      for (var i = 0; i < ordered.length; i++) {
+        if ( grid.getColumnIndex(columns[i].id) === undefined ) {
+          // If the column doesn't return a value from getColumnIndex,
+          // it is hidden. Leave it in this position.
+          ordered[i] = columns[i];
+        } else {
+          // Otherwise, grab the next visible column.
+          ordered[i] = current.shift();
+        }
+      }
+      columns = ordered;
+    }
+
+    function updateColumn(e) {
+      if ($(e.target).data("option") == "autoresize") {
+        if (e.target.checked) {
+          grid.setOptions({forceFitColumns:true});
+          grid.autosizeColumns();
+        } else {
+          grid.setOptions({forceFitColumns:false});
+        }
+        return;
+      }
+
+      if ($(e.target).data("option") == "syncresize") {
+        if (e.target.checked) {
+          grid.setOptions({syncColumnCellResize:true});
+        } else {
+          grid.setOptions({syncColumnCellResize:false});
+        }
+        return;
+      }
+
+      if ($(e.target).is(":checkbox")) {
+        var visibleColumns = [];
+        $.each(columnCheckboxes, function (i, e) {
+          if ($(this).is(":checked")) {
+            visibleColumns.push(columns[i]);
+          }
+        });
+
+        if (!visibleColumns.length) {
+          $(e.target).attr("checked", "checked");
+          return;
+        }
+
+        grid.setColumns(visibleColumns);
+      }
+    }
+
+    init(grid);
+
+    function getAllColumns() {
+      return columns;
+    }
+
+    $.extend(this, {
+      "init": init,
+      "getAllColumns": getAllColumns,
+      "destroy": destroy,
+      "showGridMenu": showGridMenu,
+      "onBeforeMenuShow": new Slick.Event(),
+      "onCommand": new Slick.Event()
+    });
+  }
+})(jQuery);

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -113,7 +113,7 @@
         $toppanel.width($toppanel.width() - gridMenuWidth);
       }
 
-      $button = $('<span class="slick-gridmenu-button"><input type="button"/></span>');
+      $button = $('<span class="slick-gridmenu-button"><button><img src="../images/drag-handle.png"/></button></span>');
       $button.insertBefore($header);
 
       $menu = $('<div class="slick-gridmenu" style="display: none" />').appendTo(document.body);

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -8,6 +8,8 @@
    * To specify a menu in a column header, extend the column definition like so:
    * var gridMenuControl = new Slick.Controls.GridMenu(columns, grid, options);
    *
+   * Available grid options, by defining a gridMenu object:
+   *
    *  var options = {
    *    enableCellNavigation: true,
    *    gridMenu: {
@@ -18,7 +20,6 @@
    *      leaveOpen: false,                         // do we want to leave the Grid Menu open after a command execution? (false by default)
    *      menuWidth: 18,                            // width that will be use to resize the column header container (18 by default)
    *      resizeOnShowHeaderRow: true,              // true by default
-   *      resizeOnShowTopPanel: true,               // true by default
    *      customItems: [
    *        {
    *          // custom menu item options
@@ -30,13 +31,6 @@
    *    }
    *  };
    *
-   *
-   * Available grid options, by defining a gridMenu object:
-   *    customTitle:            an optional title for the custom menu list
-   *    columnTitle:            an optional title for the column list
-   *    resizeOnShowHeaderRow:  do we want to resize the header row (minus the hamburger icon width)? true by default
-   *    resizeOnShowTopPanel:   do we want to resize the top panel (minus the hamburger icon width)? true by default
-   *    customItems:            list of custom menu items
    *
    * Available custom menu item options:
    *    title:        Menu item text.
@@ -98,20 +92,13 @@
       function init(grid) {
         var gridMenuWidth = (_options.gridMenu && _options.gridMenu.menuWidth) || 18;
         $header = $('.slick-header');
-        $header.width($header.width() - gridMenuWidth);
+        $header.attr('style', 'width: calc(100% - ' + gridMenuWidth +'px)');
 
         // if header row is enabled, we need to resize it's width also
-        var enableResizeHeaderRow = (_options.gridMenu && _options.gridMenu.resizeOnShowHeaderRow) ? _options.gridMenu.resizeOnShowHeaderRow : _options.showHeaderRow;
-        if(_options.showHeaderRow && enableResizeHeaderRow) {
+        var enableResizeHeaderRow = (_options.gridMenu && _options.gridMenu.resizeOnShowHeaderRow != undefined) ? _options.gridMenu.resizeOnShowHeaderRow : true;
+        if(enableResizeHeaderRow) {
           $headerrow = $('.slick-headerrow');
-          $headerrow.width($headerrow.width() - gridMenuWidth);
-        }
-
-        // if top panel is enabled, we need to resize width also
-        var enableResizeTopPanel = (_options.gridMenu && _options.gridMenu.resizeOnShowTopPanel) ? _options.gridMenu.resizeOnShowTopPanel : _options.showTopPanel;
-        if(_options.showTopPanel && enableResizeTopPanel) {
-          $toppanel = $('.slick-top-panel');
-          $toppanel.width($toppanel.width() - gridMenuWidth);
+          $headerrow.attr('style', 'width: calc(100% - ' + gridMenuWidth +'px)');
         }
 
         $button = $('<button class="slick-gridmenu-button"/>');

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -1,0 +1,210 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
+  <link rel="stylesheet" href="../css/smoothness/jquery-ui-1.11.3.custom.css" type="text/css"/>
+  <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
+  <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="../controls/slick.gridmenu.css" type="text/css"/>
+  <style>
+    .slick-headerrow-column {
+      background: #BDD8E0;
+      text-overflow: clip;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+    }
+
+    .slick-headerrow-column input {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+    }
+    .icon-help {
+      background-image: url(../images/help.png);
+    }
+  </style>
+</head>
+<body>
+<div style="position:relative">
+  <div style="width:600px;">
+    <div id="myGrid" style="width:100%;height:500px;"></div>
+  </div>
+  <div class="options-panel">
+    &lt;==
+    <h2>Demonstrates:</h2>
+    <ul>
+      <li>This example demonstrates using the Slick.Controls.GridMenu to add a Grid Menu (hamburger menu on top right of the grid)</li>
+      <li>You could also attach the Grid Menu on an external button/link (try clicking on the button below).
+      </li>
+      <button onclick="toggleGridMenu(event)"><img src="../images/drag-handle.png"/> Grid Menu</button>
+    </ul>
+      <h2>View Source:</h2>
+      <ul>
+          <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-grid-menu.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+      </ul>
+
+  </div>
+</div>
+
+<script src="../lib/firebugx.js"></script>
+
+<script src="../lib/jquery-1.11.2.min.js"></script>
+<script src="../lib/jquery-ui-1.11.3.min.js"></script>
+<script src="../lib/jquery.event.drag-2.3.0.js"></script>
+
+<script src="../slick.core.js"></script>
+<script src="../slick.dataview.js"></script>
+<script src="../slick.grid.js"></script>
+<script src="../controls/slick.gridmenu.js"></script>
+
+<script>
+  var dataView;
+  var grid;
+  var gridMenu;
+  var data = [];
+  var options = {
+    enableCellNavigation: true,
+    showHeaderRow: true,
+    headerRowHeight: 30,
+    explicitInitialization: true,
+    gridMenu: {
+      customTitle: "Custom Menus",
+      columnTitle: "Columns",
+      resizeOnShowHeaderRow: true,
+      customItems: [
+        {
+          iconImage: "../images/delete.png",
+          title: "Clear Filters",
+          disabled: false,
+          command: "clear-filter"
+        },
+        {
+          iconImage: "../images/info.gif",
+          title: "Toggle Filter Row",
+          disabled: false,
+          command: "toggle-filter"
+        },
+        {
+          iconImage: "../images/info.gif",
+          title: "Toggle Top Panel",
+          disabled: false,
+          command: "toggle-toppanel"
+        },
+        {
+          iconCssClass: "icon-help",
+          title: "Help",
+          command: "help"
+        },
+        {
+          iconImage: "",
+          title: "Disabled Command",
+          disabled: true,
+          command: "custom-command"
+        }
+      ]
+    }
+  };
+  var columns = [];
+  var columnFilters = {};
+
+  for (var i = 0; i < 10; i++) {
+    columns.push({
+      id: i,
+      name: String.fromCharCode("A".charCodeAt(0) + i),
+      field: i,
+      width: 60
+    });
+  }
+
+
+  function filter(item) {
+    for (var columnId in columnFilters) {
+      if (columnId !== undefined && columnFilters[columnId] !== "") {
+        var c = grid.getColumns()[grid.getColumnIndex(columnId)];
+        if (item[c.field] != columnFilters[columnId]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  function toggleGridMenu(e) {
+    gridMenuControl.showGridMenu(e);
+  }
+
+  $(function () {
+    for (var i = 0; i < 100; i++) {
+      var d = (data[i] = {});
+      d["id"] = i;
+      for (var j = 0; j < columns.length; j++) {
+        d[j] = Math.round(Math.random() * 10);
+      }
+    }
+
+    dataView = new Slick.Data.DataView();
+    grid = new Slick.Grid("#myGrid", dataView, columns, options);
+    gridMenuControl = new Slick.Controls.GridMenu(columns, grid, options);
+
+
+    dataView.onRowCountChanged.subscribe(function (e, args) {
+      grid.updateRowCount();
+      grid.render();
+    });
+
+    dataView.onRowsChanged.subscribe(function (e, args) {
+      grid.invalidateRows(args.rows);
+      grid.render();
+    });
+
+
+    $(grid.getHeaderRow()).on("change keyup", ":input", function (e) {
+      var columnId = $(this).data("columnId");
+      if (columnId != null) {
+        columnFilters[columnId] = $.trim($(this).val());
+        dataView.refresh();
+      }
+    });
+
+    grid.onHeaderRowCellRendered.subscribe(function(e, args) {
+        $(args.node).empty();
+        $("<input type='text'>")
+           .data("columnId", args.column.id)
+           .val(columnFilters[args.column.id])
+           .appendTo(args.node);
+    });
+
+    grid.init();
+
+    dataView.beginUpdate();
+    dataView.setItems(data);
+    dataView.setFilter(filter);
+    dataView.endUpdate();
+
+    // subscribe to Grid Menu event(s)
+    gridMenuControl.onCommand.subscribe(function(e, args) {
+      if(args.command === "toggle-filter") {
+        grid.setHeaderRowVisibility(!grid.getOptions().showHeaderRow);
+      }
+      else if(args.command === "toggle-toppanel") {
+        grid.setTopPanelVisibility(!grid.getOptions().showTopPanel);
+      }
+      else if(args.command === "clear-filter") {
+        $('.slick-headerrow-column').children().val('');
+        for (var columnId in columnFilters) {
+          columnFilters[columnId] = "";
+        }
+        dataView.refresh();
+      } else {
+        alert("Command: " + args.command);
+      }
+    });
+
+  })
+</script>
+</body>
+</html>

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -84,6 +84,7 @@
       columnTitle: "Columns",
       // iconImage: "../images/drag-handle.png", // this is the Grid Menu icon (hamburger icon)
       // iconCssClass: "fa fa-bars",    // you can provide iconImage OR iconCssClass
+      leaveOpen: false,                 // do we want to leave the Grid Menu open after a command execution? (false by default)
       // menuWidth: 18,                 // width that will be use to resize the column header container (18 by default)
       resizeOnShowHeaderRow: true,
       customItems: [

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -38,8 +38,13 @@
     <h2>Demonstrates:</h2>
     <ul>
       <li>This example demonstrates using the Slick.Controls.GridMenu to add a Grid Menu (hamburger menu on top right of the grid)</li>
-      <li>You could also attach the Grid Menu on an external button/link (try clicking on the button below).
-      </li>
+      <li>Possibility to add custom menu items via a simple array provided to the grid options (same concept as the header menu plugin)</li>
+      <li>Includes column picker list.</li>
+      <li>Optional title for the custom menu items (top section)</li>
+      <li>Optional title for the columns list (bottom section)</li>
+      <li>To dismiss the Grid Menu, user can click on the "x" on top right corner or anywhere outside of the Grid Menu</li>
+      <li>Possibility to attach the Grid Menu to an external button (try clicking on the button below).</li>
+      <br/>
       <button onclick="toggleGridMenu(event)"><img src="../images/drag-handle.png"/> Grid Menu</button>
     </ul>
       <h2>View Source:</h2>

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -76,9 +76,15 @@
     showHeaderRow: true,
     headerRowHeight: 30,
     explicitInitialization: true,
+
+    // gridMenu Object is optional
+    // when not passed, it will act as a regular Column Picker (with default Grid Menu image of drag-handle.png)
     gridMenu: {
       customTitle: "Custom Menus",
       columnTitle: "Columns",
+      // iconImage: "../images/drag-handle.png", // this is the Grid Menu icon (hamburger icon)
+      // iconCssClass: "fa fa-bars",    // you can provide iconImage OR iconCssClass
+      // menuWidth: 18,                 // width that will be use to resize the column header container (18 by default)
       resizeOnShowHeaderRow: true,
       customItems: [
         {


### PR DESCRIPTION
This a totally new Slick Control to add a Grid Menu (aka hamburger menu on top-right of the grid). This is based on a previous PR #159 (column picker) and also re-used some code and concept from the Header Menu Plugin. 

What does it do?
- Add a fixed/sticky Grid Menu on top-right of the grid
- Possibility to attach the Grid Menu to an external button 
- Possibility to add custom menu items via a simple array provided to the grid options (same concept as the header menu plugin)
  - Once defined, just subscribe to the `onCommand`
- Includes column picker in the grid menu (Column Picker Control is **not** required for this to work, since I copied over the necessary code to produce the column picker).
- Optional title for the custom menu items (top section)
- Optional title for the columns list (bottom section)
- This should work nicely with Touch Devices
- To dismiss the Grid Menu, user can click on the "x" on top right corner or anywhere outside of the Grid Menu

See below for an animated gif of the Grid Menu in action
![2017-09-25_21-58-37](https://user-images.githubusercontent.com/643976/30897118-84505a2c-a322-11e7-9646-be06e71adab2.gif)

