### PR TITLE
Publish event when columns changed via the column picker

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -29,6 +29,7 @@
     var $list;
     var $menu;
     var columnCheckboxes;
+    var onColumnsChanged = new Slick.Event();
 
     var defaults = {
       fadeSpeed: 250,
@@ -187,6 +188,7 @@
         }
 
         grid.setColumns(visibleColumns);
+        onColumnsChanged.notify({"columns": visibleColumns});
       }
     }
 
@@ -198,7 +200,8 @@
 
     return {
       "getAllColumns": getAllColumns,
-      "destroy": destroy
+      "destroy": destroy,
+      "onColumnsChanged": onColumnsChanged
     };
   }
 

--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -188,7 +188,7 @@
         }
 
         grid.setColumns(visibleColumns);
-        onColumnsChanged.notify({"columns": visibleColumns});
+        onColumnsChanged.notify({columns: visibleColumns, grid: grid});
       }
     }
 

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -387,6 +387,10 @@
           }
 
           _grid.setColumns(visibleColumns);
+          _self.onColumnsChanged.notify({
+              "grid": _grid,
+              "columns": visibleColumns
+            }, e, _self);
         }
       }
 
@@ -403,7 +407,8 @@
         "showGridMenu": showGridMenu,
         "onBeforeMenuShow": new Slick.Event(),
         "onMenuClose": new Slick.Event(),
-        "onCommand": new Slick.Event()
+        "onCommand": new Slick.Event(),
+        "onColumnsChanged": new Slick.Event()
       });
     }
   })(jQuery);

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -216,6 +216,11 @@
       }
     });
 
+    // subscribe to event when column visibility is changed via the menu
+    gridMenuControl.onColumnsChanged.subscribe(function(e, args) {
+      console.log('Columns changed via the menu');
+    });
+
     // subscribe to event when menu is closing
     gridMenuControl.onMenuClose.subscribe(function(e, args) {
       console.log('Menu is closing');

--- a/examples/example-plugin-headermenu.html
+++ b/examples/example-plugin-headermenu.html
@@ -197,6 +197,11 @@
 			}
     });
 
+    // subscribe to event when column visibility is changed via the menu
+    columnpicker.onColumnsChanged.subscribe(function(e, args) {
+      console.log('Columns changed via the menu');
+    });
+
     grid.registerPlugin(headerMenuPlugin);
 
   })


### PR DESCRIPTION
Added an event to the column picker that is published when the visible columns are changed.  This was important in an app I have in which there are many (over 100) possible columns to display, and a separate message needs to be sent to the server to tell it which columns are currently being shown, so that the data returned can be filtered server-side to only include the visible data.