### PR TITLE
Fix displayed page number being zero-based.

### DIFF
--- a/controls/slick.pager.js
+++ b/controls/slick.pager.js
@@ -142,7 +142,7 @@
       if (pagingInfo.pageSize == 0) {
         $status.text(_options.showAllText.replace('{rowCount}', pagingInfo.totalRows + "").replace('{pageCount}', pagingInfo.totalPages + ""));
       } else {
-        $status.text(_options.showPageText.replace('{pageNum}', pagingInfo.pageNum + "").replace('{pageCount}', pagingInfo.totalPages + ""));
+        $status.text(_options.showPageText.replace('{pageNum}', pagingInfo.pageNum + 1 + "").replace('{pageCount}', pagingInfo.totalPages + ""));
       }
     }
 


### PR DESCRIPTION
Addresses issue #189 

The displayed page number was zero based, meaning that the pager would show something like "Showing page 0 of 1".

This is fixed by adding one. I believe this was a bug introduced in c30867d02b269674ab27f2fffa755c7339fc8ff0 (before which, one was added to the page number to be displayed).