### PR TITLE
BUG: Clear selection if selectActiveCell is False

### DIFF
--- a/plugins/slick.cellselectionmodel.js
+++ b/plugins/slick.cellselectionmodel.js
@@ -88,6 +88,10 @@
       if (_options.selectActiveCell && args.row != null && args.cell != null) {
         setSelectedRanges([new Slick.Range(args.row, args.cell)]);
       }
+      else if (!_options.selectActiveCell) {
+        // clear the previous selection once the cell changes
+        setSelectedRanges([]);
+      }
     }
 
     function handleKeyDown(e) {


### PR DESCRIPTION
If selectActiveCell was set to false, and pasting text into a cell the
action would only work one time, and then wouldn't update again. As
selections are cleared everything seems to be working as expected.