### PR TITLE
fix issue #68 editor with activeRow selection

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2749,7 +2749,7 @@ if (typeof Slick === "undefined") {
           scrollRowIntoView(cell.row, false);
 
           var preClickModeOn = (e.target && e.target.className === Slick.preClickClassName);
-          setActiveCellInternal(getCellNode(cell.row, cell.cell), null, preClickModeOn, true);
+          setActiveCellInternal(getCellNode(cell.row, cell.cell), null, preClickModeOn, options.editable);
         }
       }
     }
@@ -3704,7 +3704,7 @@ if (typeof Slick === "undefined") {
       var newCell = getCellNode(row, cell);
 
       // if selecting the 'add new' row, start editing right away
-      setActiveCellInternal(newCell, (forceEdit || (row === getDataLength()) || options.autoEdit), null, true);
+      setActiveCellInternal(newCell, (forceEdit || (row === getDataLength()) || options.autoEdit), null, options.editable);
 
       // if no editor was created, set the focus back on the grid
       if (!currentEditor) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2749,7 +2749,7 @@ if (typeof Slick === "undefined") {
           scrollRowIntoView(cell.row, false);
 
           var preClickModeOn = (e.target && e.target.className === Slick.preClickClassName);
-          setActiveCellInternal(getCellNode(cell.row, cell.cell), null, preClickModeOn);
+          setActiveCellInternal(getCellNode(cell.row, cell.cell), null, preClickModeOn, true);
         }
       }
     }
@@ -3704,7 +3704,7 @@ if (typeof Slick === "undefined") {
       var newCell = getCellNode(row, cell);
 
       // if selecting the 'add new' row, start editing right away
-      setActiveCellInternal(newCell, forceEdit || (row === getDataLength()) || options.autoEdit);
+      setActiveCellInternal(newCell, (forceEdit || (row === getDataLength()) || options.autoEdit), null, true);
 
       // if no editor was created, set the focus back on the grid
       if (!currentEditor) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2749,7 +2749,9 @@ if (typeof Slick === "undefined") {
           scrollRowIntoView(cell.row, false);
 
           var preClickModeOn = (e.target && e.target.className === Slick.preClickClassName);
-          setActiveCellInternal(getCellNode(cell.row, cell.cell), null, preClickModeOn, options.editable);
+          var column = columns[cell.cell];
+          var suppressActiveCellChangedEvent = (options.editable && column && column.editor) ? true : false;
+          setActiveCellInternal(getCellNode(cell.row, cell.cell), null, preClickModeOn, suppressActiveCellChangedEvent);
         }
       }
     }


### PR DESCRIPTION
This fixes the error reported in issue #68 with a `Slick.RowSelectionModel({selectActiveRow: true})` was not triggering properly the Editor. 

What was happening is that the Editor was getting triggered but canceled out by the row selection. The fix is to set the `setActiveCellInternal` function 4th argument to `True` (that arg is `suppressActiveCellChangedEvent`). This makes the Editor to work correctly and doesn't trigger the cell active change. Also we want to do this only when our Grid is Editable. 

@6pac 
Totally sorry about the last commit made on Master, I was supposed to be in my own bugfix branch but forgot to create the branch before pushing the commit. So I reverted the change... Again sorry about that. 

#### Tested Scenarios
1. Double-click to Edit and `selectActiveRow` to False
   -  `autoEdit: false` 
   - `grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));`
2. Double-click to Edit and `selectActiveRow` to True
   -  `autoEdit: false` 
   - `grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: true}));`
3. Single-click to Edit and `selectActiveRow` to False
   -  `autoEdit: true` 
   - `grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));`
4. Single-click to Edit and `selectActiveRow` to True
   -  `autoEdit: true` 
   - `grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: true}));`

#### Extra Commits
After testing it intensively, I found out that the argument `suppressActiveCellChangedEvent` should only be set to `True` when there is actually an Editor associated to the cell that we just clicked. This way it cancels out the Active Cell when Editing (which is what we want) but doesn't when there isn't any Editor attached.

See below to describe what I wrote in previous paragraph. 
The example below is set with `autoEdit: true` and `selectActiveRow: true`, the grid has Column B editable but Column C is not. When we click to edit any cell of Column B, it won't activate the row, but as soon as we click on any row of Column C it will activate the row since there is not Editor associated to that cell. I believe this is the correct behavior.

![2018-05-11_21-05-39](https://user-images.githubusercontent.com/643976/39952138-81419cca-555f-11e8-9e6c-5bca3446cb6e.gif)


