### PR TITLE
Clean up .npmignore and exclude test/examples from final npm bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
+.DS_Store
 .gitk*
 .idea/*
-.DS_Store
-SlickgridRelease*
 nuget*
+SlickgridRelease*

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
 .DS_Store
+examples
 .gitk*
 .idea/*
 nuget*
 SlickgridRelease*
+tests


### PR DESCRIPTION
First commit cleans up .npmignore to sort the entries and add a missing trailing newline.

Second commit adds `tests` and `examples` to .npmignore so that they're not included in the final bundle published to npm. Saves a couple hundred KB on the final package and anyone that wants to see the tests can always go to the core repo.