### PR TITLE
feat(demo): add demo for testing grid.autosizeColumns fn, ref #264

### DIFF
--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -44,6 +44,7 @@
       <li>Optional title for the columns list (bottom section)</li>
       <li>To dismiss the Grid Menu, user can click on the "x" on top right corner or anywhere outside of the Grid Menu</li>
       <li>Possibility to attach the Grid Menu to an external button (try clicking on the button below).</li>
+      <li>You can also use some events like "onMenuClose()" and to trigger a resize of the columns with "autosizeColumns()" when "forceFitColumns: false"</li>
       <p>
         <button onclick="toggleGridMenu(event)"><img src="../images/drag-handle.png"/> Grid Menu</button>
       </p>
@@ -84,7 +85,7 @@
     showHeaderRow: true,
     headerRowHeight: 30,
     explicitInitialization: true,
-    forceFitColumns: true,
+    forceFitColumns: false,
     alwaysShowVerticalScroll: true, // this is necessary when using Grid Menu with a small dataset
     
     // gridMenu Object is optional
@@ -240,6 +241,7 @@
     // subscribe to event when menu is closing
     gridMenuControl.onMenuClose.subscribe(function(e, args) {
       console.log('Menu is closing');
+      grid.autosizeColumns();
     });
 
   })


### PR DESCRIPTION
@6pac 
as per your comment, here's a demo of the "autosizeColumns" in action. The biggest reason I use it instead of the "forceFitColumns" (which has to be `false` for the `autosizeColumns` to work) is that it won't affect the minimum width of a cell, meaning that it can expand but it won't shrink as much the other cells (like the `forceFitColumns` does which is more aggressive per say). 

I modified the Grid Menu example to disable `forceFitColumns: false` and instead use `grid.autosizeColumns()` when the menu closes with `onMenuClose` event. The result is shown below

I didn't put the following code in the PR, but if we add the following, it also works (let me know if you want that piece of code to be included as well in the PR).
```javascript
grid.onAutosizeColumns.subscribe(function(e, args) {
   console.log('onAutosize called')
});
```

Also worth to know, I have updated my lib to your latest version `2.3.21` and it works fine, the other PRs I had in the queue are also working as expected. So I don't see any new bugs. Thanks again for the quick turnaround 

![2018-07-25_22-35-30](https://user-images.githubusercontent.com/643976/43238231-55aae8e6-905b-11e8-83e5-1786678bb260.gif)
