### PR TITLE
Force re-measurement of scrollbars

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -1151,7 +1151,7 @@
     };
 
     this.accumulate = function (item) {
-      var val = item[this.field_];
+      var val = parseFloat(item[this.field_]);
       if (val != null && val !== "" && !isNaN(val)) {
         if (this.min_ == null || val < this.min_) {
           this.min_ = val;
@@ -1175,7 +1175,7 @@
     };
 
     this.accumulate = function (item) {
-      var val = item[this.field_];
+      var val = parseFloat(item[this.field_]);
       if (val != null && val !== "" && !isNaN(val)) {
         if (this.max_ == null || val > this.max_) {
           this.max_ = val;

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -1151,7 +1151,7 @@
     };
 
     this.accumulate = function (item) {
-      var val = parseFloat(item[this.field_]);
+      var val = item[this.field_];
       if (val != null && val !== "" && !isNaN(val)) {
         if (this.min_ == null || val < this.min_) {
           this.min_ = val;
@@ -1175,7 +1175,7 @@
     };
 
     this.accumulate = function (item) {
-      var val = parseFloat(item[this.field_]);
+      var val = item[this.field_];
       if (val != null && val !== "" && !isNaN(val)) {
         if (this.max_ == null || val > this.max_) {
           this.max_ = val;

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1921,7 +1921,7 @@ if (typeof Slick === "undefined") {
           (options.createPreHeaderPanel && options.showPreHeaderPanel ? options.preHeaderPanelHeight + getVBoxDelta($preHeaderPanelScroller) : 0);
     }
 
-    function resizeCanvas() {
+    function resizeCanvas(forceUpdate) {
       if (!initialized) { return; }
       if (options.autoHeight) {
         viewportH = options.rowHeight * getDataLengthIncludingAddNew();
@@ -1933,6 +1933,10 @@ if (typeof Slick === "undefined") {
       viewportW = parseFloat($.css($container[0], "width", true));
       if (!options.autoHeight) {
         $viewport.height(viewportH);
+      }
+      
+      if (forceUpdate) {
+        scrollbarDimensions = measureScrollbar();
       }
 
       if (options.forceFitColumns) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1921,7 +1921,7 @@ if (typeof Slick === "undefined") {
           (options.createPreHeaderPanel && options.showPreHeaderPanel ? options.preHeaderPanelHeight + getVBoxDelta($preHeaderPanelScroller) : 0);
     }
 
-    function resizeCanvas() {
+    function resizeCanvas(forceReMeasurement) {
       if (!initialized) { return; }
       if (options.autoHeight) {
         viewportH = options.rowHeight * getDataLengthIncludingAddNew();
@@ -1933,6 +1933,10 @@ if (typeof Slick === "undefined") {
       viewportW = parseFloat($.css($container[0], "width", true));
       if (!options.autoHeight) {
         $viewport.height(viewportH);
+      }
+      
+      if (forceReMeasurement) {
+        scrollbarDimensions = measureScrollbar();
       }
 
       if (options.forceFitColumns) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1921,7 +1921,7 @@ if (typeof Slick === "undefined") {
           (options.createPreHeaderPanel && options.showPreHeaderPanel ? options.preHeaderPanelHeight + getVBoxDelta($preHeaderPanelScroller) : 0);
     }
 
-    function resizeCanvas(forceReMeasure) {
+    function resizeCanvas(forceUpdate) {
       if (!initialized) { return; }
       if (options.autoHeight) {
         viewportH = options.rowHeight * getDataLengthIncludingAddNew();
@@ -1935,7 +1935,7 @@ if (typeof Slick === "undefined") {
         $viewport.height(viewportH);
       }
       
-      if (forceReMeasure) {
+      if (forceUpdate) {
         scrollbarDimensions = measureScrollbar();
       }
 

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1921,7 +1921,7 @@ if (typeof Slick === "undefined") {
           (options.createPreHeaderPanel && options.showPreHeaderPanel ? options.preHeaderPanelHeight + getVBoxDelta($preHeaderPanelScroller) : 0);
     }
 
-    function resizeCanvas(forceUpdate) {
+    function resizeCanvas(forceReMeasure) {
       if (!initialized) { return; }
       if (options.autoHeight) {
         viewportH = options.rowHeight * getDataLengthIncludingAddNew();
@@ -1935,7 +1935,7 @@ if (typeof Slick === "undefined") {
         $viewport.height(viewportH);
       }
       
-      if (forceUpdate) {
+      if (forceReMeasure) {
         scrollbarDimensions = measureScrollbar();
       }
 

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1921,7 +1921,7 @@ if (typeof Slick === "undefined") {
           (options.createPreHeaderPanel && options.showPreHeaderPanel ? options.preHeaderPanelHeight + getVBoxDelta($preHeaderPanelScroller) : 0);
     }
 
-    function resizeCanvas(forceUpdate) {
+    function resizeCanvas() {
       if (!initialized) { return; }
       if (options.autoHeight) {
         viewportH = options.rowHeight * getDataLengthIncludingAddNew();
@@ -1933,10 +1933,6 @@ if (typeof Slick === "undefined") {
       viewportW = parseFloat($.css($container[0], "width", true));
       if (!options.autoHeight) {
         $viewport.height(viewportH);
-      }
-      
-      if (forceUpdate) {
-        scrollbarDimensions = measureScrollbar();
       }
 
       if (options.forceFitColumns) {


### PR DESCRIPTION
Use case is the parent container of my SlickGrid instance is hidden during instantiation, so scrollbar measurement is returning {width: 0, height: 0}.  Need a way to force a re-measurement after parent container is visible.  There might be a better place than this to do so...?