### PR TITLE
fix(gridMenu): GridMenu with multiple grids & event leak

### DIFF
--- a/controls/slick.gridmenu.css
+++ b/controls/slick.gridmenu.css
@@ -8,7 +8,7 @@
   min-width: 180px;
   cursor: default;
   position:absolute;
-  z-index:20;
+  z-index: 2000;
 	overflow:auto;
   resize: both;
 }


### PR DESCRIPTION
- GridMenu was not working correctly with multiple grids
- GridMenu was not showing correctly in a Modal Window because it's `z-index` was too low
- Also found event leak, GridMenu should be destroyed on grid destroyed

#### Tested
- Tested with 2 grids in the same page
  - Commands clicked on 1st grid Grid Menu should not affect 2nd grid
- Destroying 2nd grid should destroy it's GridMenu as well & it's events attached without affecting the GridMenu of 1st grid
  - After 2nd grid is destroyed, we test that 1st GridMenu still work as expected