### PR TITLE
Feature/checkbox selector hide select all

### DIFF
--- a/examples/example-checkbox-row-select.html
+++ b/examples/example-checkbox-row-select.html
@@ -56,6 +56,9 @@
     <h2>Demonstrates:</h2>
     <ul>
       <li>Checkbox row select column</li>
+      <p>
+        <button onclick="toggleHideSelectAllCheckbox()">Toggle show/hide "Select All" checkbox</button>
+      </p>
     </ul>
       <h2>View Source:</h2>
       <ul>
@@ -94,8 +97,18 @@
     asyncEditorLoading: false,
     autoEdit: false
   };
+  var checkboxSelector1, checkboxSelector2;
   var columns = [];
   var columns2 = [];
+  var isSelectAllCheckbox1Hidden = false;
+  var isSelectAllCheckbox2Hidden = false;
+
+  function toggleHideSelectAllCheckbox() {
+    isSelectAllCheckbox1Hidden = !isSelectAllCheckbox1Hidden;
+    isSelectAllCheckbox2Hidden = !isSelectAllCheckbox2Hidden;
+    checkboxSelector1.setOptions({ hideSelectAllCheckbox: isSelectAllCheckbox1Hidden });
+    checkboxSelector2.setOptions({ hideSelectAllCheckbox: isSelectAllCheckbox2Hidden });
+  }
 
   $(function () {
     for (var i = 0; i < 100; i++) {
@@ -103,14 +116,14 @@
       d[0] = "Row " + i;
     }
 
-    var checkboxSelector = new Slick.CheckboxSelectColumn({
+    checkboxSelector1 = new Slick.CheckboxSelectColumn({
       cssClass: "slick-cell-checkboxsel"
     });
-    var checkboxSelector2 = new Slick.CheckboxSelectColumn({
+    checkboxSelector2 = new Slick.CheckboxSelectColumn({
       cssClass: "slick-cell-checkboxsel"
     });
 
-    columns.push(checkboxSelector.getColumnDefinition());
+    columns.push(checkboxSelector1.getColumnDefinition());
     columns2.push(checkboxSelector2.getColumnDefinition());
 
     for (var i = 0; i < 5; i++) {
@@ -127,7 +140,7 @@
 
     grid = new Slick.Grid("#myGrid", data, columns, options);
     grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
-    grid.registerPlugin(checkboxSelector);
+    grid.registerPlugin(checkboxSelector1);
 
     grid2 = new Slick.Grid("#myGrid2", data, columns2, options);
     grid2.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -15,9 +15,11 @@
     var _defaults = {
       columnId: "_checkbox_selector",
       cssClass: null,
+      hideSelectAllCheckbox: false,
       toolTip: "Select/Deselect All",
       width: 30
     };
+    var _isSelectAllChecked = false;
 
     var _options = $.extend(true, {}, _defaults, options);
 
@@ -32,6 +34,24 @@
 
     function destroy() {
       _handler.unsubscribeAll();
+    }
+
+    function getOptions(options) {
+      return _options;
+    }
+
+    function setOptions(options) {
+      _options = $.extend(true, {}, _options, options);
+      if (_options.hideSelectAllCheckbox) {
+        _grid.updateColumnHeader(_options.columnId, "", "");
+      } else {
+        var UID = createUID();
+        if (_isSelectAllChecked) {
+          _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox' checked='checked'><label for='header-selector" + UID + "'></label>", _options.toolTip);
+        } else {
+          _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox'><label for='header-selector" + UID + "'></label>", _options.toolTip);
+        }
+      }
     }
 
     function handleSelectedRowsChanged(e, args) {
@@ -52,10 +72,14 @@
       _selectedRowsLookup = lookup;
       _grid.render();
 
-      if (selectedRows.length && selectedRows.length == _grid.getDataLength()) {
-        _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox' checked='checked'><label for='header-selector" + UID + "'></label>", _options.toolTip);
-      } else {
-        _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox'><label for='header-selector" + UID + "'></label>", _options.toolTip);
+      if (!_options.hideSelectAllCheckbox) {
+        if (selectedRows.length && selectedRows.length == _grid.getDataLength()) {
+          _isSelectAllChecked = true;
+          _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox' checked='checked'><label for='header-selector" + UID + "'></label>", _options.toolTip);
+        } else {
+          _isSelectAllChecked = true;
+          _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox'><label for='header-selector" + UID + "'></label>", _options.toolTip);
+        }
       }
     }
 
@@ -165,13 +189,14 @@
 
       return {
         id: _options.columnId,
-        name: "<input id='header-selector" + UID + "' type='checkbox'><label for='header-selector" + UID + "'></label>",
+        name: _options.hideSelectAllCheckbox ? "" : "<input id='header-selector" + UID + "' type='checkbox'><label for='header-selector" + UID + "'></label>",
         toolTip: _options.toolTip,
         field: "sel",
         width: _options.width,
         resizable: false,
         sortable: false,
         cssClass: _options.cssClass,
+        hideSelectAllCheckbox: _options.hideSelectAllCheckbox,
         formatter: checkboxSelectionFormatter
       };
     }
@@ -196,7 +221,9 @@
       "destroy": destroy,
       "deSelectRows": deSelectRows,
       "selectRows": selectRows,
-      "getColumnDefinition": getColumnDefinition
+      "getColumnDefinition": getColumnDefinition,
+      "getOptions": getOptions,
+      "setOptions": setOptions,
     });
   }
 })(jQuery);

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -71,13 +71,12 @@
       }
       _selectedRowsLookup = lookup;
       _grid.render();
+      _isSelectAllChecked = selectedRows.length && selectedRows.length == _grid.getDataLength();
 
       if (!_options.hideSelectAllCheckbox) {
-        if (selectedRows.length && selectedRows.length == _grid.getDataLength()) {
-          _isSelectAllChecked = true;
+        if (_isSelectAllChecked) {
           _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox' checked='checked'><label for='header-selector" + UID + "'></label>", _options.toolTip);
         } else {
-          _isSelectAllChecked = true;
           _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox'><label for='header-selector" + UID + "'></label>", _options.toolTip);
         }
       }


### PR DESCRIPTION
- when using checkbox selector as a single row selection, we need a way to hide the "Select All" checkbox
- also added getOptions/setOptions to dynamically change options on the fly