### PR TITLE
[feature] Header Menu plugin autoAlign

### DIFF
--- a/examples/example-plugin-headermenu.html
+++ b/examples/example-plugin-headermenu.html
@@ -19,7 +19,6 @@
       padding: 2px;
       -moz-box-shadow: 2px 2px 2px silver;
       -webkit-box-shadow: 2px 2px 2px silver;
-      min-width: 100px;
       z-index: 20;
     }
 
@@ -60,10 +59,8 @@
       <hr>
       <h3>Auto-align option</h3>
       <p>
-        Auto-align (defaults to False), will calculate whether it has enough space to show the drop menu to the right. 
-        If it calculates that the drop menu is to fall outside of the viewport, it will automatically align the drop menu to the left.
-        However please note that to simulate a left alignement, we actually need to know the width of the drop menu.
-        The width of the drop menu is easy to find, it is the <i><b>"max-width"</b></i> set in the <i><b>".slick-header-menu"</b></i> CSS class.
+        Auto-align (defaults to True), will calculate whether it has enough space to show the drop menu to the right. 
+        If it calculates that the drop menu is to fall outside of the viewport, it will automatically align the drop menu to the left.        
       </p>
       <hr>
       <h3>Auto-Align Header Menu Drop</h3>
@@ -133,6 +130,9 @@
   var visibleColumns = columns;
 
   var options = {
+    columnPicker: {
+      columnTitle: "Columns"
+    },
     enableColumnReorder: false,
     multiColumnSort: true
   };
@@ -160,10 +160,8 @@
     });
   };
 
-  function autoAlignMenu(auto) {
-    // for the autoAlign to work properly, you need to provide the width of the drop menu.
-    // this width is the one showing in the CSS max-width, by default 100px
-    headerMenuPlugin.setOptions({ autoAlign: auto, width: 100 });
+  function autoAlignMenu(isEnabled) {
+    headerMenuPlugin.setOptions({ autoAlign: isEnabled });
   }
 
   $(function () {
@@ -220,7 +218,7 @@
 
     // subscribe to event when column visibility is changed via the menu
     columnpicker.onColumnsChanged.subscribe(function(e, args) {
-      console.log('Columns changed via the menu');
+      console.log('Columns changed via the menu', args.columns);
     });
 
     grid.registerPlugin(headerMenuPlugin);

--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -45,13 +45,15 @@
    *
    *
    * Available menu item options:
-   *    title:        Menu item text.
-   *    disabled:     Whether the item is disabled.
-   *    tooltip:      Item tooltip.
-   *    command:      A command identifier to be passed to the onCommand event handlers.
-   *    iconCssClass: A CSS class to be added to the menu item icon.
-   *    iconImage:    A url to the icon image.
-   *    autoAlign:    Auto-align drop menu to the left when not enough viewport space to show on the right
+   *    title:            Menu item text.
+   *    disabled:         Whether the item is disabled.
+   *    tooltip:          Item tooltip.
+   *    command:          A command identifier to be passed to the onCommand event handlers.
+   *    iconCssClass:     A CSS class to be added to the menu item icon.
+   *    iconImage:        A url to the icon image.
+   *    minWidth:         Minimum width that the drop menu will have
+   *    autoAlign:        Auto-align drop menu to the left when not enough viewport space to show on the right
+   *    autoAlignOffset:  When drop menu is aligned to the left, it might not be perfectly aligned with the header menu icon, if that is the case you can add an offset (positive/negative number to move right/left)
    *
    *
    * The plugin exposes the following events:
@@ -85,8 +87,9 @@
     var _defaults = {
       buttonCssClass: null,
       buttonImage: null,
-      autoAlign: false,
-      width: 100
+      minWidth: 100,
+      autoAlign: true,
+      autoAlignOffset: 0
     };
     var $menu;
     var $activeHeaderColumn;
@@ -188,7 +191,7 @@
 
 
       if (!$menu) {
-        $menu = $("<div class='slick-header-menu'></div>")
+        $menu = $("<div class='slick-header-menu' style='min-width: " + options.minWidth + "px'></div>")
           .appendTo(_grid.getContainerNode());
       }
       $menu.empty();
@@ -236,8 +239,8 @@
       // to simulate an align left, we actually need to know the width of the drop menu
       if (options.autoAlign) {
         var gridPos = _grid.getGridPosition();
-        if ((leftPos + options.width) >= gridPos.width) {
-          leftPos = leftPos - options.width;
+        if ((leftPos + options.minWidth) >= gridPos.width) {
+          leftPos = leftPos - options.minWidth + options.autoAlignOffset;
         }  
       }
       


### PR DESCRIPTION
A continuation of the PR #203, as per the note I left in last PR
> I was also thinking, that since autoAlign need to know the width, I could actually use that width to create the DOM element (instead of using CSS), I could default it internally to 100px, which is the current default in CSS. I wasn't crazy about the width being controlled by CSS, since the width of the plugin might be out of sync, the CSS width might different than the one used by the plugin for autoAlign, however if I remove the width from CSS and the width option to create the DOM element itself, then they will never be out of sync.

- remove the CSS `min-width` and instead only use the plugin `minWidth` to create the DOM element
  - to avoid having the CSS `min-width` being different than the one provided to the plugin `minWidth`
- renamed plugin `width` option to `minWidth` since minimum width is a better approach when menu command texts are longer than the width, with `minWidth` in place it will auto-resize to fit (the original CSS code was also set that way).
- enabled the `autoAlign` to True by default

@6pac 
I would seriously prefer this approach (`minWidth` to be provided in the plugin instead of by CSS) for the reason that I explained on top. 
However, I left you the decision to merge this PR or disregard it. 