### PR TITLE
fix setSelectedRows should bypass when editor is active, closes #278

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3870,7 +3870,9 @@ if (typeof Slick === "undefined") {
       if (!selectionModel) {
         throw new Error("Selection model is not set");
       }
-      selectionModel.setSelectedRanges(rowsToRanges(rows));
+      if (!grid.getEditorLock().isActive()) {
+        selectionModel.setSelectedRanges(rowsToRanges(rows));
+      }
     }
 
 


### PR DESCRIPTION
- without this in place, if the user happens to be editing a field and it's field is invalid (via Validator) it will then break all Editors and force user to refresh his browser to get all Editors back. This is quite problematic and can easily be fixed by skipping any row selection if we know that we have an active editor and that fixes it. 

#### Full Test
Tested with the Editor example by adding Row Selector and added a `console.log` to see if it would ever be hit with an else condition. The `setSelectedRanges` was triggered by the `onClick` subscribe (when a user tries to click from 1 cell to another, it will try to select the row). 

Basically the new changes is
```diff
+ if (!grid.getEditorLock().isActive()) {
   selectionModel.setSelectedRanges(rowsToRanges(rows));
+ }
```

and I tested with the following code. 
```diff
+ if (!grid.getEditorLock().isActive()) {
   selectionModel.setSelectedRanges(rowsToRanges(rows));
+ } else {
+    console.log("reaching here means the change works and it won't break the Editors");
+ }
```

Since the Editor grid example required `Title` to be filled, if I erase the title cell then the Validator will kick in and complain that the cell is not valid, if I try to click on a different row (the reason of the BUG itself), then the `onClick` that I hooked up will try to select a different row and will show the `console.log` since the `grid.getEditorLock().isActive()` is active and we should block any trial of `setSelectedRanges`. 
