### PR TITLE
Fix issue #174

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1717,7 +1717,7 @@ if (typeof Slick === "undefined") {
 
       var value = null;
       if (item) { value = getDataItemValueForColumn(item, m); }
-      var formatterResult =  getFormatter(row, m)(row, cell, value, m, item);
+      var formatterResult =  getFormatter(row, m)(row, cell, value, m, item) || '';
       
       // get addl css class names from object type formatter return and from string type return of onBeforeAppendCell
       var addlCssClasses = trigger(self.onBeforeAppendCell, { row: row, cell: cell, grid: self, value: value, dataContext: item }) || '';


### PR DESCRIPTION
Got the same problem as mentioned by @aliramadan8 in issue #174.

The default formatter does never return `null`. But user defined formatters can return `null`. If that happens, just use a empty string.