### PR TITLE
 feat(grid): add alwaysShowVerticalScroll to fix Grid Menu side effect, closes #231

### DIFF
--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -102,7 +102,7 @@
       var columnCheckboxes;
       var _defaults = {
         hideForceFitButton: false,
-        hideSyncResizeButton: false, 
+        hideSyncResizeButton: false,
         fadeSpeed: 250,
         forceFitTitle: "Force fit columns",
         menuWidth: 18,
@@ -117,7 +117,7 @@
 
         // if header row is enabled, we need to resize it's width also
         var enableResizeHeaderRow = (_options.gridMenu && _options.gridMenu.resizeOnShowHeaderRow != undefined) ? _options.gridMenu.resizeOnShowHeaderRow : _defaults.resizeOnShowHeaderRow;
-        if(enableResizeHeaderRow) {
+        if(enableResizeHeaderRow && _options.showHeaderRow) {
           var $headerrow = $('.slick-headerrow');
           $headerrow.attr('style', 'width: calc(100% - ' + gridMenuWidth +'px)');
         }

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -34,7 +34,7 @@
     <div id="myGrid" style="width:100%;height:500px;"></div>
   </div>
   <div class="options-panel">
-    &lt;==
+    &lt;== Top Right Corner
     <h2>Demonstrates:</h2>
     <ul>
       <li>This example demonstrates using the Slick.Controls.GridMenu to add a Grid Menu (hamburger menu on top right of the grid)</li>
@@ -44,10 +44,21 @@
       <li>Optional title for the columns list (bottom section)</li>
       <li>To dismiss the Grid Menu, user can click on the "x" on top right corner or anywhere outside of the Grid Menu</li>
       <li>Possibility to attach the Grid Menu to an external button (try clicking on the button below).</li>
-      <br/>
-      <button onclick="toggleGridMenu(event)"><img src="../images/drag-handle.png"/> Grid Menu</button>
     </ul>
-      <h2>View Source:</h2>
+
+    <p>
+        <button onclick="toggleGridMenu(event)"><img src="../images/drag-handle.png"/> Grid Menu</button>
+    </p>
+    <p>
+      Always show vertical scroll (with "alwaysShowVerticalScroll" flag), so that it works with small and large dataset.
+      Not using this flag, might have side effect on the UI with the Grid Menu overlapping with the data in background.
+    </p>
+    <div style="margin-bottom:10px">
+      <button onclick="loadData(15)">15 rows</button>
+      <button onclick="loadData(5000)">5000 rows</button>
+
+    </div>
+    <h2>View Source:</h2>
       <ul>
           <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-grid-menu.html" target="_sourcewindow"> View the source for this example on Github</a></li>
       </ul>
@@ -76,6 +87,8 @@
     showHeaderRow: true,
     headerRowHeight: 30,
     explicitInitialization: true,
+    forceFitColumns: true,
+    alwaysShowVerticalScroll: true, // this is necessary when using Grid Menu with a small dataset
 
     // gridMenu Object is optional
     // when not passed, it will act as a regular Column Picker (with default Grid Menu image of drag-handle.png)
@@ -134,6 +147,17 @@
     });
   }
 
+  function loadData(count) {
+    data = [];
+    for (var i = 0; i < count; i++) {
+      var d = (data[i] = {});
+      d["id"] = i;
+      for (var j = 0; j < columns.length; j++) {
+        d[j] = Math.round(Math.random() * 10);
+      }
+    }
+    dataView.setItems(data);
+  }
 
   function filter(item) {
     for (var columnId in columnFilters) {
@@ -152,13 +176,7 @@
   }
 
   $(function () {
-    for (var i = 0; i < 100; i++) {
-      var d = (data[i] = {});
-      d["id"] = i;
-      for (var j = 0; j < columns.length; j++) {
-        d[j] = Math.round(Math.random() * 10);
-      }
-    }
+
 
     dataView = new Slick.Data.DataView();
     grid = new Slick.Grid("#myGrid", dataView, columns, options);
@@ -195,8 +213,8 @@
     grid.init();
 
     dataView.beginUpdate();
-    dataView.setItems(data);
     dataView.setFilter(filter);
+    loadData(1000);
     dataView.endUpdate();
 
     // subscribe to Grid Menu event(s)

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -55,6 +55,7 @@ if (typeof Slick === "undefined") {
   function SlickGrid(container, data, columns, options) {
     // settings
     var defaults = {
+      alwaysShowVerticalScroll: false,
       explicitInitialization: false,
       rowHeight: 25,
       defaultColumnWidth: 80,
@@ -152,7 +153,7 @@ if (typeof Slick === "undefined") {
     var headerColumnWidthDiff = 0, headerColumnHeightDiff = 0, // border+padding
         cellWidthDiff = 0, cellHeightDiff = 0, jQueryNewWidthBehaviour = false;
     var absoluteColumnMinWidth;
-    
+
     var tabbingDirection = 1;
     var activePosX;
     var activeRow, activeCell;
@@ -184,7 +185,7 @@ if (typeof Slick === "undefined") {
 
     var pagingActive = false;
     var pagingIsLastPage = false;
-    
+
     // async call handles
     var h_editorLoader = null;
     var h_render = null;
@@ -217,10 +218,10 @@ if (typeof Slick === "undefined") {
     // Initialization
 
     function init() {
-      if (container instanceof jQuery) { 
-        $container = container; 
-      } else { 
-        $container = $(container); 
+      if (container instanceof jQuery) {
+        $container = container;
+      } else {
+        $container = $(container);
       }
       if ($container.length < 1) {
         throw new Error("SlickGrid requires a valid container, " + container + " does not exist in the DOM.");
@@ -302,7 +303,7 @@ if (typeof Slick === "undefined") {
       }
 
       $viewport = $("<div class='slick-viewport' style='width:100%;overflow:auto;outline:0;position:relative;;'>").appendTo($container);
-      $viewport.css("overflow-y", options.autoHeight ? "hidden" : "auto");
+      $viewport.css("overflow-y", options.alwaysShowVerticalScroll ? "scroll" : (options.autoHeight ? "hidden" : "auto"));
       $viewport.css("overflow-x", options.forceFitColumns ? "hidden" : "auto");
       if (options.viewportClass) $viewport.toggleClass(options.viewportClass, true);
 
@@ -747,7 +748,7 @@ if (typeof Slick === "undefined") {
 
         if (m.sortable) {
           header.addClass("slick-header-sortable");
-          header.append("<span class='slick-sort-indicator" 
+          header.append("<span class='slick-sort-indicator"
             + (options.numberedMultiColumnSort && !options.sortColNumberInSeparateSpan ? " slick-sort-indicator-numbered" : "" ) + "' />");
           if (options.numberedMultiColumnSort && options.sortColNumberInSeparateSpan) { header.append("<span class='slick-sort-indicator-numbered' />"); }
         }
@@ -791,7 +792,7 @@ if (typeof Slick === "undefined") {
         }
       }
     }
-    
+
     function setupColumnSort() {
       $headers.click(function (e) {
         if (columnResizeDragging) return;
@@ -823,10 +824,10 @@ if (typeof Slick === "undefined") {
             }
           }
           var hadSortCol = !!sortColumn;
-          
+
           if (options.tristateMultiColumnSort) {
-              if (!sortColumn) { 
-                sortColumn = { columnId: column.id, sortAsc: column.defaultSortAsc }; 
+              if (!sortColumn) {
+                sortColumn = { columnId: column.id, sortAsc: column.defaultSortAsc };
               }
               if (hadSortCol && sortColumn.sortAsc) {
                 // three state: remove sort rather than go back to ASC
@@ -834,8 +835,8 @@ if (typeof Slick === "undefined") {
                 sortColumn = null;
               }
               if (!options.multiColumnSort) { sortColumns = []; }
-              if (sortColumn && (!hadSortCol || !options.multiColumnSort)) { 
-                sortColumns.push(sortColumn); 
+              if (sortColumn && (!hadSortCol || !options.multiColumnSort)) {
+                sortColumns.push(sortColumn);
               }
           } else {
               // legacy behaviour
@@ -855,9 +856,9 @@ if (typeof Slick === "undefined") {
                 } else if (sortColumns.length == 0) {
                   sortColumns.push(sortColumn);
                 }
-              }              
+              }
           }
-          
+
           setSortColumns(sortColumns);
 
           if (!options.multiColumnSort) {
@@ -1388,10 +1389,10 @@ if (typeof Slick === "undefined") {
             .addClass("slick-header-column-sorted")
               .find(".slick-sort-indicator")
                 .addClass(col.sortAsc ? "slick-sort-indicator-asc" : "slick-sort-indicator-desc");
-          if (numberCols) { 
+          if (numberCols) {
             headerColumnEls.eq(columnIndex)
               .find(".slick-sort-indicator-numbered")
-                .text(i+1); 
+                .text(i+1);
           }
         }
       });
@@ -1733,23 +1734,23 @@ if (typeof Slick === "undefined") {
       }
 
       var value = null, formatterResult = '';
-      if (item) { 
+      if (item) {
         value = getDataItemValueForColumn(item, m);
         formatterResult =  getFormatter(row, m)(row, cell, value, m, item, self);
         if (formatterResult === null || formatterResult === undefined) { formatterResult = ''; }
       }
-      
+
       // get addl css class names from object type formatter return and from string type return of onBeforeAppendCell
       var addlCssClasses = trigger(self.onBeforeAppendCell, { row: row, cell: cell, grid: self, value: value, dataContext: item }) || '';
       addlCssClasses += (formatterResult && formatterResult.addClasses ? (addlCssClasses ? ' ' : '') + formatterResult.addClasses : '');
-      
+
       stringArray.push("<div class='" + cellCss + (addlCssClasses ? ' ' + addlCssClasses : '') + "'>");
 
       // if there is a corresponding row (if not, this is the Add New row or this data hasn't been loaded yet)
       if (item) {
         stringArray.push(Object.prototype.toString.call(formatterResult)  !== '[object Object]' ? formatterResult : formatterResult.text);
       }
-      
+
       stringArray.push("</div>");
 
       rowsCache[row].cellRenderQueue.push(cell);
@@ -1837,7 +1838,7 @@ if (typeof Slick === "undefined") {
           }
         }
       }
-      
+
       delete rowsCache[row];
       delete postProcessedRows[row];
       renderedRows--;
@@ -1869,16 +1870,16 @@ if (typeof Slick === "undefined") {
 
     function applyFormatResultToCellNode(formatterResult, cellNode, suppressRemove) {
         if (formatterResult === null || formatterResult === undefined) { formatterResult = ''; }
-        if (Object.prototype.toString.call(formatterResult)  !== '[object Object]') { 
+        if (Object.prototype.toString.call(formatterResult)  !== '[object Object]') {
             cellNode.innerHTML = formatterResult;
             return;
         }
         cellNode.innerHTML = formatterResult.text;
-        if (formatterResult.removeClasses && !suppressRemove) { 
-            $(cellNode).removeClass(formatterResult.removeClasses); 
+        if (formatterResult.removeClasses && !suppressRemove) {
+            $(cellNode).removeClass(formatterResult.removeClasses);
         }
-        if (formatterResult.addClasses) { 
-            $(cellNode).addClass(formatterResult.addClasses); 
+        if (formatterResult.addClasses) {
+            $(cellNode).addClass(formatterResult.addClasses);
         }
     }
 
@@ -1907,7 +1908,7 @@ if (typeof Slick === "undefined") {
       ensureCellNodesInRowsCache(row);
 
       var formatterResult, d = getDataItem(row);
-    
+
       for (var columnIdx in cacheEntry.cellNodesByColumnIdx) {
         if (!cacheEntry.cellNodesByColumnIdx.hasOwnProperty(columnIdx)) {
           continue;
@@ -1958,7 +1959,7 @@ if (typeof Slick === "undefined") {
       if (!scrollbarDimensions || !scrollbarDimensions.width) {
         scrollbarDimensions = measureScrollbar();
       }
-      
+
       if (options.forceFitColumns) {
         autosizeColumns();
       }
@@ -1985,7 +1986,7 @@ if (typeof Slick === "undefined") {
 
       var oldViewportHasVScroll = viewportHasVScroll;
       // with autoHeight, we do not need to accommodate the vertical scroll bar
-      viewportHasVScroll = !options.autoHeight && (numberOfRows * options.rowHeight > viewportH);
+      viewportHasVScroll = options.alwaysShowVerticalScroll || !options.autoHeight && (numberOfRows * options.rowHeight > viewportH);
       viewportHasHScroll = (canvasWidth > viewportW - scrollbarDimensions.width);
 
       makeActiveCellNormal();
@@ -2739,7 +2740,7 @@ if (typeof Slick === "undefined") {
       if (e.isImmediatePropagationStopped()) {
         return;
       }
-      
+
       // this optimisation causes trouble - MLeibman #329
       //if ((activeCell != cell.cell || activeRow != cell.row) && canCellBeActive(cell.row, cell.cell)) {
       if (canCellBeActive(cell.row, cell.cell)) {
@@ -2978,7 +2979,7 @@ if (typeof Slick === "undefined") {
       } else {
         activeRow = activeCell = null;
       }
-    
+
       // this optimisation causes trouble - MLeibman #329
       //if (activeCellChanged) {
       if (!suppressActiveCellChangedEvent) { trigger(self.onActiveCellChanged, getActiveCell()); }
@@ -3038,7 +3039,7 @@ if (typeof Slick === "undefined") {
           invalidatePostProcessingResults(activeRow);
         }
       }
-      
+
       // if there previously was text selected on a page (such as selected text in the edit cell just removed),
       // IE can't set focus to anything else correctly
       if (navigator.userAgent.toLowerCase().match(/msie/)) {
@@ -3939,7 +3940,7 @@ if (typeof Slick === "undefined") {
       "getCanvasWidth": getCanvasWidth,
       "focus": setFocus,
       "scrollTo": scrollTo,
-      
+
       "getCellFromPoint": getCellFromPoint,
       "getCellFromEvent": getCellFromEvent,
       "getActiveCell": getActiveCell,


### PR DESCRIPTION
This PR closes #231

@6pac 
I did the following tests, to make sure it all works without affecting regular behavior
- add Grid Option with `alwaysShowVerticalScroll: true`
- add Grid Option with `alwaysShowVerticalScroll: false`
- don't include `alwaysShowVerticalScroll` flag in the options

If you want to see the UI side effect of no scrolling with Grid Menu, remove the `alwaysShowVerticalScroll` from the Grid Menu example and load 15 rows of data, you will see the overlapping of Grid Menu with data in background.

Also note, my editor has some default settings which removes any white space at the end of a line, so it shows a lot of diff. I hope you don't mind. 

