### PR TITLE
updateRowCount shouldn't set virtual height when options.autoHeight is used

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1989,18 +1989,22 @@ if (typeof Slick === "undefined") {
       }
 
       var oldH = h;
-      th = Math.max(options.rowHeight * numberOfRows, viewportH - scrollbarDimensions.height);
-      if (th < maxSupportedCssHeight) {
-        // just one page
-        h = ph = th;
-        n = 1;
-        cj = 0;
+      if (options.autoHeight) {
+        h =  options.rowHeight * numberOfRows;
       } else {
-        // break into pages
-        h = maxSupportedCssHeight;
-        ph = h / 100;
-        n = Math.floor(th / ph);
-        cj = (th - h) / (n - 1);
+        th = Math.max(options.rowHeight * numberOfRows, viewportH - scrollbarDimensions.height);
+        if (th < maxSupportedCssHeight) {
+          // just one page
+          h = ph = th;
+          n = 1;
+          cj = 0;
+        } else {
+          // break into pages
+          h = maxSupportedCssHeight;
+          ph = h / 100;
+          n = Math.floor(th / ph);
+          cj = (th - h) / (n - 1);
+        }
       }
 
       if (h !== oldH) {


### PR DESCRIPTION
Currently, the virtual height `th` is used to update `h` in `updateRowCount`, but when filtering and autoHeight are used `options.rowHeight * numberOfRows` can be less than the current viewport height, so `th` is set to the existing `viewportH - scrollbarDimensions.height`.

The problem in this case is that `h` is always set to `oldH` and so `resizeCanvas` doesn't get called. This is only a problem on mobile browsers since there is no scrollbar height factored in, on desktop browsers the scrollbar height means that `h` does change and `resizeCanvas` does get called, but that is more of an accident than intentional... the answer anyway is not to use virtual height with the autoHeight option at all. 