### PR TITLE
bugfix(editor): add a flag to suppress active cell changed on edit #242

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -63,6 +63,7 @@ if (typeof Slick === "undefined") {
       leaveSpaceForNewRows: false,
       editable: false,
       autoEdit: true,
+      suppressActiveCellChangeOnEdit: false,
       enableCellNavigation: true,
       enableColumnReorder: true,
       asyncEditorLoading: false,
@@ -2750,7 +2751,7 @@ if (typeof Slick === "undefined") {
 
           var preClickModeOn = (e.target && e.target.className === Slick.preClickClassName);
           var column = columns[cell.cell];
-          var suppressActiveCellChangedEvent = (options.editable && column && column.editor) ? true : false;
+          var suppressActiveCellChangedEvent = (options.editable && column && column.editor && options.suppressActiveCellChangeOnEdit) ? true : false;
           setActiveCellInternal(getCellNode(cell.row, cell.cell), null, preClickModeOn, suppressActiveCellChangedEvent);
         }
       }


### PR DESCRIPTION
Possible quick fix for issue reported in #242 
The new flag `suppressActiveCellChangeOnEdit` is disable by default but can be enabled to bypass error reported in #68 