### PR TITLE
WIP - feat(RowDetail): add 2x new subscribe methods & fixed multiple issues

### DIFF
--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -14,13 +14,27 @@
     .preload {
       font-size: 18px;
     }
-	
-	.dynamic-cell-detail > :first-child
-    {
-    vertical-align:     middle;
-    line-height:        13px;
-	padding:            10px;
-	margin-left:		20px;
+
+	  .dynamic-cell-detail > :first-child {
+      vertical-align:     middle;
+      line-height:        13px;
+      padding:            10px;
+      margin-left:		20px;
+    }
+    .slick-headerrow-column {
+      background: #87ceeb;
+      text-overflow: clip;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+    }
+
+    .slick-headerrow-column input {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
     }
   </style>
 </head>
@@ -68,22 +82,24 @@
   <script src="../lib/jquery.event.drag-2.3.0.js"></script>
 
   <script src="../slick.core.js"></script>
-  <script src="../plugins/slick.rowdetailview.js"></script>
   <script src="../slick.formatters.js"></script>
+  <script src="../plugins/slick.rowdetailview.js"></script>
   <script src="../plugins/slick.rowselectionmodel.js"></script>
   <script src="../slick.grid.js"></script>
   <script src="../slick.dataview.js"></script>
 
   <script>
     var dataView;
+    var detailView;
     var grid;
     var data = [];
+    var columnFilters = {};
     var sortcol = "title";
     var sortdir = 1;
 
     var fakeNames = ['John Doe', 'Jane Doe', 'Chuck Norris', 'Bumblebee', 'Jackie Chan', 'Elvis Presley', 'Bob Marley', 'Mohammed Ali', 'Bruce Lee', 'Rocky Balboa'];
 
-    var columns = [      
+    var columns = [
       {id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 40, resizable: false, selectable: false },
       {id: "title", name: "Title", field: "title", width: 110, minWidth: 110, cssClass: "cell-title", sortable: true},
       {id: "duration", name: "Duration", field: "duration", sortable: true},
@@ -96,19 +112,31 @@
       editable: false,
       enableAddRow: false,
       enableCellNavigation: true,
-      enableColumnReorder: true
+      enableColumnReorder: true,
+      explicitInitialization: true,
+      headerRowHeight: 30,
+      showHeaderRow: true,
     };
-    var detailView;
 
     function DataItem(i) {
+      this.id = i;
       this.num = i;
-      this.id = "id_" + i;
       this.percentComplete = Math.round(Math.random() * 100);
       this.effortDriven = (i % 5 == 0);
       this.start = "01/01/2009";
       this.finish = "01/05/2009";
       this.title = "Task " + i;
       this.duration = "5 days";
+    }
+
+    function hookAssigneeOnClick(itemId) {
+      $("#who-is-assignee_" + itemId).off("click").on("click", function() {
+        alert("Assignee is " + $("#assignee_" + itemId).val());
+      });
+    }
+
+    function destroyAssigneeOnClick(itemId) {
+      $("#who-is-assignee_" + itemId).off("click");
     }
 
     function loadingTemplate() {
@@ -119,7 +147,9 @@
       return [
         '<div>',
         '<h4>' + itemDetail.title + '</h4>',
-        '<div class="detail"><label>Assignee:</label> <span>' + itemDetail.assignee + '</span></div>',
+        '<div class="detail">',
+        '<label>Assignee:</label> <input id="assignee_' + itemDetail.id + '" type="text" value="' + itemDetail.assignee + '"/>',
+        '<span style="float: right">Find out who is the Assignee <button id="who-is-assignee_' + itemDetail.id + '">Click Me</button></span></div>',
         '<div class="detail"><label>Reporter:</label> <span>' + itemDetail.reporter + '</span></div>',
         '<div class="detail"><label>Duration:</label> <span>' + itemDetail.duration + '</span></div>',
         '<div class="detail"><label>% Complete:</label> <span>' + itemDetail.percentComplete + '</span></div>',
@@ -130,39 +160,63 @@
         '</div>'
       ].join('');
     }
-    
+
+    function filter(item) {
+      for (var columnId in columnFilters) {
+        if (columnId !== undefined && columnFilters[columnId] !== "") {
+          var column = grid.getColumns()[grid.getColumnIndex(columnId)];
+
+          // IMPORTANT with Row Detail View plugin
+          // if the row is a padding row, we just get the value we're filtering on from it's parent
+          if (item._isPadding && item._parent) {
+            item = item._parent;
+          }
+
+          if (item[column.field] !== undefined) {
+            var filterResult = typeof item[column.field].indexOf === 'function'
+              ? (item[column.field].indexOf(columnFilters[columnId] && columnFilters[columnId]) === -1)
+              : (item[column.field] != columnFilters[columnId]);
+
+            if (filterResult) {
+              return false;
+            }
+          }
+        }
+      }
+      return true;
+    }
+
+    // fill the template with a delay to simulate a server call
     function simulateServerCall(item) {
-      // fill the template on delay
       setTimeout(function() {
-      
         // let's add some property to our item for a better simulation
-        var itemDetail = item;		
-        itemDetail.assignee = fakeNames[randomNumber(0, 10)];
-        itemDetail.reporter = fakeNames[randomNumber(0, 10)];
+        var itemDetail = item;
+        itemDetail.assignee = fakeNames[randomNumber(0, 9)];
+        itemDetail.reporter = fakeNames[randomNumber(0, 9)];
 
         if(itemDetail.num % 5 == 0) {
           notifyNonTemplatedView(itemDetail)
         } else {
           notifyTemplate(itemDetail)
         }
-      }, 1000);      
+      }, 1000);
     }
-    
+
+    // notify the onAsyncResponse with the "args.item" (required property)
+    // the plugin will then use itemDetail to populate the detail panel with "postTemplate"
     function notifyTemplate(itemDetail) {
-      // notify the onAsyncResponse with the "args.itemDetail" (required property)
-      // the plugin will then use itemDetail to populate the detail panel with "postTemplate"
       detailView.onAsyncResponse.notify({
-        "itemDetail": itemDetail		
+        "item": itemDetail
       }, undefined, this);
     }
-    
-    function notifyNonTemplatedView(itemDetail) {
-      // notify the onAsyncResponse with the "args.itemDetail" (required property)
-      // the plugin will then use itemDetail to populate the detail panel with "postTemplate"
-      detailView.onAsyncResponse.notify({
-        "itemDetail": itemDetail,	
 
-        // detailView Ignores any template and use whats passed though instead
+    // notify the onAsyncResponse with the "args.item" (required property)
+    // the plugin will then use itemDetail to populate the detail panel with "postTemplate"
+    function notifyNonTemplatedView(itemDetail) {
+      detailView.onAsyncResponse.notify({
+        "item": itemDetail,
+
+        // detailView Ignores any template and use what's passed through instead
         "detailView": "<div><h4>Direct view inserting without template</h4><span>This is not using the template</span></div>"
       }, undefined, this);
     }
@@ -170,16 +224,10 @@
     function randomNumber(min, max) {
       return Math.floor(Math.random() * (max - min + 1) + min);
     }
-    
-    function percentCompleteSort(a, b) {
-      return a["percentComplete"] - b["percentComplete"];
-    }
+
     function comparer(a, b) {
       var x = a[sortcol], y = b[sortcol];
       return (x == y ? 0 : (x > y ? 1 : -1));
-    }
-    function toggleFilterRow() {
-      grid.setTopPanelVisibility(!grid.getOptions().showTopPanel);
     }
 
     $(function () {
@@ -187,7 +235,7 @@
       for (var i = 0; i < 5000; i++) {
         data[i] = new DataItem(i);
       }
-      dataView = new Slick.Data.DataView({ inlineFilters: true });
+      dataView = new Slick.Data.DataView();
 
       // create the row detail plugin
       detailView = new Slick.Plugins.RowDetailView({
@@ -199,15 +247,15 @@
 
         // how many grid rows do we want to use for the detail panel
         // also note that the detail view adds an extra 1 row for padding purposes
-        // so if you choose 4 panelRows, the display will in fact use 5 rows
-        panelRows: 4 
+        // example, if you choosed 4 panelRows, the display will in fact use 5 rows
+        panelRows: 4
       });
 
       // push the plugin as the first column
       columns.unshift(detailView.getColumnDefinition());
 
       grid = new Slick.Grid("#myGrid", dataView, columns, options);
-      
+
       // register the column
       grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
       grid.registerPlugin(detailView);
@@ -217,9 +265,24 @@
       });
       detailView.onAfterRowDetailToggle.subscribe(function(e, args) {
         console.log('after toggling row detail', args.item);
+        if (args.item._collapsed) {
+          destroyAssigneeOnClick(args.item.id);
+        } else {
+
+        }
       });
       detailView.onAsyncEndUpdate.subscribe(function(e, args) {
-        console.log('finished updating the post async template', args.itemDetail);
+        console.log('finished updating the post async template', args);
+        hookAssigneeOnClick(args.item.id);
+      });
+
+      // the following subscribers can be useful to Save/Re-Render a View
+      // when it goes out of visible or back to visible range
+      detailView.onRowOutOfVisibleRange.subscribe((e, args) => {
+        destroyAssigneeOnClick(args.item.id);
+      });
+      detailView.onRowBackToVisibleRange.subscribe((e, args) => {
+        hookAssigneeOnClick(args.item.id);
       });
 
       grid.onSort.subscribe(function (e, args) {
@@ -228,12 +291,30 @@
 
         // using native sort with comparer
         // preferred method but can be very slow in IE with huge datasets
-        dataView.sort(comparer, args.sortAsc);        
+        dataView.sort(comparer, args.sortAsc);
       });
-      
+
+      $(grid.getHeaderRow()).on("change keyup", ":input", function (e) {
+        var columnId = $(this).data("columnId");
+        if (columnId != null) {
+          columnFilters[columnId] = $.trim($(this).val());
+          dataView.refresh();
+        }
+      });
+
+      grid.onHeaderRowCellRendered.subscribe(function(e, args) {
+        $(args.node).empty();
+        $("<input type='text'>")
+            .data("columnId", args.column.id)
+            .val(columnFilters[args.column.id])
+            .appendTo(args.node);
+      });
+
       // initialize the model after all the events have been hooked up
+      grid.init();
       dataView.beginUpdate();
       dataView.setItems(data);
+      dataView.setFilter(filter);
       dataView.endUpdate();
     });
   </script>

--- a/plugins/slick.rowdetailview.css
+++ b/plugins/slick.rowdetailview.css
@@ -1,23 +1,21 @@
-.detailView-toggle
-{
+.detailView-toggle {
     display:          inline-block;
     cursor:            pointer;
 }
-.detailView-toggle.expand
-{
+
+.detailView-toggle.expand {
     height:           20px;
     width:            20px;
     background: url(../images/arrow-right.gif) no-repeat center center;
 }
 
-.detailView-toggle.collapse
-{
+.detailView-toggle.collapse {
     height:           20px;
     width:            20px;
     background: url(../images/sort-desc.gif) no-repeat center center;
 }
-.dynamic-cell-detail
-{
+
+.dynamic-cell-detail {
     z-index:            10000;
     position:           absolute;
     background-color:   #dae5e8;
@@ -26,9 +24,8 @@
     width:              100%;
     overflow:           auto;
 }
- 
-.dynamic-cell-detail > :first-child
-{
+
+.dynamic-cell-detail > :first-child {
     vertical-align:     middle;
     line-height:        13px;
 }

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -18,8 +18,8 @@
  *    panelRows:              Row count to use for the template panel
  *    useRowClick:            Boolean flag, when True will open the row detail on a row click (from any column), default to False
  *    keyPrefix:              Defaults to '_', prefix used for all the plugin metadata added to the item object (meta e.g.: padding, collapsed, parent)
- *    onScrollSaveDetailView: Defaults to true, which will save the row detail view in a cache when it detects that it will become out of the viewport buffer
- *    onSortCollapseAll:      Defaults to true, which will collapse all row detail views when user calls a sort. Unless user implements a sort to deal with padding
+ *    collapseAllOnSort:      Defaults to true, which will collapse all row detail views when user calls a sort. Unless user implements a sort to deal with padding
+ *    saveDetailViewOnScroll: Defaults to true, which will save the row detail view in a cache when it detects that it will become out of the viewport buffer
  *
  * AVAILABLE PUBLIC OPTIONS:
  *    init:                 initiliaze the plugin
@@ -88,8 +88,8 @@
       cssClass: "detailView-toggle",
       keyPrefix: "_",
       loadOnce: false,
-      onScrollSaveDetailView: true,
-      onSortCollapseAll: true,
+      collapseAllOnSort: true,
+      saveDetailViewOnScroll: true,
       toolTip: "",
       width: 30
     };
@@ -114,7 +114,7 @@
         .subscribe(_grid.onScroll, handleScroll);
 
       // Sort will, by default, Collapse all of the open items (unless user implements his own onSort which deals with open row and padding)
-      if (_options.onSortCollapseAll) {
+      if (_options.collapseAllOnSort) {
         _handler.subscribe(_grid.onSort, collapseAll);
         _expandedRows = [];
         _outOfVisibleRangeRows = [];
@@ -202,7 +202,7 @@
     // If we scroll save detail views that go out of cache range
     function handleScroll(e, args) {
       calculateOutOfRangeViews();
-      if (_options.onScrollSaveDetailView) {
+      if (_options.saveDetailViewOnScroll) {
         // handleOnScrollSaveDetailView();
       }
     }
@@ -227,7 +227,7 @@
             notifyOutOfVisibility(row, rowIndex);
 
             // save the view when asked
-            if (_options.onScrollSaveDetailView) {
+            if (_options.saveDetailViewOnScroll) {
               saveDetailView(row);
             }
           }

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -3,50 +3,69 @@
  * Original StackOverflow question & article making this possible (thanks to violet313)
  * https://stackoverflow.com/questions/10535164/can-slickgrids-row-height-be-dynamically-altered#29399927
  * http://violet313.org/slickgrids/#intro
- * 
+ *
  *
  * USAGE:
  *
  * Add the slick.rowDetailView.(js|css) files and register the plugin with the grid.
  *
  * AVAILABLE ROW DETAIL OPTIONS:
- *    cssClass:         A CSS class to be added to the row detail
- *    loadOnce:         Booleang flag, when True will load the data once and then reuse it.
- *    preTemplate:      Template that will be used before the async process (typically used to show a spinner/loading)
- *    postTemplate:     Template that will be loaded once the async function finishes
- *    process:          Async server function call
- *    panelRows:        Row count to use for the template panel
- *    useRowClick:      Boolean flag, when True will open the row detail on a row click (from any column), default to False
- * 
+ *    cssClass:               A CSS class to be added to the row detail
+ *    loadOnce:               Defaults to false, when set to True it will load the data once and then reuse it.
+ *    preTemplate:            Template that will be used before the async process (typically used to show a spinner/loading)
+ *    postTemplate:           Template that will be loaded once the async function finishes
+ *    process:                Async server function call
+ *    panelRows:              Row count to use for the template panel
+ *    useRowClick:            Boolean flag, when True will open the row detail on a row click (from any column), default to False
+ *    keyPrefix:              Defaults to '_', prefix used for all the plugin metadata added to the item object (meta e.g.: padding, collapsed, parent)
+ *    onScrollSaveDetailView: Defaults to true, which will save the row detail view in a cache when it detects that it will become out of the viewport buffer
+ *    onSortCollapseAll:      Defaults to true, which will collapse all row detail views when user calls a sort. Unless user implements a sort to deal with padding
+ *
  * AVAILABLE PUBLIC OPTIONS:
  *    init:                 initiliaze the plugin
  *    destroy:              destroy the plugin and it's events
  *    collapseAll:          collapse all opened row detail panel
- *    getColumnDefinition:  get the column definitions 
+ *    getColumnDefinition:  get the column definitions
  *    getOptions:           get current plugin options
  *    setOptions:           set or change some of the plugin options
- * 
+ *
  * THE PLUGIN EXPOSES THE FOLLOWING SLICK EVENTS:
- *    onAsyncResponse:  This event must be used with the "notify" by the end user once the Asynchronous Server call returns the item detail 
- *       Event args:
- *          itemDetail: Item detail returned from the async server call
- *          detailView:  An explicit view to use instead of template (Optional)
+ *    onAsyncResponse:  This event must be used with the "notify" by the end user once the Asynchronous Server call returns the item detail
+ *      Event args:
+ *        item:         Item detail returned from the async server call
+ *        detailView:   An explicit view to use instead of template (Optional)
  *
  *    onAsyncEndUpdate: Fired when the async response finished
- *       Event args:
- *         grid:        Reference to the grid.
- *         itemDetail:  Column definition.
- * 
- *    onBeforeRowDetailToggle: Fired before the row detail gets toggled
- *       Event args:
- *         grid:        Reference to the grid.
- *         item:  Column definition.
- * 
- *    onAfterRowDetailToggle: Fired after the row detail gets toggled
- *       Event args:
- *         grid:        Reference to the grid.
- *         item:  Column definition.
+ *      Event args:
+ *        grid:         Reference to the grid.
+ *        item:         Item data context
  *
+ *    onBeforeRowDetailToggle: Fired before the row detail gets toggled
+ *      Event args:
+ *        grid:         Reference to the grid.
+ *        item:         Item data context
+ *
+ *    onAfterRowDetailToggle: Fired after the row detail gets toggled
+ *      Event args:
+ *        grid:         Reference to the grid.
+ *        item:         Item data context
+ *        expandedRows: Array of the Expanded Rows
+ *
+ *    onRowOutOfVisibleRange: Fired after a row becomes out of visible range (user can't see the row anymore)
+ *      Event args:
+ *        grid:         Reference to the grid.
+ *        item:         Item data context
+ *        rowIndex:     Index of the Row in the Grid
+ *        expandedRows: Array of the Expanded Rows
+ *        outOfVisibleRangeRows: Array of the Out of Visible Range Rows
+ *
+ *    onRowBackToVisibleRange: Fired after the row detail gets toggled
+ *      Event args:
+ *        grid:         Reference to the grid.
+ *        item:         Item data context
+ *        rowIndex:     Index of the Row in the Grid
+ *        expandedRows: Array of the Expanded Rows
+ *        outOfVisibleRangeRows: Array of the Out of Visible Range Rows
  */
 (function ($) {
   // register namespace
@@ -58,38 +77,64 @@
     }
   });
 
-
   function RowDetailView(options) {
     var _grid;
+    var _gridOptions;
     var _self = this;
     var _expandedRows = [];
     var _handler = new Slick.EventHandler();
     var _defaults = {
       columnId: "_detail_selector",
-      cssClass: null,
+      cssClass: "detailView-toggle",
+      keyPrefix: "_",
+      loadOnce: false,
+      onScrollSaveDetailView: true,
+      onSortCollapseAll: true,
       toolTip: "",
       width: 30
     };
-
+    var _keyPrefix = _defaults.keyPrefix;
+    var _gridRowBuffer = 0;
+    var _outOfVisibleRangeRows = [];
+    var _visibleRenderedCellCount = 0;
     var _options = $.extend(true, {}, _defaults, options);
 
     function init(grid) {
       _grid = grid;
+      _gridOptions = grid.getOptions() || {};
       _dataView = _grid.getData();
+      _keyPrefix = _options && _options.keyPrefix || "_";
 
       // Update the minRowBuffer so that the view doesn't disappear when it's at top of screen + the original default 3
-      _grid.getOptions().minRowBuffer = _options.panelRows + 3;
+      _gridRowBuffer = _gridOptions.minRowBuffer;
+      options.minRowBuffer = _options.panelRows + 3;
 
       _handler
         .subscribe(_grid.onClick, handleClick)
-        .subscribe(_grid.onSort, handleSort)
-		.subscribe(_grid.onScroll, handleScroll);
+        .subscribe(_grid.onScroll, handleScroll);
 
-      _grid.getData().onRowCountChanged.subscribe(function () { _grid.updateRowCount(); _grid.render(); });
-      _grid.getData().onRowsChanged.subscribe(function (e, a) { _grid.invalidateRows(a.rows); _grid.render(); });
+      // Sort will, by default, Collapse all of the open items (unless user implements his own onSort which deals with open row and padding)
+      if (_options.onSortCollapseAll) {
+        _handler.subscribe(_grid.onSort, collapseAll);
+        _expandedRows = [];
+        _outOfVisibleRangeRows = [];
+      }
+
+      _grid.getData().onRowCountChanged.subscribe(function () {
+        _grid.updateRowCount();
+        _grid.render();
+      });
+
+      _grid.getData().onRowsChanged.subscribe(function (e, a) {
+        _grid.invalidateRows(a.rows);
+        _grid.render();
+      });
 
       // subscribe to the onAsyncResponse so that the plugin knows when the user server side calls finished
       subscribeToOnAsyncResponse();
+
+      setTimeout(calculateVisibleRenderedCount, 250);
+      $(window).on("resize", calculateVisibleRenderedCount);
     }
 
     function destroy() {
@@ -98,19 +143,33 @@
       _self.onAsyncEndUpdate.unsubscribe();
       _self.onAfterRowDetailToggle.unsubscribe();
       _self.onBeforeRowDetailToggle.unsubscribe();
+      _self.onRowOutOfVisibleRange.unsubscribe();
+      _self.onRowBackToVisibleRange.unsubscribe();
+      $(window).off('resize');
     }
 
-    function getOptions(options) {
+    function getOptions() {
       return _options;
     }
 
     function setOptions(options) {
       _options = $.extend(true, {}, _options, options);
     }
-  
+
+    function arrayFindIndex(sourceArray, value) {
+      if (sourceArray) {
+        for (var i = 0; i < sourceArray.length; i++) {
+          if (sourceArray[i] === value) {
+            return i;
+          }
+        }
+      }
+      return -1;
+    }
+
     function handleClick(e, args) {
       // clicking on a row select checkbox
-      if (_options.useRowClick || _grid.getColumns()[args.cell].id === _options.columnId && $(e.target).hasClass("detailView-toggle")) {
+      if (_options.useRowClick || _grid.getColumns()[args.cell].id === _options.columnId && $(e.target).hasClass(_options.cssClass)) {
         // if editing, try to commit
         if (_grid.getEditorLock().isActive() && !_grid.getEditorLock().commitCurrentEdit()) {
           e.preventDefault();
@@ -131,7 +190,8 @@
         // trigger an event after toggling
         _self.onAfterRowDetailToggle.notify({
           "grid": _grid,
-          "item": item
+          "item": item,
+          "expandedRows": _expandedRows,
         }, e, _self);
 
         e.stopPropagation();
@@ -139,113 +199,176 @@
       }
     }
 
-    // Sort will just collapse all of the open items
-    function handleSort(e, args) {
-      collapseAll();
-    }
-
-	// If we scroll save detail views that go out of cache range
+    // If we scroll save detail views that go out of cache range
     function handleScroll(e, args) {
-        
-        var range = _grid.getRenderedRange();
-
-        var start = (range.top > 0 ? range.top : 0);
-        var end = (range.bottom > _dataView.getLength() ? range.bottom : _dataView.getLength());
-        
-        // Get the item at the top of the view
-        var topMostItem = _dataView.getItemByIdx(start);
-
-        // Check it is a parent item
-        if (topMostItem && topMostItem._parent == undefined)
-        {
-            // This is a standard row as we have no parent.
-            var nextItem = _dataView.getItemByIdx(start + 1);
-            if(nextItem !== undefined && nextItem._parent !== undefined)
-            {
-                // This is likely the expanded Detail Row View
-                // Check for safety
-                if(nextItem._parent == topMostItem)
-                {
-                    saveDetailView(topMostItem);
-                }
-            }
-        }
-
-        // Find the bottom most item that is likely to go off screen
-        var bottomMostItem = _dataView.getItemByIdx(end - 1);
-
-        // If we are a detailView and we are about to go out of cache view
-        if (bottomMostItem && bottomMostItem._parent !== undefined)
-        {
-            saveDetailView(bottomMostItem._parent);
-            
-        }
+      calculateOutOfRangeViews();
+      if (_options.onScrollSaveDetailView) {
+        // handleOnScrollSaveDetailView();
+      }
     }
-	
+
+    function calculateVisibleRenderedCount() {
+      var renderedRange = _grid.getRenderedRange() || {};
+      _visibleRenderedCellCount = renderedRange.bottom - renderedRange.top - _gridRowBuffer;
+	    return _visibleRenderedCellCount;
+    }
+
+    function calculateOutOfRangeViews() {
+      if (_grid) {
+        var renderedRange = _grid.getRenderedRange();
+
+        _expandedRows.forEach((row) => {
+          var rowIndex = _dataView.getRowById(row.id);
+          var isOutOfVisibility = checkIsRowOutOfVisibleRange(rowIndex, renderedRange);
+
+          if (!isOutOfVisibility && arrayFindIndex(_outOfVisibleRangeRows, rowIndex) >= 0) {
+            notifyBackToVisibleWhenDomExist(row, rowIndex);
+          } else if (isOutOfVisibility) {
+            notifyOutOfVisibility(row, rowIndex);
+
+            // save the view when asked
+            if (_options.onScrollSaveDetailView) {
+              saveDetailView(row);
+            }
+          }
+        });
+      }
+    }
+
+    /** Check if the row became out of visible range (when user can't see it anymore) */
+    function checkIsRowOutOfVisibleRange(rowIndex, renderedRange) {
+  	  if (Math.abs(renderedRange.bottom - _gridRowBuffer - rowIndex) > _visibleRenderedCellCount * 2) {
+        return true;
+      }
+      return false;
+    }
+
+    function notifyOutOfVisibility(item, rowIndex) {
+      _self.onRowOutOfVisibleRange.notify({
+        "grid": _grid,
+        "item": item,
+        "rowIndex": rowIndex,
+        "expandedRows": _expandedRows,
+        "outOfVisibleRangeRows": updateOutOfVisibleArrayWhenNecessary(rowIndex, true)
+      }, null, _self);
+    }
+
+    function notifyBackToVisibleWhenDomExist(item, rowIndex) {
+      var rowIndex = item.rowIndex || _dataView.getRowById(item.id);
+      setTimeout(function() {
+        // make sure View Row DOM Element really exist before notifying that it's a row that is visible again
+        if ($('.cellDetailView_' + item.id).length) {
+          _self.onRowBackToVisibleRange.notify({
+            "grid": _grid,
+            "item": item,
+            "rowIndex": rowIndex,
+            "expandedRows": _expandedRows,
+            "outOfVisibleRangeRows": updateOutOfVisibleArrayWhenNecessary(rowIndex, false)
+          }, null, _self);
+        }
+      }, 100);
+    }
+
+    function updateOutOfVisibleArrayWhenNecessary(rowIndex, isAdding) {
+      var arrayRowIndex = arrayFindIndex(_outOfVisibleRangeRows, rowIndex);
+
+      if (isAdding && arrayRowIndex < 0) {
+        _outOfVisibleRangeRows.push(rowIndex);
+      } else if (!isAdding && arrayRowIndex >= 0) {
+        _outOfVisibleRangeRows.splice(arrayRowIndex, 1);
+      }
+      return _outOfVisibleRangeRows;
+    }
+
+    function handleOnScrollSaveDetailView() {
+      var range = _grid.getRenderedRange();
+      var start = (range.top > 0 ? range.top : 0);
+      var end = (range.bottom > _dataView.getLength() ? range.bottom : _dataView.getLength());
+
+      // Get the item at the top of the view
+      var topMostItem = _dataView.getItemByIdx(start);
+
+      // Check it is a parent item
+      if (topMostItem && topMostItem[_keyPrefix + 'parent'] == undefined) {
+        // This is a standard row as we have no parent.
+        var nextItem = _dataView.getItemByIdx(start + 1);
+        if (nextItem !== undefined && nextItem[_keyPrefix + 'parent'] !== undefined) {
+          // This is likely the expanded Detail Row View
+          // Check for safety
+          if (nextItem[_keyPrefix + 'parent'] == topMostItem) {
+            saveDetailView(topMostItem);
+          }
+        }
+      }
+
+      // Find the bottom most item that is likely to go off screen
+      var bottomMostItem = _dataView.getItemByIdx(end - 1);
+
+      // If we are a detailView and we are about to go out of cache view
+      if (bottomMostItem && bottomMostItem[_keyPrefix + 'parent'] !== undefined) {
+        saveDetailView(bottomMostItem[_keyPrefix + 'parent']);
+      }
+    }
+
     // Toggle between showing and hiding a row
     function toggleRowSelection(row) {
-      _grid.getData().beginUpdate();
+      _dataView.beginUpdate();
       HandleAccordionShowHide(row);
-      _grid.getData().endUpdate();
+      _dataView.endUpdate();
     }
 
     // Collapse all of the open items
     function collapseAll() {
+      _dataView.beginUpdate();
       for (var i = _expandedRows.length - 1; i >= 0; i--) {
-        collapseItem(_expandedRows[i]);
+        collapseItem(_expandedRows[i], true);
       }
+      _dataView.endUpdate();
     }
-	
-    // Saves the current state of the detail view
-    function saveDetailView(item)
-    {
-        var view = $("#innerDetailView_" + item.id);
-        if (view)
-        {
-            var html = $("#innerDetailView_" + item.id).html();
-            if(html !== undefined)
-            {
-                item._detailContent = html;
-            }
-        }   
-    }
-	
-    // Colapse an Item so it is notlonger seen
-    function collapseItem(item) {
-	  
+
+    // Colapse an Item so it is not longer seen
+    function collapseItem(item, multipleCollapse) {
+      if (!multipleCollapse) {
+        _dataView.beginUpdate();
+      }
       // Save the details on the collapse assuming onetime loading
       if (_options.loadOnce) {
-          saveDetailView(item);
+        saveDetailView(item);
       }
-		
-      item._collapsed = true;
-      for (var idx = 1; idx <= item._sizePadding; idx++) {
+
+      item[_keyPrefix + 'collapsed'] = true;
+      for (var idx = 1; idx <= item[_keyPrefix + 'sizePadding']; idx++) {
         _dataView.deleteItem(item.id + "." + idx);
       }
-      item._sizePadding = 0;
+      item[_keyPrefix + 'sizePadding'] = 0;
       _dataView.updateItem(item.id, item);
 
       // Remove the item from the expandedRows
       _expandedRows = _expandedRows.filter(function (r) {
         return r.id !== item.id;
       });
+
+      if (!multipleCollapse) {
+        _dataView.endUpdate();
+      }
     }
 
     // Expand a row given the dataview item that is to be expanded
     function expandItem(item) {
-      item._collapsed = false;
+      item[_keyPrefix + 'collapsed'] = false;
       _expandedRows.push(item);
-      
+
       // In the case something went wrong loading it the first time such a scroll of screen before loaded
-      if (!item._detailContent) item._detailViewLoaded = false;	  
-	   
+      if (!item[_keyPrefix + 'detailContent']) item[_keyPrefix + 'detailViewLoaded'] = false;
+
       // display pre-loading template
-      if (!item._detailViewLoaded || _options.loadOnce !== true) {
-        item._detailContent = _options.preTemplate(item);
+      if (!item[_keyPrefix + 'detailViewLoaded'] || _options.loadOnce !== true) {
+        item[_keyPrefix + 'detailContent'] = _options.preTemplate(item);
       } else {
         _self.onAsyncResponse.notify({
+          "item": item,
           "itemDetail": item,
-          "detailView": item._detailContent
+          "detailView": item[_keyPrefix + 'detailContent']
         }, undefined, this);
         applyTemplateNewLineHeight(item);
         _dataView.updateItem(item.id, item);
@@ -260,39 +383,52 @@
       _options.process(item);
     }
 
+    // Saves the current state of the detail view
+    function saveDetailView(item) {
+      var view = $(".innerDetailView_" + item.id);
+      if (view) {
+        var html = $(".innerDetailView_" + item.id).html();
+        if (html !== undefined) {
+          item[_keyPrefix + 'detailContent'] = html;
+        }
+      }
+    }
+
     /**
      * subscribe to the onAsyncResponse so that the plugin knows when the user server side calls finished
-     * the response has to be as "args.itemDetail" with it's data back
+     * the response has to be as "args.item" (or "args.itemDetail") with it's data back
      */
-    function subscribeToOnAsyncResponse() {      
-      _self.onAsyncResponse.subscribe(function (e, args) {      
-        if (!args || !args.itemDetail) {
-          throw 'Slick.RowDetailView plugin requires the onAsyncResponse() to supply "args.itemDetail" property.'
+    function subscribeToOnAsyncResponse() {
+      _self.onAsyncResponse.subscribe(function (e, args) {
+        if (!args || (!args.item && !args.itemDetail)) {
+          throw 'Slick.RowDetailView plugin requires the onAsyncResponse() to supply "args.item" property.'
         }
+
+        // we accept item/itemDetail, just get the one which has data
+        var itemDetail = args.item || args.itemDetail;
 
         // If we just want to load in a view directly we can use detailView property to do so
         if (args.detailView) {
-          args.itemDetail._detailContent = args.detailView;
+          itemDetail[_keyPrefix + 'detailContent'] = args.detailView;
         } else {
-          args.itemDetail._detailContent = _options.postTemplate(args.itemDetail);
+          itemDetail[_keyPrefix + 'detailContent'] = _options.postTemplate(itemDetail);
         }
 
-        args.itemDetail._detailViewLoaded = true;
-
-        var idxParent = _dataView.getIdxById(args.itemDetail.id);
-        _dataView.updateItem(args.itemDetail.id, args.itemDetail);
+        itemDetail[_keyPrefix + 'detailViewLoaded'] = true;
+        _dataView.updateItem(itemDetail.id, itemDetail);
 
         // trigger an event once the post template is finished loading
         _self.onAsyncEndUpdate.notify({
-            "grid": _grid,
-            "itemDetail": args.itemDetail
+          "grid": _grid,
+          "item": itemDetail,
+          "itemDetail": itemDetail
         }, e, _self);
       });
     }
 
     function HandleAccordionShowHide(item) {
       if (item) {
-        if (!item._collapsed) {
+        if (!item[_keyPrefix + 'collapsed']) {
           collapseItem(item);
         } else {
           expandItem(item);
@@ -310,30 +446,29 @@
       }
       item.id = parent.id + "." + offset;
 
-      //additional hidden padding metadata fields
-      item._collapsed = true;
-      item._isPadding = true;
-      item._parent = parent;
-      item._offset = offset;
+      // additional hidden padding metadata fields
+      item[_keyPrefix + 'collapsed'] = true;
+      item[_keyPrefix + 'isPadding'] = true;
+      item[_keyPrefix + 'parent'] = parent;
+      item[_keyPrefix + 'offset'] = offset;
 
       return item;
     }
 
     //////////////////////////////////////////////////////////////
-    //create the detail ctr node. this belongs to the dev & can be custom-styled as per
+    // create the detail ctr node. this belongs to the dev & can be custom-styled as per
     //////////////////////////////////////////////////////////////
     function applyTemplateNewLineHeight(item) {
-      // the height seems to be calculated by the template row count (how many line of items does the template have)
+      // the height is calculated by the template row count (how many line of items does the template view have)
       var rowCount = _options.panelRows;
 
-      //calculate padding requirements based on detail-content..
-      //ie. worst-case: create an invisible dom node now &find it's height.
-      var lineHeight = 13; //we know cuz we wrote the custom css innit ;)
-      item._sizePadding = Math.ceil(((rowCount * 2) * lineHeight) / _grid.getOptions().rowHeight);
-      item._height = (item._sizePadding * _grid.getOptions().rowHeight);
-
+      // calculate padding requirements based on detail-content..
+      // ie. worst-case: create an invisible dom node now & find it's height.
+      var lineHeight = 13; // we know cuz we wrote the custom css init ;)
+      item[_keyPrefix + 'sizePadding'] = Math.ceil(((rowCount * 2) * lineHeight) / _gridOptions.rowHeight);
+      item[_keyPrefix + 'height'] = (item[_keyPrefix + 'sizePadding'] * _gridOptions.rowHeight);
       var idxParent = _dataView.getIdxById(item.id);
-      for (var idx = 1; idx <= item._sizePadding; idx++) {
+      for (var idx = 1; idx <= item[_keyPrefix + 'sizePadding']; idx++) {
         _dataView.insertItem(idxParent + idx, getPaddingItem(item, idx));
       }
     }
@@ -354,24 +489,22 @@
     }
 
     function detailSelectionFormatter(row, cell, value, columnDef, dataContext) {
-
-      if (dataContext._collapsed == undefined) {
-        dataContext._collapsed = true,
-          dataContext._sizePadding = 0,     //the required number of pading rows
-          dataContext._height = 0,     //the actual height in pixels of the detail field
-          dataContext._isPadding = false,
-          dataContext._parent = undefined,
-          dataContext._offset = 0
+      if (dataContext[_keyPrefix + 'collapsed'] == undefined) {
+        dataContext[_keyPrefix + 'collapsed'] = true,
+        dataContext[_keyPrefix + 'sizePadding'] = 0,     //the required number of pading rows
+        dataContext[_keyPrefix + 'height'] = 0,     //the actual height in pixels of the detail field
+        dataContext[_keyPrefix + 'isPadding'] = false,
+        dataContext[_keyPrefix + 'parent'] = undefined,
+        dataContext[_keyPrefix + 'offset'] = 0
       }
 
-      if (dataContext._isPadding == true) {
+      if (dataContext[_keyPrefix + 'isPadding'] == true) {
         //render nothing
-      } else if (dataContext._collapsed) {
-        return "<div class='detailView-toggle expand'></div>";
+      } else if (dataContext[_keyPrefix + 'collapsed']) {
+        return "<div class='" + _options.cssClass + " expand'></div>";
       } else {
         var html = [];
-        var rowHeight = _grid.getOptions().rowHeight;
-        var bottomMargin = 5;
+        var rowHeight = _gridOptions.rowHeight;
 
         //V313HAX:
         //putting in an extra closing div after the closing toggle div and ommiting a
@@ -382,13 +515,13 @@
         //slick-cell to escape the cell overflow clipping.
 
         //sneaky extra </div> inserted here-----------------v
-        html.push("<div class='detailView-toggle collapse'></div></div>");
+        html.push("<div class='" + _options.cssClass + " collapse'></div></div>");
 
-        html.push("<div id='cellDetailView_", dataContext.id, "' class='dynamic-cell-detail' ");   //apply custom css to detail
-        html.push("style='height:", dataContext._height, "px;"); //set total height of padding
+        html.push("<div class='dynamic-cell-detail cellDetailView_", dataContext.id, "' ");   //apply custom css to detail
+        html.push("style='height:", dataContext[_keyPrefix + 'height'], "px;"); //set total height of padding
         html.push("top:", rowHeight, "px'>");             //shift detail below 1st row
-        html.push("<div id='detailViewContainer_", dataContext.id, "'  class='detail-container' style='max-height:" + (dataContext._height - rowHeight + bottomMargin) + "px'>"); //sub ctr for custom styling
-        html.push("<div id='innerDetailView_" , dataContext.id , "'>" , dataContext._detailContent, "</div></div>"); 
+        html.push("<div class='detail-container detailViewContainer_", dataContext.id, "'>"); //sub ctr for custom styling
+        html.push("<div class='innerDetailView_", dataContext.id, "'>", dataContext[_keyPrefix + 'detailContent'], "</div></div>");
         //&omit a final closing detail container </div> that would come next
 
         return html.join("");
@@ -398,50 +531,50 @@
 
     function resizeDetailView(item) {
       if (!item) return;
-      
-      // Grad each of the dom items
-      var mainContainer = document.getElementById('detailViewContainer_' + item.id);
-      var cellItem = document.getElementById('cellDetailView_' + item.id);
-      var inner = document.getElementById('innerDetailView_' + item.id);
-      
+
+      // Grad each of the DOM elements
+      var mainContainer = document.getElementsByClassName('detailViewContainer_' + item.id);
+      var cellItem = document.getElementsByClassName('cellDetailView_' + item.id);
+      var inner = document.getElementsByClassName('innerDetailView_' + item.id);
+
       if (!mainContainer || !cellItem || !inner) return;
-      
-      for (var idx = 1; idx <= item._sizePadding; idx++) {
-          _dataView.deleteItem(item.id + "." + idx);
+
+      for (var idx = 1; idx <= item[_keyPrefix + 'sizePadding']; idx++) {
+        _dataView.deleteItem(item.id + "." + idx);
       }
-      
-      var rowHeight = _grid.getOptions().rowHeight; // height of a row
-      var lineHeight = 13; //we know cuz we wrote the custom css innit ;)
-      
+
+      var rowHeight = _gridOptions.rowHeight; // height of a row
+      var lineHeight = 13; // we know cuz we wrote the custom css innit ;)
+
       // Get the inner Item height as this will be the actual size
       var itemHeight = inner.clientHeight;
-      
-      // Now work out how many rows 
+
+      // Now work out how many rows
       var rowCount = Math.ceil(itemHeight / rowHeight) + 1;
-      
-      item._sizePadding = Math.ceil(((rowCount * 2) * lineHeight) / rowHeight);
-      item._height = (item._sizePadding * rowHeight);
-	  
-	  // If the padding is now more than the original minRowBuff we need to increase it
-      if (_grid.getOptions().minRowBuffer < item._sizePadding)
-      {
-          // Update the minRowBuffer so that the view doesn't disappear when it's at top of screen + the original default 3
-          _grid.getOptions().minRowBuffer =item._sizePadding + 3;
+
+      item[_keyPrefix + 'sizePadding'] = Math.ceil(((rowCount * 2) * lineHeight) / rowHeight);
+      item[_keyPrefix + 'height'] = (item[_keyPrefix + 'sizePadding'] * rowHeight);
+
+      // If the padding is now more than the original minRowBuff we need to increase it
+      if (_gridOptions.minRowBuffer < item[_keyPrefix + 'sizePadding']) {
+        // Update the minRowBuffer so that the view doesn't disappear when it's at top of screen + the original default 3
+        _gridOptions.minRowBuffer = item[_keyPrefix + 'sizePadding'] + 3;
       }
-      
-      mainContainer.setAttribute("style", "max-height: " + item._height + "px");
-      if (cellItem) cellItem.setAttribute("style", "height: " + item._height + "px;top:" + rowHeight + "px");
-      
+
+      mainContainer.setAttribute("style", "max-height: " + item[_keyPrefix + 'height'] + "px");
+      if (cellItem) cellItem.setAttribute("style", "height: " + item[_keyPrefix + 'height'] + "px;top:" + rowHeight + "px");
+
       var idxParent = _dataView.getIdxById(item.id);
-      for (var idx = 1; idx <= item._sizePadding; idx++) {
-          _dataView.insertItem(idxParent + idx, getPaddingItem(item, idx));
+      for (var idx = 1; idx <= item[_keyPrefix + 'sizePadding']; idx++) {
+        _dataView.insertItem(idxParent + idx, getPaddingItem(item, idx));
       }
     }
-	
+
     $.extend(this, {
       "init": init,
       "destroy": destroy,
       "collapseAll": collapseAll,
+      "collapseItem": collapseItem,
       "getColumnDefinition": getColumnDefinition,
       "getOptions": getOptions,
       "setOptions": setOptions,
@@ -449,7 +582,9 @@
       "onAsyncEndUpdate": new Slick.Event(),
       "onAfterRowDetailToggle": new Slick.Event(),
       "onBeforeRowDetailToggle": new Slick.Event(),
-	  "resizeDetailView": resizeDetailView
+      "onRowOutOfVisibleRange": new Slick.Event(),
+      "onRowBackToVisibleRange": new Slick.Event(),
+      "resizeDetailView": resizeDetailView
     });
   }
 })(jQuery);


### PR DESCRIPTION
**DO NOT MERGE**
This PR will be replaced by another PR that we are currently ironing out in my local repo. 

This PR might also close #252 

- add `onRowOutOfVisibleRange` subscribe
- add `onRowBackToVisibleRange` subscribe
- expose `collapseItem` public
- add new `keyPrefix` property to change the key prefix of all metadata used by the plugin that appears on the item object
- add new `collapseAllOnSort` boolean flag to provide possibility to implement it's own code for on sort
- add new `saveDetailViewOnScroll` boolean flag because saving detail is not used by all frontend frameworks
- use `item` everywhere instead of `itemDetail` in some areas (however make it to work with both so that it doesn't break anyone's code)
- changed all containers to classes instead of ids (e.g. id="detailViewContainer_2" is now class"detailViewContainer_" on the DOM element)
- fixed `cssClass` which was not fully implemented in the code
- add Filter example and padding tweak
- add JS code with dynamic template examples
- fixed some issues found and cleaned up unused code

There's a lot of changes, but I believe that it will be a simple plug & play for most users. The biggest feature is the additions of 2x new subscribe methods to let the user know when the Row Detail View is out or back to visible range. Also a working sample with Filters is a nice addition. 