### PR TITLE
[feature] Header Menu plugin autoAlign

### DIFF
--- a/examples/example-plugin-headermenu.html
+++ b/examples/example-plugin-headermenu.html
@@ -47,7 +47,7 @@
 </head>
 <body>
 <div style="position:relative">
-  <div style="width:600px;">
+  <div style="width:500px;">
     <div id="myGrid" style="width:100%;height:500px;"></div>
   </div>
 
@@ -57,11 +57,16 @@
         This example demonstrates using the <b>Slick.Plugins.HeaderMenu</b> plugin to add drop-down menus to column
         headers.  (Hover over the headers.)
       </p>
+      <hr>
+      <h3>Auto-align option</h3>
       <p>
-        Auto-align will divide into 2 groups (columns on the left &amp; right).
-        The left side columns will have their drop menu align on right while the right side columns will align on the left
+        Auto-align (defaults to False), will calculate whether it has enough space to show the drop menu to the right. 
+        If it calculates that the drop menu is to fall outside of the viewport, it will automatically align the drop menu to the left.
+        However please note that to simulate a left alignement, we actually need to know the width of the drop menu.
+        The width of the drop menu is easy to find, it is the <i><b>"max-width"</b></i> set in the <i><b>".slick-header-menu"</b></i> CSS class.
       </p>
-      <h3>Auto-Align Header Drop Menu</h3>
+      <hr>
+      <h3>Auto-Align Header Menu Drop</h3>
       <button onclick="autoAlignMenu(true)">ON</button>
       <button onclick="autoAlignMenu(false)">OFF</button>
       <h2>View Source:</h2>
@@ -84,12 +89,13 @@
   var grid;
   var headerMenuPlugin;
   var columns = [
-    {id: "title", name: "Title", field: "title"},
-    {id: "duration", name: "Duration", field: "duration", sortable: true},
-    {id: "%", name: "% Complete", field: "percentComplete", sortable: true},
+    {id: "title", name: "Title", field: "title", width: 90},
+    {id: "duration", name: "Duration", field: "duration", sortable: true, width: 90},
+    {id: "%", name: "% Complete", field: "percentComplete", sortable: true, width: 90},
     {id: "start", name: "Start", field: "start"},
     {id: "finish", name: "Finish", field: "finish"},
     {id: "effort-driven", name: "Effort Driven", field: "effortDriven"}
+
   ];
 
   for (var i = 0; i < columns.length; i++) {

--- a/examples/example-plugin-headermenu.html
+++ b/examples/example-plugin-headermenu.html
@@ -52,10 +52,18 @@
   </div>
 
   <div class="options-panel">
-    <p>
-      This example demonstrates using the <b>Slick.Plugins.HeaderMenu</b> plugin to add drop-down menus to column
-      headers.  (Hover over the headers.)
-    </p>
+      <h2>Demonstrates:</h2>
+      <p>
+        This example demonstrates using the <b>Slick.Plugins.HeaderMenu</b> plugin to add drop-down menus to column
+        headers.  (Hover over the headers.)
+      </p>
+      <p>
+        Auto-align will divide into 2 groups (columns on the left &amp; right).
+        The left side columns will have their drop menu align on right while the right side columns will align on the left
+      </p>
+      <h3>Auto-Align Header Drop Menu</h3>
+      <button onclick="autoAlignMenu(true)">ON</button>
+      <button onclick="autoAlignMenu(false)">OFF</button>
       <h2>View Source:</h2>
       <ul>
           <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-plugin-headermenu.html" target="_sourcewindow"> View the source for this example on Github</a></li>
@@ -74,6 +82,7 @@
 <script>
   var data = [];
   var grid;
+  var headerMenuPlugin;
   var columns = [
     {id: "title", name: "Title", field: "title"},
     {id: "duration", name: "Duration", field: "duration", sortable: true},
@@ -145,6 +154,12 @@
     });
   };
 
+  function autoAlignMenu(auto) {
+    // for the autoAlign to work properly, you need to provide the width of the drop menu.
+    // this width is the one showing in the CSS max-width, by default 100px
+    headerMenuPlugin.setOptions({ autoAlign: auto, width: 100 });
+  }
+
   $(function () {
     data = [];
     for (var i = 0; i < 500; i++) {
@@ -160,7 +175,7 @@
 
     grid = new Slick.Grid("#myGrid", data, columns, options);
     var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
-    var headerMenuPlugin = new Slick.Plugins.HeaderMenu({});
+    headerMenuPlugin = new Slick.Plugins.HeaderMenu({});
 
     grid.onSort.subscribe(function (e, args) {
       executeSort(args.sortCols);

--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -51,6 +51,7 @@
    *    command:      A command identifier to be passed to the onCommand event handlers.
    *    iconCssClass: A CSS class to be added to the menu item icon.
    *    iconImage:    A url to the icon image.
+   *    autoAlign:    Auto-align will divide into 2 groups and make the left columns have drop menu align on right and vice versa
    *
    *
    * The plugin exposes the following events:
@@ -83,7 +84,9 @@
     var _handler = new Slick.EventHandler();
     var _defaults = {
       buttonCssClass: null,
-      buttonImage: null
+      buttonImage: null,
+      autoAlign: false,
+      width: 100
     };
     var $menu;
     var $activeHeaderColumn;
@@ -101,6 +104,10 @@
 
       // Hide the menu on outside click.
       $(document.body).on("mousedown", handleBodyMouseDown);
+    }
+
+    function setOptions(newOptions) {
+      options = $.extend(true, {}, options, newOptions);
     }
 
 
@@ -222,10 +229,18 @@
           .appendTo($li);
       }
 
-
-      // Position the menu.
+      var leftPos = $(this).offset().left;
+      
+      // when auto-align is set, it will make the left columns have drop menu align on right and vice versa
+      if (options.autoAlign) {
+        var columnCount = _grid.getColumns().length;
+        if (_grid.getColumnIndex(columnDef.id) >= (columnCount / 2)) {
+          leftPos = leftPos - options.width;
+        }  
+      }
+      
       $menu
-        .offset({ top: $(this).offset().top + $(this).height(), left: $(this).offset().left });
+        .offset({ top: $(this).offset().top + $(this).height(), left: leftPos });
 
 
       // Mark the header as active to keep the highlighting.
@@ -267,6 +282,7 @@
     $.extend(this, {
       "init": init,
       "destroy": destroy,
+      "setOptions": setOptions,
 
       "onBeforeMenuShow": new Slick.Event(),
       "onCommand": new Slick.Event()

--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -51,7 +51,7 @@
    *    command:      A command identifier to be passed to the onCommand event handlers.
    *    iconCssClass: A CSS class to be added to the menu item icon.
    *    iconImage:    A url to the icon image.
-   *    autoAlign:    Auto-align will divide into 2 groups and make the left columns have drop menu align on right and vice versa
+   *    autoAlign:    Auto-align drop menu to the left when not enough viewport space to show on the right
    *
    *
    * The plugin exposes the following events:
@@ -230,11 +230,13 @@
       }
 
       var leftPos = $(this).offset().left;
-      
-      // when auto-align is set, it will make the left columns have drop menu align on right and vice versa
+
+      // when auto-align is set, it will calculate whether it has enough space in the viewport to show the drop menu on the right (default)
+      // if there isn't enough space on the right, it will automatically align the drop menu to the left
+      // to simulate an align left, we actually need to know the width of the drop menu
       if (options.autoAlign) {
-        var columnCount = _grid.getColumns().length;
-        if (_grid.getColumnIndex(columnDef.id) >= (columnCount / 2)) {
+        var gridPos = _grid.getGridPosition();
+        if ((leftPos + options.width) >= gridPos.width) {
           leftPos = leftPos - options.width;
         }  
       }


### PR DESCRIPTION
Another improvement for the Header Menu Plugin.

This plugin is nice but it has a flaw, it's always align to the right and if the last column (on the right) is too close to the edge of the browser or the viewport, we cannot see the entire menu.
So this PR fixes that problem, I added 2 new options which is `autoAlign` (defaults to false so that it doesn't break change previous behavior of always showing drop menu on the right), the other option is the `width` which the `autoAlign` need for simulating a left align of the drop menu. I also created a new function `setOptions({ })` because I need it for the demo, to enable/disable the `autoAlign` with a simple button click. 

How does it work?
Auto-align (defaults to False), will calculate whether it has enough space to show the drop menu to the right. If it calculates that the drop menu is to fall outside of the viewport, it will automatically align the drop menu to the left. However please note that to simulate a left alignement, we actually need to know the width of the drop menu. The width of the drop menu is a known thing, it is the `max-width` defined in the `.slick-header-menu` CSS class, which is `100px` in the demo.

Demo, animated GIF
The animated gif starts with `autoAlign` disabled, and you can see that the last menu falls outside of the viewport and we only see half of the drop menu. The animated gif continues by enabling the `autoAlign: true` and then going back to the last column and bingo, the drop menu now shows on the left since it knows that there isn't enough room on the right to show it all. 

![2018-02-25_01-37-09](https://user-images.githubusercontent.com/643976/36638920-7da3338e-19ce-11e8-9da4-f96c513864ec.gif)
