### PR TITLE
fix setSelectedRows should bypass when editor is active, closes #278

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -155,7 +155,7 @@ if (typeof Slick === "undefined") {
     var headerColumnWidthDiff = 0, headerColumnHeightDiff = 0, // border+padding
         cellWidthDiff = 0, cellHeightDiff = 0, jQueryNewWidthBehaviour = false;
     var absoluteColumnMinWidth;
-    
+
     var tabbingDirection = 1;
     var activePosX;
     var activeRow, activeCell;
@@ -187,9 +187,9 @@ if (typeof Slick === "undefined") {
 
     var pagingActive = false;
     var pagingIsLastPage = false;
-    
+
     var scrollThrottle = ActionThrottle(render, 50);
-    
+
     // async call handles
     var h_editorLoader = null;
     var h_render = null;
@@ -222,10 +222,10 @@ if (typeof Slick === "undefined") {
     // Initialization
 
     function init() {
-      if (container instanceof jQuery) { 
-        $container = container; 
-      } else { 
-        $container = $(container); 
+      if (container instanceof jQuery) {
+        $container = container;
+      } else {
+        $container = $(container);
       }
       if ($container.length < 1) {
         throw new Error("SlickGrid requires a valid container, " + container + " does not exist in the DOM.");
@@ -752,7 +752,7 @@ if (typeof Slick === "undefined") {
 
         if (m.sortable) {
           header.addClass("slick-header-sortable");
-          header.append("<span class='slick-sort-indicator" 
+          header.append("<span class='slick-sort-indicator"
             + (options.numberedMultiColumnSort && !options.sortColNumberInSeparateSpan ? " slick-sort-indicator-numbered" : "" ) + "' />");
           if (options.numberedMultiColumnSort && options.sortColNumberInSeparateSpan) { header.append("<span class='slick-sort-indicator-numbered' />"); }
         }
@@ -796,7 +796,7 @@ if (typeof Slick === "undefined") {
         }
       }
     }
-    
+
     function setupColumnSort() {
       $headers.click(function (e) {
         if (columnResizeDragging) return;
@@ -828,10 +828,10 @@ if (typeof Slick === "undefined") {
             }
           }
           var hadSortCol = !!sortColumn;
-          
+
           if (options.tristateMultiColumnSort) {
-              if (!sortColumn) { 
-                sortColumn = { columnId: column.id, sortAsc: column.defaultSortAsc }; 
+              if (!sortColumn) {
+                sortColumn = { columnId: column.id, sortAsc: column.defaultSortAsc };
               }
               if (hadSortCol && sortColumn.sortAsc) {
                 // three state: remove sort rather than go back to ASC
@@ -839,8 +839,8 @@ if (typeof Slick === "undefined") {
                 sortColumn = null;
               }
               if (!options.multiColumnSort) { sortColumns = []; }
-              if (sortColumn && (!hadSortCol || !options.multiColumnSort)) { 
-                sortColumns.push(sortColumn); 
+              if (sortColumn && (!hadSortCol || !options.multiColumnSort)) {
+                sortColumns.push(sortColumn);
               }
           } else {
               // legacy behaviour
@@ -860,9 +860,9 @@ if (typeof Slick === "undefined") {
                 } else if (sortColumns.length == 0) {
                   sortColumns.push(sortColumn);
                 }
-              }              
+              }
           }
-          
+
           setSortColumns(sortColumns);
 
           if (!options.multiColumnSort) {
@@ -1329,8 +1329,8 @@ if (typeof Slick === "undefined") {
       applyColumnHeaderWidths();
       updateCanvasWidth(true);
 
-      trigger(self.onAutosizeColumns, { "columns": columns});      
-      
+      trigger(self.onAutosizeColumns, { "columns": columns});
+
       if (reRender) {
         invalidateAllRows();
         render();
@@ -1396,10 +1396,10 @@ if (typeof Slick === "undefined") {
             .addClass("slick-header-column-sorted")
               .find(".slick-sort-indicator")
                 .addClass(col.sortAsc ? "slick-sort-indicator-asc" : "slick-sort-indicator-desc");
-          if (numberCols) { 
+          if (numberCols) {
             headerColumnEls.eq(columnIndex)
               .find(".slick-sort-indicator-numbered")
-                .text(i+1); 
+                .text(i+1);
           }
         }
       });
@@ -1741,23 +1741,23 @@ if (typeof Slick === "undefined") {
       }
 
       var value = null, formatterResult = '';
-      if (item) { 
+      if (item) {
         value = getDataItemValueForColumn(item, m);
         formatterResult =  getFormatter(row, m)(row, cell, value, m, item, self);
         if (formatterResult === null || formatterResult === undefined) { formatterResult = ''; }
       }
-      
+
       // get addl css class names from object type formatter return and from string type return of onBeforeAppendCell
       var addlCssClasses = trigger(self.onBeforeAppendCell, { row: row, cell: cell, value: value, dataContext: item }) || '';
       addlCssClasses += (formatterResult && formatterResult.addClasses ? (addlCssClasses ? ' ' : '') + formatterResult.addClasses : '');
-      
+
       stringArray.push("<div class='" + cellCss + (addlCssClasses ? ' ' + addlCssClasses : '') + "'>");
 
       // if there is a corresponding row (if not, this is the Add New row or this data hasn't been loaded yet)
       if (item) {
         stringArray.push(Object.prototype.toString.call(formatterResult)  !== '[object Object]' ? formatterResult : formatterResult.text);
       }
-      
+
       stringArray.push("</div>");
 
       rowsCache[row].cellRenderQueue.push(cell);
@@ -1845,7 +1845,7 @@ if (typeof Slick === "undefined") {
           }
         }
       }
-      
+
       delete rowsCache[row];
       delete postProcessedRows[row];
       renderedRows--;
@@ -1877,16 +1877,16 @@ if (typeof Slick === "undefined") {
 
     function applyFormatResultToCellNode(formatterResult, cellNode, suppressRemove) {
         if (formatterResult === null || formatterResult === undefined) { formatterResult = ''; }
-        if (Object.prototype.toString.call(formatterResult)  !== '[object Object]') { 
+        if (Object.prototype.toString.call(formatterResult)  !== '[object Object]') {
             cellNode.innerHTML = formatterResult;
             return;
         }
         cellNode.innerHTML = formatterResult.text;
-        if (formatterResult.removeClasses && !suppressRemove) { 
-            $(cellNode).removeClass(formatterResult.removeClasses); 
+        if (formatterResult.removeClasses && !suppressRemove) {
+            $(cellNode).removeClass(formatterResult.removeClasses);
         }
-        if (formatterResult.addClasses) { 
-            $(cellNode).addClass(formatterResult.addClasses); 
+        if (formatterResult.addClasses) {
+            $(cellNode).addClass(formatterResult.addClasses);
         }
     }
 
@@ -1915,7 +1915,7 @@ if (typeof Slick === "undefined") {
       ensureCellNodesInRowsCache(row);
 
       var formatterResult, d = getDataItem(row);
-    
+
       for (var columnIdx in cacheEntry.cellNodesByColumnIdx) {
         if (!cacheEntry.cellNodesByColumnIdx.hasOwnProperty(columnIdx)) {
           continue;
@@ -1966,7 +1966,7 @@ if (typeof Slick === "undefined") {
       if (!scrollbarDimensions || !scrollbarDimensions.width) {
         scrollbarDimensions = measureScrollbar();
       }
-      
+
       if (options.forceFitColumns) {
         autosizeColumns();
       }
@@ -2327,9 +2327,9 @@ if (typeof Slick === "undefined") {
 
     function render() {
       if (!initialized) { return; }
-      
+
       scrollThrottle.dequeue();
-      
+
       var visible = getVisibleRange();
       var rendered = getRenderedRange();
 
@@ -2476,8 +2476,8 @@ if (typeof Slick === "undefined") {
         enqueue: enqueue,
         dequeue: dequeue
       }
-    }    
-    
+    }
+
     function asyncPostProcessRows() {
       var dataLength = getDataLength();
       while (postProcessFromRow <= postProcessToRow) {
@@ -2790,7 +2790,7 @@ if (typeof Slick === "undefined") {
       if (e.isImmediatePropagationStopped()) {
         return;
       }
-      
+
       // this optimisation causes trouble - MLeibman #329
       //if ((activeCell != cell.cell || activeRow != cell.row) && canCellBeActive(cell.row, cell.cell)) {
       if (canCellBeActive(cell.row, cell.cell)) {
@@ -3031,7 +3031,7 @@ if (typeof Slick === "undefined") {
       } else {
         activeRow = activeCell = null;
       }
-    
+
       // this optimisation causes trouble - MLeibman #329
       //if (activeCellChanged) {
       if (!suppressActiveCellChangedEvent) { trigger(self.onActiveCellChanged, getActiveCell()); }
@@ -3091,7 +3091,7 @@ if (typeof Slick === "undefined") {
           invalidatePostProcessingResults(activeRow);
         }
       }
-      
+
       // if there previously was text selected on a page (such as selected text in the edit cell just removed),
       // IE can't set focus to anything else correctly
       if (navigator.userAgent.toLowerCase().match(/msie/)) {
@@ -3870,7 +3870,9 @@ if (typeof Slick === "undefined") {
       if (!selectionModel) {
         throw new Error("Selection model is not set");
       }
-      selectionModel.setSelectedRanges(rowsToRanges(rows));
+      if (!grid.getEditorLock().isActive()) {
+        selectionModel.setSelectedRanges(rowsToRanges(rows));
+      }
     }
 
 
@@ -3990,7 +3992,7 @@ if (typeof Slick === "undefined") {
       "getCanvasWidth": getCanvasWidth,
       "focus": setFocus,
       "scrollTo": scrollTo,
-      
+
       "getCellFromPoint": getCellFromPoint,
       "getCellFromEvent": getCellFromEvent,
       "getActiveCell": getActiveCell,


### PR DESCRIPTION
- without this in place, if the user happens to be editing a field and it's field is invalid (via Validator) it will then break all Editors and force user to refresh his browser to get all Editors back. This is quite problematic and can easily be fixed by skipping any row selection if we know that we have an active editor and that fixes it. 

#### Full Test
Tested with the Editor example by adding Row Selector and added a `console.log` to see if it would ever be hit with an else condition. The `setSelectedRanges` was triggered by the `onClick` subscribe (when a user tries to click from 1 cell to another, it will try to select the row). 

Basically the new changes is
```diff
+ if (!grid.getEditorLock().isActive()) {
   selectionModel.setSelectedRanges(rowsToRanges(rows));
+ }
```

and I tested with the following code. 
```diff
+ if (!grid.getEditorLock().isActive()) {
   selectionModel.setSelectedRanges(rowsToRanges(rows));
+ } else {
+    console.log("reaching here means the change works and it won't break the Editors");
+ }
```

Since the Editor grid example required `Title` to be filled, if I erase the title cell then the Validator will kick in and complain that the cell is not valid, if I try to click on a different row (the reason of the BUG itself), then the `onClick` that I hooked up will try to select a different row and will show the `console.log` since the `grid.getEditorLock().isActive()` is active and we should block any trial of `setSelectedRanges`. 
