### PR TITLE
feat(checkbox): add way to show Checkbox Selector in Filter Row

### DIFF
--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" crossorigin="anonymous">
   <style>
     .slick-headerrow-column {
-      background: #87ceeb;
+      background: #87b6c9;
       text-overflow: clip;
       -moz-box-sizing: border-box;
       box-sizing: border-box;
@@ -39,7 +39,7 @@
       content: "\f00c";
       font-size: 13px;
     }
-    #myGrid input[type=checkbox] + label:before { opacity: 0.1; } /* unchecked icon */
+    #myGrid input[type=checkbox] + label:before { opacity: 0.2; } /* unchecked icon */
     #myGrid input[type=checkbox]:checked + label:before { opacity: 1; } /* checked icon */
   </style>
 </head>
@@ -92,16 +92,16 @@
   };
   var columns = [];
   var columnFilters = {};
-  var checkboxSelector3;
-  var isSelectAllCheckbox3Hidden = false;
+  var checkboxSelector;
+  var isSelectAllCheckboxHidden = false;
 
-  checkboxSelector3 = new Slick.CheckboxSelectColumn({
+  checkboxSelector = new Slick.CheckboxSelectColumn({
     cssClass: "slick-cell-checkboxsel",
     showInColumnTitleRow: false,
     showInFilterHeaderRow: true
   });
 
-  columns.push(checkboxSelector3.getColumnDefinition());
+  columns.push(checkboxSelector.getColumnDefinition());
 
   for (var i = 0; i < 10; i++) {
     columns.push({
@@ -125,8 +125,8 @@
   }
 
   function toggleHideSelectAllCheckbox() {
-    isSelectAllCheckbox3Hidden = !isSelectAllCheckbox3Hidden;
-    checkboxSelector3.setOptions({ hideSelectAllCheckbox: isSelectAllCheckbox3Hidden });
+    isSelectAllCheckboxHidden = !isSelectAllCheckboxHidden;
+    checkboxSelector.setOptions({ hideSelectAllCheckbox: isSelectAllCheckboxHidden });
   }
 
   $(function () {
@@ -138,12 +138,10 @@
       }
     }
 
-    
-
     dataView = new Slick.Data.DataView();
     grid = new Slick.Grid("#myGrid", dataView, columns, options);
     grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
-    grid.registerPlugin(checkboxSelector3);
+    grid.registerPlugin(checkboxSelector);
 
     var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
 

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -58,6 +58,9 @@
       <p>
         <button onclick="toggleHideSelectAllCheckbox()">Toggle show/hide "Select All" checkbox</button>
       </p>
+      <p>
+        <button onclick="toggleWhichRowToShowSelectAll()">Toggle which row to show "Select All" checkbox</button>
+      </p>
     </ul>
       <h2>View Source:</h2>
       <ul>
@@ -94,11 +97,12 @@
   var columnFilters = {};
   var checkboxSelector;
   var isSelectAllCheckboxHidden = false;
+  var isSelectAllShownAsColumnTitle = false;
 
   checkboxSelector = new Slick.CheckboxSelectColumn({
     cssClass: "slick-cell-checkboxsel",
-    showInColumnTitleRow: false,
-    showInFilterHeaderRow: true
+    showInColumnTitleRow: isSelectAllShownAsColumnTitle,
+    showInFilterHeaderRow: !isSelectAllShownAsColumnTitle
   });
 
   columns.push(checkboxSelector.getColumnDefinition());
@@ -127,6 +131,14 @@
   function toggleHideSelectAllCheckbox() {
     isSelectAllCheckboxHidden = !isSelectAllCheckboxHidden;
     checkboxSelector.setOptions({ hideSelectAllCheckbox: isSelectAllCheckboxHidden });
+  }
+
+  function toggleWhichRowToShowSelectAll() {
+    isSelectAllShownAsColumnTitle = !isSelectAllShownAsColumnTitle;
+    checkboxSelector.setOptions({ 
+      showInColumnTitleRow: isSelectAllShownAsColumnTitle,
+      showInFilterHeaderRow: !isSelectAllShownAsColumnTitle,
+    });
   }
 
   $(function () {

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -1,0 +1,170 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
+  <link rel="stylesheet" href="../css/smoothness/jquery-ui-1.11.3.custom.css" type="text/css"/>
+  <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
+  <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <style>
+    .slick-headerrow-column {
+      background: #87ceeb;
+      text-overflow: clip;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+    }
+
+    .slick-headerrow-column input {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+    }
+  </style>
+</head>
+<body>
+<div style="position:relative">
+  <div style="width:600px;">
+    <div id="myGrid" style="width:100%;height:500px;"></div>
+  </div>
+
+  <div class="options-panel">
+    <h2>Demonstrates:</h2>
+    <ul>
+      <li>Using a fixed header row to implement column-level filters with Checkbox Selector</li>
+      <li>Type numbers in textboxes to filter grid data</li>
+      <li>Checkbox row select column</li>
+      <p>
+        <button onclick="toggleHideSelectAllCheckbox()">Toggle show/hide "Select All" checkbox</button>
+      </p>
+    </ul>
+      <h2>View Source:</h2>
+      <ul>
+          <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-header-row.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+      </ul>
+  </div>
+</div>
+
+<script src="../lib/firebugx.js"></script>
+
+<script src="../lib/jquery-1.11.2.min.js"></script>
+<script src="../lib/jquery-ui-1.11.3.min.js"></script>
+<script src="../lib/jquery.event.drag-2.3.0.js"></script>
+
+<script src="../plugins/slick.checkboxselectcolumn.js"></script>
+<script src="../plugins/slick.rowselectionmodel.js"></script>
+<script src="../controls/slick.columnpicker.js"></script>
+
+<script src="../slick.core.js"></script>
+<script src="../slick.dataview.js"></script>
+<script src="../slick.grid.js"></script>
+
+<script>
+  var dataView;
+  var grid;
+  var data = [];
+  var options = {
+    enableCellNavigation: true,
+    showHeaderRow: true,
+    headerRowHeight: 30,
+    explicitInitialization: true
+  };
+  var columns = [];
+  var columnFilters = {};
+  var checkboxSelector3;
+  var isSelectAllCheckbox3Hidden = false;
+
+  checkboxSelector3 = new Slick.CheckboxSelectColumn({
+    cssClass: "slick-cell-checkboxsel",
+    showInColumnTitleRow: false,
+    showInFilterHeaderRow: true
+  });
+
+  columns.push(checkboxSelector3.getColumnDefinition());
+
+  for (var i = 0; i < 10; i++) {
+    columns.push({
+      id: i,
+      name: String.fromCharCode("A".charCodeAt(0) + i),
+      field: i,
+      width: 60
+    });
+  }
+
+  function filter(item) {
+    for (var columnId in columnFilters) {
+      if (columnId !== undefined && columnFilters[columnId] !== "") {
+        var c = grid.getColumns()[grid.getColumnIndex(columnId)];
+        if (item[c.field] != columnFilters[columnId]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  function toggleHideSelectAllCheckbox() {
+    isSelectAllCheckbox3Hidden = !isSelectAllCheckbox3Hidden;
+    checkboxSelector3.setOptions({ hideSelectAllCheckbox: isSelectAllCheckbox3Hidden });
+  }
+
+  $(function () {
+    for (var i = 0; i < 100; i++) {
+      var d = (data[i] = {});
+      d["id"] = i;
+      for (var j = 0; j < columns.length; j++) {
+        d[j] = Math.round(Math.random() * 10);
+      }
+    }
+
+    
+
+    dataView = new Slick.Data.DataView();
+    grid = new Slick.Grid("#myGrid", dataView, columns, options);
+    grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
+    grid.registerPlugin(checkboxSelector3);
+
+    var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
+
+
+    dataView.onRowCountChanged.subscribe(function (e, args) {
+      grid.updateRowCount();
+      grid.render();
+    });
+
+    dataView.onRowsChanged.subscribe(function (e, args) {
+      grid.invalidateRows(args.rows);
+      grid.render();
+    });
+
+
+    $(grid.getHeaderRow()).on("change keyup", ":input", function (e) {
+      var columnId = $(this).data("columnId");
+      if (columnId != null) {
+        columnFilters[columnId] = $.trim($(this).val());
+        dataView.refresh();
+      }
+    });
+
+    grid.onHeaderRowCellRendered.subscribe(function(e, args) {
+      if (args.column.field !== "sel") {
+        $(args.node).empty();
+        $("<input type='text'>")
+           .data("columnId", args.column.id)
+           .val(columnFilters[args.column.id])
+           .appendTo(args.node);
+      }
+    });
+
+    grid.init();
+
+    dataView.beginUpdate();
+    dataView.setItems(data);
+    dataView.setFilter(filter);
+    dataView.endUpdate();
+  })
+</script>
+</body>
+</html>

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="../css/smoothness/jquery-ui-1.11.3.custom.css" type="text/css"/>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" crossorigin="anonymous">
   <style>
     .slick-headerrow-column {
       background: #87ceeb;
@@ -22,6 +23,24 @@
       -moz-box-sizing: border-box;
       box-sizing: border-box;
     }
+    
+    .slick-cell-checkboxsel {
+      background: #f0f0f0;
+      border-right-color: silver;
+      border-right-style: solid;
+    }
+
+    #myGrid input[type=checkbox] { display:none; } /* to hide the checkbox itself */
+    #myGrid input[type=checkbox] + label:before {
+      font-family: FontAwesome;
+      color: rgb(143, 14, 106);
+      font-weight: bold;
+      display: inline-block;
+      content: "\f00c";
+      font-size: 13px;
+    }
+    #myGrid input[type=checkbox] + label:before { opacity: 0.1; } /* unchecked icon */
+    #myGrid input[type=checkbox]:checked + label:before { opacity: 1; } /* checked icon */
   </style>
 </head>
 <body>

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -32,6 +32,7 @@
 
     #myGrid input[type=checkbox] { display:none; } /* to hide the checkbox itself */
     #myGrid input[type=checkbox] + label:before {
+      cursor: pointer;
       font-family: FontAwesome;
       color: rgb(143, 14, 106);
       font-weight: bold;
@@ -101,8 +102,8 @@
 
   checkboxSelector = new Slick.CheckboxSelectColumn({
     cssClass: "slick-cell-checkboxsel",
-    showInColumnTitleRow: isSelectAllShownAsColumnTitle,
-    showInFilterHeaderRow: !isSelectAllShownAsColumnTitle
+    hideInColumnTitleRow: !isSelectAllShownAsColumnTitle,
+    hideInFilterHeaderRow: isSelectAllShownAsColumnTitle
   });
 
   columns.push(checkboxSelector.getColumnDefinition());
@@ -136,8 +137,8 @@
   function toggleWhichRowToShowSelectAll() {
     isSelectAllShownAsColumnTitle = !isSelectAllShownAsColumnTitle;
     checkboxSelector.setOptions({ 
-      showInColumnTitleRow: isSelectAllShownAsColumnTitle,
-      showInFilterHeaderRow: !isSelectAllShownAsColumnTitle,
+      hideInColumnTitleRow: !isSelectAllShownAsColumnTitle,
+      hideInFilterHeaderRow: isSelectAllShownAsColumnTitle,
     });
   }
 

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -42,7 +42,7 @@
     </ul>
       <h2>View Source:</h2>
       <ul>
-          <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-header-row.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+          <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-checkbox-header-row.html" target="_sourcewindow"> View the source for this example on Github</a></li>
       </ul>
   </div>
 </div>

--- a/examples/example-checkbox-row-select.html
+++ b/examples/example-checkbox-row-select.html
@@ -29,6 +29,7 @@
 
     #myGrid2 input[type=checkbox] { display:none; } /* to hide the checkbox itself */
     #myGrid2 input[type=checkbox] + label:before {
+      cursor: pointer;
       font-family: FontAwesome;
       color: rgb(143, 14, 106);
       font-weight: bold;

--- a/examples/example-checkbox-row-select.html
+++ b/examples/example-checkbox-row-select.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../css/smoothness/jquery-ui-1.11.3.custom.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
-  <link rel="stylesheet" href="https://opensource.keycdn.com/fontawesome/4.7.0/font-awesome.min.css" integrity="sha384-dNpIIXE8U05kAbPhy3G1cz+yZmTzA6CY8Vg/u2L9xRnHjJiAK76m2BIEaSEV+/aU" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" crossorigin="anonymous">
   <style>
     .slick-cell-checkboxsel {
       background: #f0f0f0;

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -52,8 +52,8 @@
       _options = $.extend(true, {}, _options, options);
       
       if (_options.hideSelectAllCheckbox) {
-        _grid.updateColumnHeader(_options.columnId, "", "");
-        $("#filter-checkbox-selectall-container").hide();
+        hideSelectAllFromColumnHeaderTitleRow();
+        hideSelectAllFromColumnHeaderFilterRow();
       } else {
         if (_options.showInColumnTitleRow) {
           if (_isSelectAllChecked) {
@@ -61,13 +61,26 @@
           } else {
             _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + _selectAll_UID + "' type='checkbox'><label for='header-selector" + _selectAll_UID + "'></label>", _options.toolTip);
           }
+        } else {
+          hideSelectAllFromColumnHeaderTitleRow();
         }
+
         if (_options.showInFilterHeaderRow) {
           $("#filter-checkbox-selectall-container").show();
           var selectAllElm = $("#header-filter-selector");
           selectAllElm.prop("checked", _isSelectAllChecked);
+        } else {
+          hideSelectAllFromColumnHeaderFilterRow();
         }
       } 
+    }
+
+    function hideSelectAllFromColumnHeaderTitleRow() {
+      _grid.updateColumnHeader(_options.columnId, "", "");
+    }
+
+    function hideSelectAllFromColumnHeaderFilterRow() {
+      $("#filter-checkbox-selectall-container").hide();
     }
 
     function handleSelectedRowsChanged(e, args) {

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -9,7 +9,7 @@
 
   function CheckboxSelectColumn(options) {
     var _grid;
-    var _self = this;
+    var _selectAll_UID = createUID();
     var _handler = new Slick.EventHandler();
     var _selectedRowsLookup = {};
     var _defaults = {
@@ -17,7 +17,9 @@
       cssClass: null,
       hideSelectAllCheckbox: false,
       toolTip: "Select/Deselect All",
-      width: 30
+      width: 30,
+      showInColumnTitleRow: true,
+      showInFilterHeaderRow: false
     };
     var _isSelectAllChecked = false;
 
@@ -26,36 +28,48 @@
     function init(grid) {
       _grid = grid;
       _handler
-        .subscribe(_grid.onSelectedRowsChanged, handleSelectedRowsChanged)
-        .subscribe(_grid.onClick, handleClick)
-        .subscribe(_grid.onHeaderClick, handleHeaderClick)
-        .subscribe(_grid.onKeyDown, handleKeyDown);
+      .subscribe(_grid.onSelectedRowsChanged, handleSelectedRowsChanged)
+      .subscribe(_grid.onClick, handleClick)
+      .subscribe(_grid.onKeyDown, handleKeyDown);
+      
+      if (_options.showInFilterHeaderRow) {
+        addCheckboxToFilterHeaderRow(grid);
+      }
+      if (_options.showInColumnTitleRow) {
+        _handler.subscribe(_grid.onHeaderClick, handleHeaderClick)
+      }
     }
 
     function destroy() {
       _handler.unsubscribeAll();
     }
 
-    function getOptions(options) {
+    function getOptions() {
       return _options;
     }
 
     function setOptions(options) {
       _options = $.extend(true, {}, _options, options);
+      
       if (_options.hideSelectAllCheckbox) {
         _grid.updateColumnHeader(_options.columnId, "", "");
+        $("#header-filter-selector" + _selectAll_UID).hide();
       } else {
-        var UID = createUID();
-        if (_isSelectAllChecked) {
-          _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox' checked='checked'><label for='header-selector" + UID + "'></label>", _options.toolTip);
-        } else {
-          _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox'><label for='header-selector" + UID + "'></label>", _options.toolTip);
+        if (_options.showInColumnTitleRow) {
+          if (_isSelectAllChecked) {
+            _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + _selectAll_UID + "' type='checkbox' checked='checked'><label for='header-selector" + _selectAll_UID + "'></label>", _options.toolTip);
+          } else {
+            _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + _selectAll_UID + "' type='checkbox'><label for='header-selector" + _selectAll_UID + "'></label>", _options.toolTip);
+          }
         }
-      }
+        if (_options.showInFilterHeaderRow) {
+          var selectAllElm = $("#header-filter-selector" + _selectAll_UID).show();
+          selectAllElm.prop("checked", _isSelectAllChecked);
+        }
+      } 
     }
 
     function handleSelectedRowsChanged(e, args) {
-      var UID = createUID();
       var selectedRows = _grid.getSelectedRows();
       var lookup = {}, row, i;
       for (i = 0; i < selectedRows.length; i++) {
@@ -73,12 +87,16 @@
       _grid.render();
       _isSelectAllChecked = selectedRows.length && selectedRows.length == _grid.getDataLength();
 
-      if (!_options.hideSelectAllCheckbox) {
+      if (_options.showInColumnTitleRow && !_options.hideSelectAllCheckbox) {
         if (_isSelectAllChecked) {
-          _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox' checked='checked'><label for='header-selector" + UID + "'></label>", _options.toolTip);
+          _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + _selectAll_UID + "' type='checkbox' checked='checked'><label for='header-selector" + _selectAll_UID + "'></label>", _options.toolTip);
         } else {
-          _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + UID + "' type='checkbox'><label for='header-selector" + UID + "'></label>", _options.toolTip);
+          _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + _selectAll_UID + "' type='checkbox'><label for='header-selector" + _selectAll_UID + "'></label>", _options.toolTip);
         }
+      } 
+      if (_options.showInFilterHeaderRow) {
+        var selectAllElm = $("#header-filter-selector" + _selectAll_UID);
+        selectAllElm.prop("checked", _isSelectAllChecked);
       }
     }
 
@@ -184,11 +202,9 @@
     }
 
     function getColumnDefinition() {
-      var UID = createUID();
-
       return {
         id: _options.columnId,
-        name: _options.hideSelectAllCheckbox ? "" : "<input id='header-selector" + UID + "' type='checkbox'><label for='header-selector" + UID + "'></label>",
+        name: (_options.hideSelectAllCheckbox || !_options.showInColumnTitleRow) ? "" : "<input id='header-selector" + _selectAll_UID + "' type='checkbox'><label for='header-selector" + _selectAll_UID + "'></label>",
         toolTip: _options.toolTip,
         field: "sel",
         width: _options.width,
@@ -198,6 +214,19 @@
         hideSelectAllCheckbox: _options.hideSelectAllCheckbox,
         formatter: checkboxSelectionFormatter
       };
+    }
+
+    function addCheckboxToFilterHeaderRow(grid) {
+      grid.onHeaderRowCellRendered.subscribe(function(e, args) {
+        if (args.column.field === "sel") {
+          $(args.node).empty();
+          $("<input id='header-filter-selector" + _selectAll_UID + "' type='checkbox'><label for='header-selector" + _selectAll_UID + "'></label>")
+            .appendTo(args.node)
+            .on('click', function(evnt) { 
+              handleHeaderClick(evnt, args) 
+            });
+        }
+      });
     }
 
     function createUID() {

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -18,8 +18,8 @@
       hideSelectAllCheckbox: false,
       toolTip: "Select/Deselect All",
       width: 30,
-      showInColumnTitleRow: true,
-      showInFilterHeaderRow: false
+      hideInColumnTitleRow: false,
+      hideInFilterHeaderRow: true
     };
     var _isSelectAllChecked = false;
 
@@ -32,10 +32,10 @@
       .subscribe(_grid.onClick, handleClick)
       .subscribe(_grid.onKeyDown, handleKeyDown);
       
-      if (_options.showInFilterHeaderRow) {
+      if (!_options.hideInFilterHeaderRow) {
         addCheckboxToFilterHeaderRow(grid);
       }
-      if (_options.showInColumnTitleRow) {
+      if (!_options.hideInColumnTitleRow) {
         _handler.subscribe(_grid.onHeaderClick, handleHeaderClick)
       }
     }
@@ -55,7 +55,7 @@
         hideSelectAllFromColumnHeaderTitleRow();
         hideSelectAllFromColumnHeaderFilterRow();
       } else {
-        if (_options.showInColumnTitleRow) {
+        if (!_options.hideInColumnTitleRow) {
           if (_isSelectAllChecked) {
             _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + _selectAll_UID + "' type='checkbox' checked='checked'><label for='header-selector" + _selectAll_UID + "'></label>", _options.toolTip);
           } else {
@@ -66,7 +66,7 @@
           hideSelectAllFromColumnHeaderTitleRow();
         }
 
-        if (_options.showInFilterHeaderRow) {
+        if (!_options.hideInFilterHeaderRow) {
           var selectAllContainer = $("#filter-checkbox-selectall-container");
           selectAllContainer.show();
           selectAllContainer.find('input[type="checkbox"]').prop("checked", _isSelectAllChecked);
@@ -102,14 +102,14 @@
       _grid.render();
       _isSelectAllChecked = selectedRows.length && selectedRows.length == _grid.getDataLength();
 
-      if (_options.showInColumnTitleRow && !_options.hideSelectAllCheckbox) {
+      if (!_options.hideInColumnTitleRow && !_options.hideSelectAllCheckbox) {
         if (_isSelectAllChecked) {
           _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + _selectAll_UID + "' type='checkbox' checked='checked'><label for='header-selector" + _selectAll_UID + "'></label>", _options.toolTip);
         } else {
           _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + _selectAll_UID + "' type='checkbox'><label for='header-selector" + _selectAll_UID + "'></label>", _options.toolTip);
         }
       } 
-      if (_options.showInFilterHeaderRow) {
+      if (!_options.hideInFilterHeaderRow) {
         var selectAllElm = $("#header-filter-selector" + _selectAll_UID);
         selectAllElm.prop("checked", _isSelectAllChecked);
       }
@@ -219,7 +219,7 @@
     function getColumnDefinition() {
       return {
         id: _options.columnId,
-        name: (_options.hideSelectAllCheckbox || !_options.showInColumnTitleRow) ? "" : "<input id='header-selector" + _selectAll_UID + "' type='checkbox'><label for='header-selector" + _selectAll_UID + "'></label>",
+        name: (_options.hideSelectAllCheckbox || _options.hideInColumnTitleRow) ? "" : "<input id='header-selector" + _selectAll_UID + "' type='checkbox'><label for='header-selector" + _selectAll_UID + "'></label>",
         toolTip: _options.toolTip,
         field: "sel",
         width: _options.width,

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -220,7 +220,7 @@
       grid.onHeaderRowCellRendered.subscribe(function(e, args) {
         if (args.column.field === "sel") {
           $(args.node).empty();
-          $("<input id='header-filter-selector" + _selectAll_UID + "' type='checkbox'><label for='header-selector" + _selectAll_UID + "'></label>")
+          $("<input id='header-filter-selector" + _selectAll_UID + "' type='checkbox'><label for='header-filter-selector" + _selectAll_UID + "'></label>")
             .appendTo(args.node)
             .on('click', function(evnt) { 
               handleHeaderClick(evnt, args) 

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -61,6 +61,7 @@
           } else {
             _grid.updateColumnHeader(_options.columnId, "<input id='header-selector" + _selectAll_UID + "' type='checkbox'><label for='header-selector" + _selectAll_UID + "'></label>", _options.toolTip);
           }
+          _handler.subscribe(_grid.onHeaderClick, handleHeaderClick);
         } else {
           hideSelectAllFromColumnHeaderTitleRow();
         }

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -53,7 +53,7 @@
       
       if (_options.hideSelectAllCheckbox) {
         _grid.updateColumnHeader(_options.columnId, "", "");
-        $("#header-filter-selector" + _selectAll_UID).hide();
+        $("#filter-checkbox-selectall-container").hide();
       } else {
         if (_options.showInColumnTitleRow) {
           if (_isSelectAllChecked) {
@@ -63,7 +63,8 @@
           }
         }
         if (_options.showInFilterHeaderRow) {
-          var selectAllElm = $("#header-filter-selector" + _selectAll_UID).show();
+          $("#filter-checkbox-selectall-container").show();
+          var selectAllElm = $("#header-filter-selector");
           selectAllElm.prop("checked", _isSelectAllChecked);
         }
       } 
@@ -220,7 +221,7 @@
       grid.onHeaderRowCellRendered.subscribe(function(e, args) {
         if (args.column.field === "sel") {
           $(args.node).empty();
-          $("<input id='header-filter-selector" + _selectAll_UID + "' type='checkbox'><label for='header-filter-selector" + _selectAll_UID + "'></label>")
+          $("<span id='filter-checkbox-selectall-container'><input id='header-filter-selector" + _selectAll_UID + "' type='checkbox'><label for='header-filter-selector" + _selectAll_UID + "'></label></span>")
             .appendTo(args.node)
             .on('click', function(evnt) { 
               handleHeaderClick(evnt, args) 

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -66,9 +66,9 @@
         }
 
         if (_options.showInFilterHeaderRow) {
-          $("#filter-checkbox-selectall-container").show();
-          var selectAllElm = $("#header-filter-selector");
-          selectAllElm.prop("checked", _isSelectAllChecked);
+          var selectAllContainer = $("#filter-checkbox-selectall-container");
+          selectAllContainer.show();
+          selectAllContainer.find('input[type="checkbox"]').prop("checked", _isSelectAllChecked);
         } else {
           hideSelectAllFromColumnHeaderFilterRow();
         }


### PR DESCRIPTION
This PR was created to address a small styling issue I have seen. Our app has some grids with Column Header Titles with up to 3 rows (or even 4 rows) of text because the text is too long. The fact that the Checkbox Selector (select all) shows up in these Column Titles and top aligned is not always pretty. Since all of our grids have the Column Filters (header row) enabled, this PR provide a way to display the Checkbox Selector in that Filter Row.

- add a way to show the Checkbox Selector (select all) inside the Header Row (aka Filter row) via a new flag boolean ~`showInFilterHeaderRow` false~ `hideInFilterHeaderRow` true by defaults
- keep previous behavior of showing Checkbox Select in the Column Header Title Row, via a new flag ~`showInColumnTitleRow`, true~ `hideInColumnTitleRow`, false by default
- both flags can be used (and tested) together, but most often used separately
- update previous Font-Awesome CDN to a new link since previous was no longer working

#### Tests
- does not affect previous grids with checkbox selector (default behavior is to always show in Column Header Title Row).
- tested both new flags independently
- tested both new flags together (will show in both Title + Filters Rows), both selector are working the same
- tested with/without Font-Awesome icons
- tested toggle of hide Select All
- tested toggle of which row to show the Select All button ( as title or filter)

#### Notes
Ready to be merged, unless you have better names for the 2 new flags which are ~(`showInColumnTitleRow` and `showInFilterHeaderRow`)~
  - to be consistent with all other `hideX` flags, I've renamed the 2 new flags to 
     - `hideInColumnTitleRow`: false by default
     - `hideInFilterHeaderRow`: true by default

See demo below

Show in new Filter Row (header row)
![2018-09-11_12-50-11](https://user-images.githubusercontent.com/643976/45374824-42de9880-b5c1-11e8-8ee1-2e233d10ffcf.gif)

or Show in both rows at same time (a bit awkward but possible)

![2018-09-11_12-33-18](https://user-images.githubusercontent.com/643976/45374062-05790b80-b5bf-11e8-9818-8d57abfd9665.gif)
