### PR TITLE
Introducing an extra option enablePagingDuringScroll. If this option …

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1802,7 +1802,8 @@ if (typeof Slick === "undefined") {
 
     function removeRowFromCache(row) {
       var cacheEntry = rowsCache[row];
-      if (!cacheEntry) {
+      //In some cases cacheEntry is filled with a null rowNode...
+      if (!cacheEntry || !cacheEntry.rowNode) {
         return;
       }
 

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -99,7 +99,8 @@ if (typeof Slick === "undefined") {
       addNewRowCssClass: "new-row",
       preserveCopiedSelectionOnPaste: false,
       showCellSelection: true,
-      viewportClass: null
+      viewportClass: null,
+      enablePagingDuringScroll: true
     };
 
     var columnDefaults = {
@@ -3594,8 +3595,8 @@ if (typeof Slick === "undefined") {
       var stepFn = stepFunctions[dir];
       var pos = stepFn(activeRow, activeCell, activePosX);
       if (pos) {
-        var isAddNewRow = (pos.row == getDataLength());
-        scrollCellIntoView(pos.row, pos.cell, !isAddNewRow);
+        var doPaging = options.enablePagingDuringScroll && (pos.row == getDataLength());
+        scrollCellIntoView(pos.row, pos.cell, doPaging);
         setActiveCellInternal(getCellNode(pos.row, pos.cell));
         activePosX = pos.posX;
         return true;


### PR DESCRIPTION
…is false (defaults to true), scrolling by using the arrows is not scrolling a line at a time even if we reach the start/end of a page.

The default is true, which makes the change backward compatible.