### PR TITLE
Fix for column header width during autoHeight

### DIFF
--- a/slick.grid.css
+++ b/slick.grid.css
@@ -12,6 +12,10 @@ classes should alter those!
   border-left: 0px !important;
 }
 
+.slick-header.ui-state-default {
+  overflow: inherit;
+}
+
 .slick-header::-webkit-scrollbar,  .slick-headerrow::-webkit-scrollbar, .slick-footerrow::-webkit-scrollbar {
   display: none
 }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -502,7 +502,7 @@ if (typeof Slick === "undefined") {
     }
 
     function getHeadersWidth() {
-      var headersWidth = getColumnTotalWidth(true);
+      var headersWidth = getColumnTotalWidth(!options.autoHeight);
       return Math.max(headersWidth, viewportW) + 1000;
     }
 


### PR DESCRIPTION
Also corrects misplaced border on default theme / other themes. This related to issue 162, which was closed without really addressing the issue on Firefox. I didn't notice any breaks in other examples and it does solve the issues in Example 11 on IE11/Firefox/Chrome/Edge.