### PR TITLE
add empty label on checkbox selector for styling purposes

### DIFF
--- a/examples/example-checkbox-row-select.html
+++ b/examples/example-checkbox-row-select.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="../css/smoothness/jquery-ui-1.11.3.custom.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
+  <link rel="stylesheet" href="https://opensource.keycdn.com/fontawesome/4.7.0/font-awesome.min.css" integrity="sha384-dNpIIXE8U05kAbPhy3G1cz+yZmTzA6CY8Vg/u2L9xRnHjJiAK76m2BIEaSEV+/aU" crossorigin="anonymous">
   <style>
     .slick-cell-checkboxsel {
       background: #f0f0f0;
@@ -25,12 +26,30 @@
     .slick-group-title[level='2'] {
       font-style: italic;
     }
+
+    #myGrid2 input[type=checkbox] { display:none; } /* to hide the checkbox itself */
+    #myGrid2 input[type=checkbox] + label:before {
+      font-family: FontAwesome;
+      color: rgb(143, 14, 106);
+      font-weight: bold;
+      display: inline-block;
+      content: "\f00c";
+      font-size: 13px;
+    }
+    #myGrid2 input[type=checkbox] + label:before { opacity: 0.1; } /* unchecked icon */
+    #myGrid2 input[type=checkbox]:checked + label:before { opacity: 1; } /* checked icon */
   </style>
 </head>
 <body>
 <div style="position:relative">
+  <p>Without Font Styling</p>
   <div style="width:600px;">
-    <div id="myGrid" style="width:100%;height:500px;"></div>
+    <div id="myGrid" style="width:100%;height:300px;"></div>
+  </div>
+  <br/>
+  <p>With Font Styling</p>
+  <div style="width:600px;">
+    <div id="myGrid2" style="width:100%;height:300px;" class="example-grid"></div>
   </div>
 
   <div class="options-panel">
@@ -67,6 +86,7 @@
 
 <script>
   var grid;
+  var grid2;
   var data = [];
   var options = {
     editable: true,
@@ -75,6 +95,7 @@
     autoEdit: false
   };
   var columns = [];
+  var columns2 = [];
 
   $(function () {
     for (var i = 0; i < 100; i++) {
@@ -85,33 +106,43 @@
     var checkboxSelector = new Slick.CheckboxSelectColumn({
       cssClass: "slick-cell-checkboxsel"
     });
+    var checkboxSelector2 = new Slick.CheckboxSelectColumn({
+      cssClass: "slick-cell-checkboxsel"
+    });
 
     columns.push(checkboxSelector.getColumnDefinition());
+    columns2.push(checkboxSelector2.getColumnDefinition());
 
     for (var i = 0; i < 5; i++) {
-      columns.push({
+      var item = {
         id: i,
         name: String.fromCharCode("A".charCodeAt(0) + i),
         field: i,
         width: 100,
         editor: Slick.Editors.Text
-      });
+      };
+      columns.push(item);
+      columns2.push(item);
     }
 
     grid = new Slick.Grid("#myGrid", data, columns, options);
     grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
     grid.registerPlugin(checkboxSelector);
 
+    grid2 = new Slick.Grid("#myGrid2", data, columns2, options);
+    grid2.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
+    grid2.registerPlugin(checkboxSelector2);
+
     var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
-    
+
     grid.onSelectedRowsChanged.subscribe(function (e, args) {
         // debugging to see the active row in response to questions
         // active row has no correlation to the selected rows
         // it will remain null until a row is clicked and made active
         // selecting and deselecting rows via checkboxes will not change the active row
-        var rtn = args.grid.getActiveCell(); 
+        var rtn = args.grid.getActiveCell();
         var x = args.rows;
-    });    
+    });
   })
 </script>
 </body>

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -101,7 +101,7 @@
 
     function selectRows(rowArray) {
       var i, l=rowArray.length, addRows = [];
-      for(i=0; i<l; i++) { 
+      for(i=0; i<l; i++) {
         if (!_selectedRowsLookup[rowArray[i]]) {
           addRows[addRows.length] = rowArray[i];
         }
@@ -111,7 +111,7 @@
 
     function deSelectRows(rowArray) {
       var i, l=rowArray.length, removeRows = [];
-      for(i=0; i<l; i++) { 
+      for(i=0; i<l; i++) {
         if (_selectedRowsLookup[rowArray[i]]) {
           removeRows[removeRows.length] = rowArray[i];
         }
@@ -145,13 +145,13 @@
     }
 
     var _checkboxColumnCellIndex = null;
-    
+
     function getCheckboxColumnCellIndex() {
       if (_checkboxColumnCellIndex === null) {
         _checkboxColumnCellIndex = 0;
         var colArr = _grid.getColumns();
         for (var i=0; i < colArr.length; i++) {
-          if (colArr[i].id == _options.columnId) { 
+          if (colArr[i].id == _options.columnId) {
             _checkboxColumnCellIndex = i;
           }
         }
@@ -176,8 +176,8 @@
     function checkboxSelectionFormatter(row, cell, value, columnDef, dataContext) {
       if (dataContext) {
         return _selectedRowsLookup[row]
-            ? "<input type='checkbox' checked='checked'>"
-            : "<input type='checkbox'>";
+            ? "<input id='selector" + row + "' type='checkbox' checked='checked'><label for='selector" + row + "'></label>"
+            : "<input id='selector" + row + "' type='checkbox'><label for='selector" + row + "'></label>";
       }
       return null;
     }

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -177,11 +177,11 @@
     }
 
     function createUID() {
-      return Math.round(1000000 * Math.random());
+      return Math.round(10000000 * Math.random());
     }
 
     function checkboxSelectionFormatter(row, cell, value, columnDef, dataContext) {
-      var UID = createUID();
+      var UID = createUID() + row;
 
       if (dataContext) {
         return _selectedRowsLookup[row]

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -52,9 +52,9 @@
       _grid.render();
 
       if (selectedRows.length && selectedRows.length == _grid.getDataLength()) {
-        _grid.updateColumnHeader(_options.columnId, "<input type='checkbox' checked='checked'>", _options.toolTip);
+        _grid.updateColumnHeader(_options.columnId, "<input id='header-selector' type='checkbox' checked='checked'><label for='header-selector'></label>", _options.toolTip);
       } else {
-        _grid.updateColumnHeader(_options.columnId, "<input type='checkbox'>", _options.toolTip);
+        _grid.updateColumnHeader(_options.columnId, "<input id='header-selector' type='checkbox'><label for='header-selector'></label>", _options.toolTip);
       }
     }
 
@@ -162,7 +162,7 @@
     function getColumnDefinition() {
       return {
         id: _options.columnId,
-        name: "<input type='checkbox'>",
+        name: "<input id='header-selector' type='checkbox'><label for='header-selector'></label>",
         toolTip: _options.toolTip,
         field: "sel",
         width: _options.width,

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -35,6 +35,7 @@
     }
 
     function handleSelectedRowsChanged(e, args) {
+      var UID = createUID();
       var selectedRows = _grid.getSelectedRows();
       var lookup = {}, row, i;
       for (i = 0; i < selectedRows.length; i++) {
@@ -52,9 +53,9 @@
       _grid.render();
 
       if (selectedRows.length && selectedRows.length == _grid.getDataLength()) {
-        _grid.updateColumnHeader(_options.columnId, "<input id='header-selector' type='checkbox' checked='checked'><label for='header-selector'></label>", _options.toolTip);
+        _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox' checked='checked'><label for='header-selector" + UID + "'></label>", _options.toolTip);
       } else {
-        _grid.updateColumnHeader(_options.columnId, "<input id='header-selector' type='checkbox'><label for='header-selector'></label>", _options.toolTip);
+        _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox'><label for='header-selector" + UID + "'></label>", _options.toolTip);
       }
     }
 
@@ -160,9 +161,11 @@
     }
 
     function getColumnDefinition() {
+      var UID = createUID();
+
       return {
         id: _options.columnId,
-        name: "<input id='header-selector' type='checkbox'><label for='header-selector'></label>",
+        name: "<input id='header-selector" + UID + "' type='checkbox'><label for='header-selector" + UID + "'></label>",
         toolTip: _options.toolTip,
         field: "sel",
         width: _options.width,
@@ -173,11 +176,17 @@
       };
     }
 
+    function createUID() {
+      return Math.round(1000000 * Math.random());
+    }
+
     function checkboxSelectionFormatter(row, cell, value, columnDef, dataContext) {
+      var UID = createUID();
+
       if (dataContext) {
         return _selectedRowsLookup[row]
-            ? "<input id='selector" + row + "' type='checkbox' checked='checked'><label for='selector" + row + "'></label>"
-            : "<input id='selector" + row + "' type='checkbox'><label for='selector" + row + "'></label>";
+            ? "<input id='selector" + UID + "' type='checkbox' checked='checked'><label for='selector" + UID + "'></label>"
+            : "<input id='selector" + UID + "' type='checkbox'><label for='selector" + UID + "'></label>";
       }
       return null;
     }


### PR DESCRIPTION
This PR simply adds an empty `<label>` to each checkbox selector. What does that bring to the table? We can apply extra styling that is not possible without a `<label>`. For example, I want to replace the checkbox (that is different in every browser) by a Font-Awesome [icon](http://fontawesome.io/icon/check/) that will be consistent in all browser and since it's a Font, I can choose whichever size or color I want and it will be consistent across all browser. 

The PR changes the Formatter of the input checkbox from this
```javascript
"<input type='checkbox' checked='checked'>"
```
To this
```javascript
"<input id='selector" + row + "' type='checkbox' checked='checked'><label for='selector" + row + "'></label>"
```

It's really just adding a `<label>` to the input