### PR TITLE
feat(picker): Column Picker expose init to use by translation

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -28,6 +28,7 @@
 
 (function ($) {
   function SlickColumnPicker(columns, grid, options) {
+    var _grid = grid;
     var $list;
     var $menu;
     var columnCheckboxes;
@@ -43,7 +44,7 @@
       syncResizeTitle: "Synchronous resize"
     };
 
-    function init() {
+    function init(grid) {
       grid.onHeaderContextMenu.subscribe(handleHeaderContextMenu);
       grid.onColumnsReordered.subscribe(updateColumnOrder);
       options = $.extend({}, defaults, options);
@@ -69,8 +70,8 @@
     }
 
     function destroy() {
-      grid.onHeaderContextMenu.unsubscribe(handleHeaderContextMenu);
-      grid.onColumnsReordered.unsubscribe(updateColumnOrder);
+      _grid.onHeaderContextMenu.unsubscribe(handleHeaderContextMenu);
+      _grid.onColumnsReordered.unsubscribe(updateColumnOrder);
       $(document.body).off("mousedown", handleBodyMouseDown);
       $("div.slick-columnpicker").hide(options.fadeSpeed);
       $menu.remove();
@@ -94,7 +95,7 @@
         $input = $("<input type='checkbox' />").data("column-id", columns[i].id);
         columnCheckboxes.push($input);
 
-        if (grid.getColumnIndex(columns[i].id) != null) {
+        if (_grid.getColumnIndex(columns[i].id) != null) {
           $input.attr("checked", "checked");
         }
 
@@ -116,7 +117,7 @@
             .text(forceFitTitle)
             .prepend($input)
             .appendTo($li);
-        if (grid.getOptions().forceFitColumns) {
+        if (_grid.getOptions().forceFitColumns) {
           $input.attr("checked", "checked");
         }
       }
@@ -129,7 +130,7 @@
             .text(syncResizeTitle)
             .prepend($input)
             .appendTo($li);
-        if (grid.getOptions().syncColumnCellResize) {
+        if (_grid.getOptions().syncColumnCellResize) {
           $input.attr("checked", "checked");
         }
       }
@@ -150,10 +151,10 @@
       // We create a new `columns` structure by leaving currently-hidden
       // columns in their original ordinal position and interleaving the results
       // of the current column sort.
-      var current = grid.getColumns().slice(0);
+      var current = _grid.getColumns().slice(0);
       var ordered = new Array(columns.length);
       for (var i = 0; i < ordered.length; i++) {
-        if ( grid.getColumnIndex(columns[i].id) === undefined ) {
+        if ( _grid.getColumnIndex(columns[i].id) === undefined ) {
           // If the column doesn't return a value from getColumnIndex,
           // it is hidden. Leave it in this position.
           ordered[i] = columns[i];
@@ -168,19 +169,19 @@
     function updateColumn(e) {
       if ($(e.target).data("option") == "autoresize") {
         if (e.target.checked) {
-          grid.setOptions({forceFitColumns:true});
-          grid.autosizeColumns();
+          _grid.setOptions({forceFitColumns:true});
+          _grid.autosizeColumns();
         } else {
-          grid.setOptions({forceFitColumns:false});
+          _grid.setOptions({forceFitColumns:false});
         }
         return;
       }
 
       if ($(e.target).data("option") == "syncresize") {
         if (e.target.checked) {
-          grid.setOptions({syncColumnCellResize:true});
+          _grid.setOptions({syncColumnCellResize:true});
         } else {
-          grid.setOptions({syncColumnCellResize:false});
+          _grid.setOptions({syncColumnCellResize:false});
         }
         return;
       }
@@ -198,8 +199,8 @@
           return;
         }
 
-        grid.setColumns(visibleColumns);
-        onColumnsChanged.notify({columns: visibleColumns, grid: grid});
+        _grid.setColumns(visibleColumns);
+        onColumnsChanged.notify({columns: visibleColumns, grid: _grid});
       }
     }
 
@@ -207,9 +208,10 @@
       return columns;
     }
 
-    init();
+    init(_grid);
 
     return {
+      "init": init,
       "getAllColumns": getAllColumns,
       "destroy": destroy,
       "onColumnsChanged": onColumnsChanged


### PR DESCRIPTION
- exposing the init() function helps dealing with i18n translation without losing any Slick.Event attached like onColumnsChanged
- added a global `_grid` object to make it distinct from the local `grid` object used inside the `init(grid)` function. You can refer to the Grid Menu Control for reference.