### PR TITLE
Feature/row detail view

### DIFF
--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -36,17 +36,17 @@
       -moz-box-sizing: border-box;
       box-sizing: border-box;
     }
-	
-	
-	
-	
+
+
+
+
 	/* Style the tab */
 	.tab {
 		overflow: hidden;
 		border: 1px solid #ccc;
 		background-color: #f1f1f1;
 	}
-	
+
 	/* Style the buttons inside the tab */
 	.tab button {
 		background-color: inherit;
@@ -58,24 +58,24 @@
 		transition: 0.3s;
 		font-size: 17px;
 	}
-	
+
 	/* Change background color of buttons on hover */
 	.tab button:hover {
 		background-color: #ddd;
 	}
-	
+
 	/* Create an active/current tablink class */
 	.tab button.active {
 		background-color: #ccc;
 	}
-	
+
 	/* Style the tab content */
 	.tabcontent {
 		display: none;
 		padding: 6px 12px;
 		border: 1px solid #ccc;
 		border-top: none;
-	}	
+	}
   </style>
 </head>
 <body>
@@ -253,8 +253,8 @@
     // notify the onAsyncResponse with the "args.item" (required property)
     // the plugin will then use itemDetail to populate the detail panel with "postTemplate"
     function notifyNonTemplatedView(itemDetail) {
-	
-	var temp = 
+
+	var temp =
 		"<div class=\"tab\">"+
 		"<button class=\"tablinks\" onclick=\"openCity(event, 'London')\">London</button>" +
 		"<button class=\"tablinks\" onclick=\"openCity(event, 'Paris')\">Paris</button>" +
@@ -281,15 +281,15 @@
 				"<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
 				"Done Yay" +
 				"</div>" +
-		"</div>";	
-	
+		"</div>";
+
       detailView.onAsyncResponse.notify({
         "item": itemDetail,
         // detailView Ignores any template and use what's passed through instead
         "detailView": temp,
       }, undefined, this);
     }
-	
+
 	function openCity(evt, cityName) {
     var i, tabcontent, tablinks;
     tabcontent = document.getElementsByClassName("tabcontent");
@@ -302,7 +302,7 @@
     }
     document.getElementById(cityName).style.display = "block";
     evt.currentTarget.className += " active";
-}	
+}
 
     function randomNumber(min, max) {
       return Math.floor(Math.random() * (max - min + 1) + min);
@@ -327,6 +327,7 @@
         postTemplate: loadView,
         process: simulateServerCall,
         useRowClick: true,
+        outOfVisibleDetectEarlierRows: 7, // for an earlier detection (out of visible range)
 
         // how many grid rows do we want to use for the detail panel
         // also note that the detail view adds an extra 1 row for padding purposes

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -304,6 +304,10 @@
       document.getElementById(cityName).style.display = "block";
       evt.currentTarget.className += " active";
 
+      /* You can save the detail view here OR on the filter keyup
+       the reason we save the detail view is to keep the entire content of the view
+       before doing certain action like filtering/sorting/reorderingColumn/...
+      */
       // detailView.saveDetailView(data[rowIdx]);
     }
 
@@ -384,7 +388,12 @@
       $(grid.getHeaderRow()).on("change keyup", ":input", function (e) {
         var columnId = $(this).data("columnId");
         if (columnId != null) {
-          // we can save the detail view content before filtering
+          /* we can save the detail view content before filtering (this will save on every keyup)
+            OR you can save in other area of your code (like in the "openCity()" function)
+            the reason we save the detail view is to keep the entire content of the view
+            before doing certain action like filtering/sorting/reorderingColumn/...
+            it's up to you to decide where and if you need to save the detail view
+          */
           var expandedRows = detailView.getExpandedRows();
           expandedRows.forEach(function (row) {
             detailView.saveDetailView(row);

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -36,6 +36,46 @@
       -moz-box-sizing: border-box;
       box-sizing: border-box;
     }
+	
+	
+	
+	
+	/* Style the tab */
+	.tab {
+		overflow: hidden;
+		border: 1px solid #ccc;
+		background-color: #f1f1f1;
+	}
+	
+	/* Style the buttons inside the tab */
+	.tab button {
+		background-color: inherit;
+		float: left;
+		border: none;
+		outline: none;
+		cursor: pointer;
+		padding: 14px 16px;
+		transition: 0.3s;
+		font-size: 17px;
+	}
+	
+	/* Change background color of buttons on hover */
+	.tab button:hover {
+		background-color: #ddd;
+	}
+	
+	/* Create an active/current tablink class */
+	.tab button.active {
+		background-color: #ccc;
+	}
+	
+	/* Style the tab content */
+	.tabcontent {
+		display: none;
+		padding: 6px 12px;
+		border: 1px solid #ccc;
+		border-top: none;
+	}	
   </style>
 </head>
 <body>
@@ -213,24 +253,56 @@
     // notify the onAsyncResponse with the "args.item" (required property)
     // the plugin will then use itemDetail to populate the detail panel with "postTemplate"
     function notifyNonTemplatedView(itemDetail) {
+	
+	var temp = 
+		"<div class=\"tab\">"+
+		"<button class=\"tablinks\" onclick=\"openCity(event, 'London')\">London</button>" +
+		"<button class=\"tablinks\" onclick=\"openCity(event, 'Paris')\">Paris</button>" +
+		"<button class=\"tablinks\" onclick=\"openCity(event, 'Tokyo')\">Tokyo</button>" +
+		"</div>" +
+
+		"<div id=\"London\" class=\"tabcontent\">" +
+		"<h3>London</h3>" +
+		"<p>London is the capital city of England.</p>" +
+		"</div>" +
+
+		"<div id=\"Paris\" class=\"tabcontent\">" +
+		"<h3>Paris</h3>" +
+		"<p>Paris is the capital of France.</p> " +
+		"</div>" +
+
+		"<div id=\"Tokyo\" class=\"tabcontent\">" +
+			"<div>" +
+				"<h4>Direct view inserting without template</h4>" +
+				"<span>This is not using the template</span><br/>" +
+				"<button onclick=\"detailView.resizeDetailView(data[" + itemDetail.id + "])\">Resize detail view</button>" +
+				"<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
+				"This is to make the loaded area longer" +
+				"<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
+				"Done Yay" +
+				"</div>" +
+		"</div>";	
+	
       detailView.onAsyncResponse.notify({
         "item": itemDetail,
-
         // detailView Ignores any template and use what's passed through instead
-        "detailView": "<div>" +
-					  "<h4>Direct view inserting without template</h4>" +
-					  "<span>This is not using the template</span><br/>" +
-					  "<button onclick=\"detailView.resizeDetailView(data[" + itemDetail.id + "])\">Resize detail view</button>" +
-					  "<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
-					  "This is to make the loaded area longer" +
-					  "<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
-					  "And Loooooonnnnnggggerrr<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
-					  "Nearly there<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
-					  "One more to go<br/><br/><br/><br/>" +
-					  "Done Yay" +
-					  "</div>"
+        "detailView": temp,
       }, undefined, this);
     }
+	
+	function openCity(evt, cityName) {
+    var i, tabcontent, tablinks;
+    tabcontent = document.getElementsByClassName("tabcontent");
+    for (i = 0; i < tabcontent.length; i++) {
+        tabcontent[i].style.display = "none";
+    }
+    tablinks = document.getElementsByClassName("tablinks");
+    for (i = 0; i < tablinks.length; i++) {
+        tablinks[i].className = tablinks[i].className.replace(" active", "");
+    }
+    document.getElementById(cityName).style.display = "block";
+    evt.currentTarget.className += " active";
+}	
 
     function randomNumber(min, max) {
       return Math.floor(Math.random() * (max - min + 1) + min);

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -6,236 +6,158 @@
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="../css/smoothness/jquery-ui-1.11.3.custom.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
-  <link rel="stylesheet" href="../plugins/slick.rowdetailview.css" type="text/css"/>
+  <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" crossorigin="anonymous">
   <style>
-    .detail {
-        padding: 5px
+    .slick-cell-checkboxsel {
+      background: #f0f0f0;
+      border-right-color: silver;
+      border-right-style: solid;
     }
-    .preload {
-      font-size: 18px;
+
+    .slick-group-title[level='0'] {
+      font-weight: bold;
     }
-	
-	.dynamic-cell-detail > :first-child
-    {
-    vertical-align:     middle;
-    line-height:        13px;
-	padding:            10px;
-	margin-left:		20px;
+
+    .slick-group-title[level='1'] {
+      text-decoration: underline;
     }
+
+    .slick-group-title[level='2'] {
+      font-style: italic;
+    }
+
+    #myGrid2 input[type=checkbox] { display:none; } /* to hide the checkbox itself */
+    #myGrid2 input[type=checkbox] + label:before {
+      cursor: pointer;
+      font-family: FontAwesome;
+      color: rgb(143, 14, 106);
+      font-weight: bold;
+      display: inline-block;
+      content: "\f00c";
+      font-size: 13px;
+    }
+    #myGrid2 input[type=checkbox] + label:before { opacity: 0.1; } /* unchecked icon */
+    #myGrid2 input[type=checkbox]:checked + label:before { opacity: 1; } /* checked icon */
   </style>
 </head>
 <body>
-  <div style="position:relative">
-    <td valign="top" width="50%">
-      <div id="myGrid" style="width:600px;height:500px;"></div>
-    </td>
-    <br/>
-
-    <div class="options-panel">
-      <h2>Demonstrates:</h2>
-      <ul>
-        <li>RowDetailView Plugin</li>
-        <li>See more detail of an item by toggling a row detail panel.<li></li>
-        <li>"useRowClick: True" to toggle from any column</li>
-        <li>"useRowClick: False" to toggle from the toggle icon only</li>
-        <li>"panelRows: 4" DetailView is RowHeight * 4</li>
-        <li>"loadOnce: True" Try shrink and reopen same row</li>
-        <li>"loadOnce: False DEFAULT" Will call load every time row is expanded</li>
-        <li>&nbsp;</li>
-        <li>Example of using non templated view e.g. check any row multiple of 5<li>
-      </ul>
-
-      <h2>Options:</h2>
-      <button onclick="detailView.setOptions({ loadOnce: true, useRowClick: detailView.useRowClick })">Load Once ON</button>
-      &nbsp;
-      <button onclick="detailView.setOptions({ loadOnce: false, useRowClick: detailView.useRowClick})">Load Once OFF</button>
-      <p>
-        <button onclick="detailView.setOptions({ loadOnce: detailView.loadOnce, useRowClick: true })">Row Click ON</button>
-        &nbsp;
-        <button onclick="detailView.setOptions({ loadOnce: detailView.loadOnce, useRowClick: false })">Row Click OFF</button>
-        <h2>View Source:</h2>
-        <ul>
-          <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example16-row-detail.html" target="_sourcewindow"> View the source for this example on Github</a></li>
-        </ul>
-      </p>
-    </div>
+<div style="position:relative">
+  <p>Without Font Styling</p>
+  <div style="width:600px;">
+    <div id="myGrid" style="width:100%;height:300px;"></div>
+  </div>
+  <br/>
+  <p>With Font Styling</p>
+  <div style="width:600px;">
+    <div id="myGrid2" style="width:100%;height:300px;" class="example-grid"></div>
   </div>
 
-  <script src="../lib/firebugx.js"></script>
+  <div class="options-panel">
+    <h2>Demonstrates:</h2>
+    <ul>
+      <li>Checkbox row select column</li>
+      <p>
+        <button onclick="toggleHideSelectAllCheckbox()">Toggle show/hide "Select All" checkbox</button>
+      </p>
+    </ul>
+      <h2>View Source:</h2>
+      <ul>
+          <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-checkbox-row-select.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+      </ul>
 
-  <script src="../lib/jquery-1.11.2.min.js"></script>
-  <script src="../lib/jquery-ui-1.11.3.min.js"></script>
-  <script src="../lib/jquery.event.drag-2.3.0.js"></script>
+  </div>
+</div>
 
-  <script src="../slick.core.js"></script>
-  <script src="../plugins/slick.rowdetailview.js"></script>
-  <script src="../slick.formatters.js"></script>
-  <script src="../plugins/slick.rowselectionmodel.js"></script>
-  <script src="../slick.grid.js"></script>
-  <script src="../slick.dataview.js"></script>
+<script src="../lib/firebugx.js"></script>
 
-  <script>
-    var dataView;
-    var grid;
-    var data = [];
-    var sortcol = "title";
-    var sortdir = 1;
+<script src="../lib/jquery-1.11.2.min.js"></script>
+<script src="../lib/jquery-ui-1.11.3.min.js"></script>
+<script src="../lib/jquery.event.drag-2.3.0.js"></script>
 
-    var fakeNames = ['John Doe', 'Jane Doe', 'Chuck Norris', 'Bumblebee', 'Jackie Chan', 'Elvis Presley', 'Bob Marley', 'Mohammed Ali', 'Bruce Lee', 'Rocky Balboa'];
+<script src="../slick.core.js"></script>
+<script src="../plugins/slick.checkboxselectcolumn.js"></script>
+<script src="../plugins/slick.autotooltips.js"></script>
+<script src="../plugins/slick.cellrangedecorator.js"></script>
+<script src="../plugins/slick.cellrangeselector.js"></script>
+<script src="../plugins/slick.cellcopymanager.js"></script>
+<script src="../plugins/slick.cellselectionmodel.js"></script>
+<script src="../plugins/slick.rowselectionmodel.js"></script>
+<script src="../controls/slick.columnpicker.js"></script>
+<script src="../slick.formatters.js"></script>
+<script src="../slick.editors.js"></script>
+<script src="../slick.grid.js"></script>
 
-    var columns = [      
-      {id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 40, resizable: false, selectable: false },
-      {id: "title", name: "Title", field: "title", width: 110, minWidth: 110, cssClass: "cell-title", sortable: true},
-      {id: "duration", name: "Duration", field: "duration", sortable: true},
-      {id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, sortable: true},
-      {id: "start", name: "Start", field: "start", minWidth: 60},
-      {id: "finish", name: "Finish", field: "finish", minWidth: 60},
-      {id: "effort-driven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark}
-    ];
-    var options = {
-      editable: false,
-      enableAddRow: false,
-      enableCellNavigation: true,
-      enableColumnReorder: true
-    };
-    var detailView;
+<script>
+  var grid;
+  var grid2;
+  var data = [];
+  var options = {
+    editable: true,
+    enableCellNavigation: true,
+    asyncEditorLoading: false,
+    autoEdit: false
+  };
+  var checkboxSelector1, checkboxSelector2;
+  var columns = [];
+  var columns2 = [];
+  var isSelectAllCheckbox1Hidden = false;
+  var isSelectAllCheckbox2Hidden = false;
 
-    function DataItem(i) {
-      this.num = i;
-      this.id = "id_" + i;
-      this.percentComplete = Math.round(Math.random() * 100);
-      this.effortDriven = (i % 5 == 0);
-      this.start = "01/01/2009";
-      this.finish = "01/05/2009";
-      this.title = "Task " + i;
-      this.duration = "5 days";
+  function toggleHideSelectAllCheckbox() {
+    isSelectAllCheckbox1Hidden = !isSelectAllCheckbox1Hidden;
+    isSelectAllCheckbox2Hidden = !isSelectAllCheckbox2Hidden;
+    checkboxSelector1.setOptions({ hideSelectAllCheckbox: isSelectAllCheckbox1Hidden });
+    checkboxSelector2.setOptions({ hideSelectAllCheckbox: isSelectAllCheckbox2Hidden });
+  }
+
+  $(function () {
+    for (var i = 0; i < 100; i++) {
+      var d = (data[i] = {});
+      d[0] = "Row " + i;
     }
 
-    function loadingTemplate() {
-      return '<div class="preload">Loading...</div>';
-    }
-
-    function loadView(itemDetail) {
-      return [
-        '<div>',
-        '<h4>' + itemDetail.title + '</h4>',
-        '<div class="detail"><label>Assignee:</label> <span>' + itemDetail.assignee + '</span></div>',
-        '<div class="detail"><label>Reporter:</label> <span>' + itemDetail.reporter + '</span></div>',
-        '<div class="detail"><label>Duration:</label> <span>' + itemDetail.duration + '</span></div>',
-        '<div class="detail"><label>% Complete:</label> <span>' + itemDetail.percentComplete + '</span></div>',
-        '<div class="detail"><label>Start:</label> <span>' + itemDetail.start + '</span></div>',
-        '<div class="detail"><label>Finish:</label> <span>' + itemDetail.finish + '</span></div>',
-        '<div class="detail"><label>Effort Driven:</label> <span>' + itemDetail.effortDriven + '</span></div>',
-        '<div class="detail"><label>Effort Driven:</label> <span>' + itemDetail.effortDriven + '</span></div>',
-        '</div>'
-      ].join('');
-    }
-    
-    function simulateServerCall(item) {
-      // fill the template on delay
-      setTimeout(function() {
-      
-        // let's add some property to our item for a better simulation
-        var itemDetail = item;		
-        itemDetail.assignee = fakeNames[randomNumber(0, 10)];
-        itemDetail.reporter = fakeNames[randomNumber(0, 10)];
-
-        if(itemDetail.num % 5 == 0) {
-          notifyNonTemplatedView(itemDetail)
-        } else {
-          notifyTemplate(itemDetail)
-        }
-      }, 1000);      
-    }
-    
-    function notifyTemplate(itemDetail) {
-      // notify the onAsyncResponse with the "args.itemDetail" (required property)
-      // the plugin will then use itemDetail to populate the detail panel with "postTemplate"
-      detailView.onAsyncResponse.notify({
-        "itemDetail": itemDetail		
-      }, undefined, this);
-    }
-    
-    function notifyNonTemplatedView(itemDetail) {
-      // notify the onAsyncResponse with the "args.itemDetail" (required property)
-      // the plugin will then use itemDetail to populate the detail panel with "postTemplate"
-      detailView.onAsyncResponse.notify({
-        "itemDetail": itemDetail,	
-
-        // detailView Ignores any template and use whats passed though instead
-        "detailView": "<div><h4>Direct view inserting without template</h4><span>This is not using the template</span></div>"
-      }, undefined, this);
-    }
-
-    function randomNumber(min, max) {
-      return Math.floor(Math.random() * (max - min + 1) + min);
-    }
-    
-    function percentCompleteSort(a, b) {
-      return a["percentComplete"] - b["percentComplete"];
-    }
-    function comparer(a, b) {
-      var x = a[sortcol], y = b[sortcol];
-      return (x == y ? 0 : (x > y ? 1 : -1));
-    }
-    function toggleFilterRow() {
-      grid.setTopPanelVisibility(!grid.getOptions().showTopPanel);
-    }
-
-    $(function () {
-      // prepare the data
-      for (var i = 0; i < 5000; i++) {
-        data[i] = new DataItem(i);
-      }
-      dataView = new Slick.Data.DataView({ inlineFilters: true });
-
-      // create the row detail plugin
-      detailView = new Slick.Plugins.RowDetailView({
-        cssClass: "detailView-toggle",
-        preTemplate: loadingTemplate,
-        postTemplate: loadView,
-        process: simulateServerCall,
-        useRowClick: true,
-
-        // how many grid rows do we want to use for the detail panel
-        // also note that the detail view adds an extra 1 row for padding purposes
-        // so if you choose 4 panelRows, the display will in fact use 5 rows
-        panelRows: 4 
-      });
-
-      // push the plugin as the first column
-      columns.unshift(detailView.getColumnDefinition());
-
-      grid = new Slick.Grid("#myGrid", dataView, columns, options);
-      
-      // register the column
-      grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
-      grid.registerPlugin(detailView);
-
-      detailView.onBeforeRowDetailToggle.subscribe(function(e, args) {
-        console.log('before toggling row detail', args.item);
-      });
-      detailView.onAfterRowDetailToggle.subscribe(function(e, args) {
-        console.log('after toggling row detail', args.item);
-      });
-      detailView.onAsyncEndUpdate.subscribe(function(e, args) {
-        console.log('finished updating the post async template', args.itemDetail);
-      });
-
-      grid.onSort.subscribe(function (e, args) {
-        sortdir = args.sortAsc ? 1 : -1;
-        sortcol = args.sortCol.field;
-
-        // using native sort with comparer
-        // preferred method but can be very slow in IE with huge datasets
-        dataView.sort(comparer, args.sortAsc);        
-      });
-      
-      // initialize the model after all the events have been hooked up
-      dataView.beginUpdate();
-      dataView.setItems(data);
-      dataView.endUpdate();
+    checkboxSelector1 = new Slick.CheckboxSelectColumn({
+      cssClass: "slick-cell-checkboxsel"
     });
-  </script>
+    checkboxSelector2 = new Slick.CheckboxSelectColumn({
+      cssClass: "slick-cell-checkboxsel"
+    });
+
+    columns.push(checkboxSelector1.getColumnDefinition());
+    columns2.push(checkboxSelector2.getColumnDefinition());
+
+    for (var i = 0; i < 5; i++) {
+      var item = {
+        id: i,
+        name: String.fromCharCode("A".charCodeAt(0) + i),
+        field: i,
+        width: 100,
+        editor: Slick.Editors.Text
+      };
+      columns.push(item);
+      columns2.push(item);
+    }
+
+    grid = new Slick.Grid("#myGrid", data, columns, options);
+    grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
+    grid.registerPlugin(checkboxSelector1);
+
+    grid2 = new Slick.Grid("#myGrid2", data, columns2, options);
+    grid2.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
+    grid2.registerPlugin(checkboxSelector2);
+
+    var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
+
+    grid.onSelectedRowsChanged.subscribe(function (e, args) {
+        // debugging to see the active row in response to questions
+        // active row has no correlation to the selected rows
+        // it will remain null until a row is clicked and made active
+        // selecting and deselecting rows via checkboxes will not change the active row
+        var rtn = args.grid.getActiveCell();
+        var x = args.rows;
+    });
+  })
+</script>
 </body>
 </html>

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -217,7 +217,18 @@
         "item": itemDetail,
 
         // detailView Ignores any template and use what's passed through instead
-        "detailView": "<div><h4>Direct view inserting without template</h4><span>This is not using the template</span></div>"
+        "detailView": "<div>" + 
+					  "<h4>Direct view inserting without template</h4>" +
+					  "<span>This is not using the template</span><br/>" + 
+					  "<button onclick=\"detailView.resizeDetailView(data[" + itemDetail.id + "])\">Resize detail view</button>" +
+					  "<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" + 
+					  "This is to make the loaded area longer" +
+					  "<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
+					  "And Loooooonnnnnggggerrr<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
+					  "Nearly there<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
+					  "One more to go<br/><br/><br/><br/>" +
+					  "Done Yay" + 
+					  "</div>"
       }, undefined, this);
     }
 

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -37,45 +37,42 @@
       box-sizing: border-box;
     }
 
+    /* Style the tab */
+    .tab {
+      overflow: hidden;
+      border: 1px solid #ccc;
+      background-color: #f1f1f1;
+    }
 
+    /* Style the buttons inside the tab */
+    .tab button {
+      background-color: inherit;
+      float: left;
+      border: none;
+      outline: none;
+      cursor: pointer;
+      padding: 14px 16px;
+      transition: 0.3s;
+      font-size: 17px;
+    }
 
+    /* Change background color of buttons on hover */
+    .tab button:hover {
+      background-color: #ddd;
+    }
 
-	/* Style the tab */
-	.tab {
-		overflow: hidden;
-		border: 1px solid #ccc;
-		background-color: #f1f1f1;
-	}
+    /* Create an active/current tablink class */
+    .tab button.active {
+      background-color: #ccc;
+    }
 
-	/* Style the buttons inside the tab */
-	.tab button {
-		background-color: inherit;
-		float: left;
-		border: none;
-		outline: none;
-		cursor: pointer;
-		padding: 14px 16px;
-		transition: 0.3s;
-		font-size: 17px;
-	}
-
-	/* Change background color of buttons on hover */
-	.tab button:hover {
-		background-color: #ddd;
-	}
-
-	/* Create an active/current tablink class */
-	.tab button.active {
-		background-color: #ccc;
-	}
-
-	/* Style the tab content */
-	.tabcontent {
-		display: none;
-		padding: 6px 12px;
-		border: 1px solid #ccc;
-		border-top: none;
-	}
+    /* Style the tab content */
+    .tabcontent {
+      display: none;
+      padding: 6px 12px;
+      border: 1px solid #ccc;
+      border-top: none;
+    }
   </style>
 </head>
 <body>
@@ -103,23 +100,18 @@
       <button onclick="detailView.setOptions({ loadOnce: true, useRowClick: detailView.useRowClick })">Load Once ON</button>
       &nbsp;
       <button onclick="detailView.setOptions({ loadOnce: false, useRowClick: detailView.useRowClick})">Load Once OFF</button>
-      
-	  <p>
-	  <input type="number" id="panelRowInput"/> <button onclick="setPanelRows()">Set Panel Rows Option</button>
-	  </p>
-	  
-	  <p>
-	  <input type="number" id="maxRowInput"/> <button onclick="setMaxRows()">Set Max Panel Rows Option</button>
-	  </p>
-	  
-	  <p>
+	    <p>
+	      <input type="number" id="panelRowInput"/> <button onclick="setPanelRows()">Set Panel Rows Option</button>
+	    </p>
+      <p>
+        <input type="number" id="maxRowInput"/> <button onclick="setMaxRows()">Set Max Panel Rows Option</button>
+      </p>
+	    <p>
         <button onclick="detailView.setOptions({ loadOnce: detailView.loadOnce, useRowClick: true })">Row Click ON</button>
         &nbsp;
         <button onclick="detailView.setOptions({ loadOnce: detailView.loadOnce, useRowClick: false })">Row Click OFF</button>
-        
-		
-		
-		<h2>View Source:</h2>
+
+        <h2>View Source:</h2>
         <ul>
           <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example16-row-detail.html" target="_sourcewindow"> View the source for this example on Github</a></li>
         </ul>
@@ -181,34 +173,28 @@
       this.duration = "5 days";
     }
 
-	function setMaxRows(amount){
-		var value = $("#maxRowInput").val();		
-		var maxRows = parseInt(value);
-		
-		var options = detailView.getOptions();
-				
-		if(!isNaN(maxRows))
-		{
-			options.maxRows = maxRows;	
-		}
-		
-		detailView.setOptions(options);
-	}
-	
-	function setPanelRows(amount){
-		var value = $("#panelRowInput").val();		
-		var panelRows = parseInt(value);
-		
-		var options = detailView.getOptions();
-				
-		if(!isNaN(panelRows))
-		{
-			options.panelRows = panelRows;	
-		}
-		
-		detailView.setOptions(options);
-	}	
-	
+    function setMaxRows(amount) {
+      var value = $("#maxRowInput").val();
+      var maxRows = parseInt(value);
+      var options = detailView.getOptions();
+
+      if(!isNaN(maxRows)) {
+        options.maxRows = maxRows;
+      }
+      detailView.setOptions(options);
+    }
+
+    function setPanelRows(amount) {
+      var value = $("#panelRowInput").val();
+      var panelRows = parseInt(value);
+      var options = detailView.getOptions();
+
+      if(!isNaN(panelRows)) {
+        options.panelRows = panelRows;
+      }
+      detailView.setOptions(options);
+    }
+
     function hookAssigneeOnClick(itemId) {
       $("#who-is-assignee_" + itemId).off("click").on("click", function() {
         alert("Assignee is " + $("#assignee_" + itemId).val());
@@ -291,36 +277,36 @@
     // notify the onAsyncResponse with the "args.item" (required property)
     // the plugin will then use itemDetail to populate the detail panel with "postTemplate"
     function notifyNonTemplatedView(itemDetail) {
-	var rowIdx = grid.getData().getIdxById(itemDetail.id);
-	var temp =
-		"<div class=\"tab\">"+
-		"<button class=\"tablinks\" onclick=\"openCity(event, 'London'," + rowIdx +")\">London</button>" +
-		"<button class=\"tablinks\" onclick=\"openCity(event, 'Paris'," + rowIdx +")\">Paris</button>" +
-		"<button class=\"tablinks\" onclick=\"openCity(event, 'Tokyo'," + rowIdx +")\">Tokyo</button>" +
-		"</div>" +
+	    var rowIdx = grid.getData().getIdxById(itemDetail.id);
+	    var temp =
+        "<div class=\"tab\">"+
+        "<button class=\"tablinks\" onclick=\"openCity(event, 'London'," + rowIdx +")\">London</button>" +
+        "<button class=\"tablinks\" onclick=\"openCity(event, 'Paris'," + rowIdx +")\">Paris</button>" +
+        "<button class=\"tablinks\" onclick=\"openCity(event, 'Tokyo'," + rowIdx +")\">Tokyo</button>" +
+        "</div>" +
 
-		"<div id=\"London\" class=\"tabcontent\">" +
-		"<h3>London</h3>" +
-		"<p>London is the capital city of England.</p>" +
-		"<button onclick=\"detailView.resizeDetailView(data[" + rowIdx + "])\">Resize detail view</button>" +
-		"</div>" +
+        "<div id=\"London\" class=\"tabcontent\">" +
+        "<h3>London</h3>" +
+        "<p>London is the capital city of England.</p>" +
+        "<button onclick=\"detailView.resizeDetailView(data[" + rowIdx + "])\">Resize detail view</button>" +
+        "</div>" +
 
-		"<div id=\"Paris\" class=\"tabcontent\">" +
-		"<h3>Paris</h3>" +
-		"<p>Paris is the capital of France.</p> " +
-		"</div>" +
+        "<div id=\"Paris\" class=\"tabcontent\">" +
+        "<h3>Paris</h3>" +
+        "<p>Paris is the capital of France.</p> " +
+        "</div>" +
 
-		"<div id=\"Tokyo\" class=\"tabcontent\">" +
-			"<div>" +
-				"<h4>Direct view inserting without template</h4>" +
-				"<span>This is not using the template</span><br/>" +
-				"<button onclick=\"detailView.resizeDetailView(data[" + rowIdx + "])\">Resize detail view</button>" +
-				"<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
-				"This is to make the loaded area longer" +
-				"<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
-				"Done Yay" +
-				"</div>" +
-		"</div>";
+        "<div id=\"Tokyo\" class=\"tabcontent\">" +
+          "<div>" +
+            "<h4>Direct view inserting without template</h4>" +
+            "<span>This is not using the template</span><br/>" +
+            "<button onclick=\"detailView.resizeDetailView(data[" + rowIdx + "])\">Resize detail view</button>" +
+            "<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
+            "This is to make the loaded area longer" +
+            "<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
+            "Done Yay" +
+            "</div>" +
+        "</div>";
 
       detailView.onAsyncResponse.notify({
         "item": itemDetail,
@@ -393,6 +379,7 @@
       detailView.onBeforeRowDetailToggle.subscribe(function(e, args) {
         console.log('before toggling row detail', args.item);
       });
+
       detailView.onAfterRowDetailToggle.subscribe(function(e, args) {
         console.log('after toggling row detail', args.item);
         if (args.item._collapsed) {
@@ -401,6 +388,7 @@
 
         }
       });
+
       detailView.onAsyncEndUpdate.subscribe(function(e, args) {
         console.log('finished updating the post async template', args);
         hookAssigneeOnClick(args.item.id);
@@ -408,10 +396,11 @@
 
       // the following subscribers can be useful to Save/Re-Render a View
       // when it goes out of visible or back to visible range
-      detailView.onRowOutOfVisibleRange.subscribe((e, args) => {
+      detailView.onRowOutOfVisibleRange.subscribe(function(e, args) {
         destroyAssigneeOnClick(args.item.id);
       });
-      detailView.onRowBackToVisibleRange.subscribe((e, args) => {
+
+      detailView.onRowBackToVisibleRange.subscribe(function(e, args) {
         hookAssigneeOnClick(args.item.id);
       });
 

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -6,158 +6,317 @@
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="../css/smoothness/jquery-ui-1.11.3.custom.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
-  <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" crossorigin="anonymous">
+  <link rel="stylesheet" href="../plugins/slick.rowdetailview.css" type="text/css"/>
   <style>
-    .slick-cell-checkboxsel {
-      background: #f0f0f0;
-      border-right-color: silver;
-      border-right-style: solid;
+    .detail {
+        padding: 5px
+    }
+    .preload {
+      font-size: 18px;
     }
 
-    .slick-group-title[level='0'] {
-      font-weight: bold;
+	  .dynamic-cell-detail > :first-child {
+      vertical-align:     middle;
+      line-height:        13px;
+      padding:            10px;
+      margin-left:		20px;
+    }
+    .slick-headerrow-column {
+      background: #87ceeb;
+      text-overflow: clip;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
     }
 
-    .slick-group-title[level='1'] {
-      text-decoration: underline;
+    .slick-headerrow-column input {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
     }
-
-    .slick-group-title[level='2'] {
-      font-style: italic;
-    }
-
-    #myGrid2 input[type=checkbox] { display:none; } /* to hide the checkbox itself */
-    #myGrid2 input[type=checkbox] + label:before {
-      cursor: pointer;
-      font-family: FontAwesome;
-      color: rgb(143, 14, 106);
-      font-weight: bold;
-      display: inline-block;
-      content: "\f00c";
-      font-size: 13px;
-    }
-    #myGrid2 input[type=checkbox] + label:before { opacity: 0.1; } /* unchecked icon */
-    #myGrid2 input[type=checkbox]:checked + label:before { opacity: 1; } /* checked icon */
   </style>
 </head>
 <body>
-<div style="position:relative">
-  <p>Without Font Styling</p>
-  <div style="width:600px;">
-    <div id="myGrid" style="width:100%;height:300px;"></div>
-  </div>
-  <br/>
-  <p>With Font Styling</p>
-  <div style="width:600px;">
-    <div id="myGrid2" style="width:100%;height:300px;" class="example-grid"></div>
-  </div>
+  <div style="position:relative">
+    <td valign="top" width="50%">
+      <div id="myGrid" style="width:600px;height:500px;"></div>
+    </td>
+    <br/>
 
-  <div class="options-panel">
-    <h2>Demonstrates:</h2>
-    <ul>
-      <li>Checkbox row select column</li>
-      <p>
-        <button onclick="toggleHideSelectAllCheckbox()">Toggle show/hide "Select All" checkbox</button>
-      </p>
-    </ul>
-      <h2>View Source:</h2>
+    <div class="options-panel">
+      <h2>Demonstrates:</h2>
       <ul>
-          <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-checkbox-row-select.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+        <li>RowDetailView Plugin</li>
+        <li>See more detail of an item by toggling a row detail panel.<li></li>
+        <li>"useRowClick: True" to toggle from any column</li>
+        <li>"useRowClick: False" to toggle from the toggle icon only</li>
+        <li>"panelRows: 4" DetailView is RowHeight * 4</li>
+        <li>"loadOnce: True" Try shrink and reopen same row</li>
+        <li>"loadOnce: False DEFAULT" Will call load every time row is expanded</li>
+        <li>&nbsp;</li>
+        <li>Example of using non templated view e.g. check any row multiple of 5<li>
       </ul>
 
+      <h2>Options:</h2>
+      <button onclick="detailView.setOptions({ loadOnce: true, useRowClick: detailView.useRowClick })">Load Once ON</button>
+      &nbsp;
+      <button onclick="detailView.setOptions({ loadOnce: false, useRowClick: detailView.useRowClick})">Load Once OFF</button>
+      <p>
+        <button onclick="detailView.setOptions({ loadOnce: detailView.loadOnce, useRowClick: true })">Row Click ON</button>
+        &nbsp;
+        <button onclick="detailView.setOptions({ loadOnce: detailView.loadOnce, useRowClick: false })">Row Click OFF</button>
+        <h2>View Source:</h2>
+        <ul>
+          <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example16-row-detail.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+        </ul>
+      </p>
+    </div>
   </div>
-</div>
 
-<script src="../lib/firebugx.js"></script>
+  <script src="../lib/firebugx.js"></script>
 
-<script src="../lib/jquery-1.11.2.min.js"></script>
-<script src="../lib/jquery-ui-1.11.3.min.js"></script>
-<script src="../lib/jquery.event.drag-2.3.0.js"></script>
+  <script src="../lib/jquery-1.11.2.min.js"></script>
+  <script src="../lib/jquery-ui-1.11.3.min.js"></script>
+  <script src="../lib/jquery.event.drag-2.3.0.js"></script>
 
-<script src="../slick.core.js"></script>
-<script src="../plugins/slick.checkboxselectcolumn.js"></script>
-<script src="../plugins/slick.autotooltips.js"></script>
-<script src="../plugins/slick.cellrangedecorator.js"></script>
-<script src="../plugins/slick.cellrangeselector.js"></script>
-<script src="../plugins/slick.cellcopymanager.js"></script>
-<script src="../plugins/slick.cellselectionmodel.js"></script>
-<script src="../plugins/slick.rowselectionmodel.js"></script>
-<script src="../controls/slick.columnpicker.js"></script>
-<script src="../slick.formatters.js"></script>
-<script src="../slick.editors.js"></script>
-<script src="../slick.grid.js"></script>
+  <script src="../slick.core.js"></script>
+  <script src="../slick.formatters.js"></script>
+  <script src="../plugins/slick.rowdetailview.js"></script>
+  <script src="../plugins/slick.rowselectionmodel.js"></script>
+  <script src="../slick.grid.js"></script>
+  <script src="../slick.dataview.js"></script>
 
-<script>
-  var grid;
-  var grid2;
-  var data = [];
-  var options = {
-    editable: true,
-    enableCellNavigation: true,
-    asyncEditorLoading: false,
-    autoEdit: false
-  };
-  var checkboxSelector1, checkboxSelector2;
-  var columns = [];
-  var columns2 = [];
-  var isSelectAllCheckbox1Hidden = false;
-  var isSelectAllCheckbox2Hidden = false;
+  <script>
+    var dataView;
+    var detailView;
+    var grid;
+    var data = [];
+    var columnFilters = {};
+    var sortcol = "title";
+    var sortdir = 1;
 
-  function toggleHideSelectAllCheckbox() {
-    isSelectAllCheckbox1Hidden = !isSelectAllCheckbox1Hidden;
-    isSelectAllCheckbox2Hidden = !isSelectAllCheckbox2Hidden;
-    checkboxSelector1.setOptions({ hideSelectAllCheckbox: isSelectAllCheckbox1Hidden });
-    checkboxSelector2.setOptions({ hideSelectAllCheckbox: isSelectAllCheckbox2Hidden });
-  }
+    var fakeNames = ['John Doe', 'Jane Doe', 'Chuck Norris', 'Bumblebee', 'Jackie Chan', 'Elvis Presley', 'Bob Marley', 'Mohammed Ali', 'Bruce Lee', 'Rocky Balboa'];
 
-  $(function () {
-    for (var i = 0; i < 100; i++) {
-      var d = (data[i] = {});
-      d[0] = "Row " + i;
+    var columns = [
+      {id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 40, resizable: false, selectable: false },
+      {id: "title", name: "Title", field: "title", width: 110, minWidth: 110, cssClass: "cell-title", sortable: true},
+      {id: "duration", name: "Duration", field: "duration", sortable: true},
+      {id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, sortable: true},
+      {id: "start", name: "Start", field: "start", minWidth: 60},
+      {id: "finish", name: "Finish", field: "finish", minWidth: 60},
+      {id: "effort-driven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark}
+    ];
+    var options = {
+      editable: false,
+      enableAddRow: false,
+      enableCellNavigation: true,
+      enableColumnReorder: true,
+      explicitInitialization: true,
+      headerRowHeight: 30,
+      showHeaderRow: true,
+    };
+
+    function DataItem(i) {
+      this.id = i;
+      this.num = i;
+      this.percentComplete = Math.round(Math.random() * 100);
+      this.effortDriven = (i % 5 == 0);
+      this.start = "01/01/2009";
+      this.finish = "01/05/2009";
+      this.title = "Task " + i;
+      this.duration = "5 days";
     }
 
-    checkboxSelector1 = new Slick.CheckboxSelectColumn({
-      cssClass: "slick-cell-checkboxsel"
-    });
-    checkboxSelector2 = new Slick.CheckboxSelectColumn({
-      cssClass: "slick-cell-checkboxsel"
-    });
-
-    columns.push(checkboxSelector1.getColumnDefinition());
-    columns2.push(checkboxSelector2.getColumnDefinition());
-
-    for (var i = 0; i < 5; i++) {
-      var item = {
-        id: i,
-        name: String.fromCharCode("A".charCodeAt(0) + i),
-        field: i,
-        width: 100,
-        editor: Slick.Editors.Text
-      };
-      columns.push(item);
-      columns2.push(item);
+    function hookAssigneeOnClick(itemId) {
+      $("#who-is-assignee_" + itemId).off("click").on("click", function() {
+        alert("Assignee is " + $("#assignee_" + itemId).val());
+      });
     }
 
-    grid = new Slick.Grid("#myGrid", data, columns, options);
-    grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
-    grid.registerPlugin(checkboxSelector1);
+    function destroyAssigneeOnClick(itemId) {
+      $("#who-is-assignee_" + itemId).off("click");
+    }
 
-    grid2 = new Slick.Grid("#myGrid2", data, columns2, options);
-    grid2.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
-    grid2.registerPlugin(checkboxSelector2);
+    function loadingTemplate() {
+      return '<div class="preload">Loading...</div>';
+    }
 
-    var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
+    function loadView(itemDetail) {
+      return [
+        '<div>',
+        '<h4>' + itemDetail.title + '</h4>',
+        '<div class="detail">',
+        '<label>Assignee:</label> <input id="assignee_' + itemDetail.id + '" type="text" value="' + itemDetail.assignee + '"/>',
+        '<span style="float: right">Find out who is the Assignee <button id="who-is-assignee_' + itemDetail.id + '">Click Me</button></span></div>',
+        '<div class="detail"><label>Reporter:</label> <span>' + itemDetail.reporter + '</span></div>',
+        '<div class="detail"><label>Duration:</label> <span>' + itemDetail.duration + '</span></div>',
+        '<div class="detail"><label>% Complete:</label> <span>' + itemDetail.percentComplete + '</span></div>',
+        '<div class="detail"><label>Start:</label> <span>' + itemDetail.start + '</span></div>',
+        '<div class="detail"><label>Finish:</label> <span>' + itemDetail.finish + '</span></div>',
+        '<div class="detail"><label>Effort Driven:</label> <span>' + itemDetail.effortDriven + '</span></div>',
+        '<div class="detail"><label>Effort Driven:</label> <span>' + itemDetail.effortDriven + '</span></div>',
+        '</div>'
+      ].join('');
+    }
 
-    grid.onSelectedRowsChanged.subscribe(function (e, args) {
-        // debugging to see the active row in response to questions
-        // active row has no correlation to the selected rows
-        // it will remain null until a row is clicked and made active
-        // selecting and deselecting rows via checkboxes will not change the active row
-        var rtn = args.grid.getActiveCell();
-        var x = args.rows;
+    function filter(item) {
+      for (var columnId in columnFilters) {
+        if (columnId !== undefined && columnFilters[columnId] !== "") {
+          var column = grid.getColumns()[grid.getColumnIndex(columnId)];
+
+          // IMPORTANT with Row Detail View plugin
+          // if the row is a padding row, we just get the value we're filtering on from it's parent
+          if (item._isPadding && item._parent) {
+            item = item._parent;
+          }
+
+          if (item[column.field] !== undefined) {
+            var filterResult = typeof item[column.field].indexOf === 'function'
+              ? (item[column.field].indexOf(columnFilters[columnId] && columnFilters[columnId]) === -1)
+              : (item[column.field] != columnFilters[columnId]);
+
+            if (filterResult) {
+              return false;
+            }
+          }
+        }
+      }
+      return true;
+    }
+
+    // fill the template with a delay to simulate a server call
+    function simulateServerCall(item) {
+      setTimeout(function() {
+        // let's add some property to our item for a better simulation
+        var itemDetail = item;
+        itemDetail.assignee = fakeNames[randomNumber(0, 9)];
+        itemDetail.reporter = fakeNames[randomNumber(0, 9)];
+
+        if(itemDetail.num % 5 == 0) {
+          notifyNonTemplatedView(itemDetail)
+        } else {
+          notifyTemplate(itemDetail)
+        }
+      }, 1000);
+    }
+
+    // notify the onAsyncResponse with the "args.item" (required property)
+    // the plugin will then use itemDetail to populate the detail panel with "postTemplate"
+    function notifyTemplate(itemDetail) {
+      detailView.onAsyncResponse.notify({
+        "item": itemDetail
+      }, undefined, this);
+    }
+
+    // notify the onAsyncResponse with the "args.item" (required property)
+    // the plugin will then use itemDetail to populate the detail panel with "postTemplate"
+    function notifyNonTemplatedView(itemDetail) {
+      detailView.onAsyncResponse.notify({
+        "item": itemDetail,
+
+        // detailView Ignores any template and use what's passed through instead
+        "detailView": "<div><h4>Direct view inserting without template</h4><span>This is not using the template</span></div>"
+      }, undefined, this);
+    }
+
+    function randomNumber(min, max) {
+      return Math.floor(Math.random() * (max - min + 1) + min);
+    }
+
+    function comparer(a, b) {
+      var x = a[sortcol], y = b[sortcol];
+      return (x == y ? 0 : (x > y ? 1 : -1));
+    }
+
+    $(function () {
+      // prepare the data
+      for (var i = 0; i < 5000; i++) {
+        data[i] = new DataItem(i);
+      }
+      dataView = new Slick.Data.DataView();
+
+      // create the row detail plugin
+      detailView = new Slick.Plugins.RowDetailView({
+        cssClass: "detailView-toggle",
+        preTemplate: loadingTemplate,
+        postTemplate: loadView,
+        process: simulateServerCall,
+        useRowClick: true,
+
+        // how many grid rows do we want to use for the detail panel
+        // also note that the detail view adds an extra 1 row for padding purposes
+        // example, if you choosed 4 panelRows, the display will in fact use 5 rows
+        panelRows: 4
+      });
+
+      // push the plugin as the first column
+      columns.unshift(detailView.getColumnDefinition());
+
+      grid = new Slick.Grid("#myGrid", dataView, columns, options);
+
+      // register the column
+      grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
+      grid.registerPlugin(detailView);
+
+      detailView.onBeforeRowDetailToggle.subscribe(function(e, args) {
+        console.log('before toggling row detail', args.item);
+      });
+      detailView.onAfterRowDetailToggle.subscribe(function(e, args) {
+        console.log('after toggling row detail', args.item);
+        if (args.item._collapsed) {
+          destroyAssigneeOnClick(args.item.id);
+        } else {
+
+        }
+      });
+      detailView.onAsyncEndUpdate.subscribe(function(e, args) {
+        console.log('finished updating the post async template', args);
+        hookAssigneeOnClick(args.item.id);
+      });
+
+      // the following subscribers can be useful to Save/Re-Render a View
+      // when it goes out of visible or back to visible range
+      detailView.onRowOutOfVisibleRange.subscribe((e, args) => {
+        destroyAssigneeOnClick(args.item.id);
+      });
+      detailView.onRowBackToVisibleRange.subscribe((e, args) => {
+        hookAssigneeOnClick(args.item.id);
+      });
+
+      grid.onSort.subscribe(function (e, args) {
+        sortdir = args.sortAsc ? 1 : -1;
+        sortcol = args.sortCol.field;
+
+        // using native sort with comparer
+        // preferred method but can be very slow in IE with huge datasets
+        dataView.sort(comparer, args.sortAsc);
+      });
+
+      $(grid.getHeaderRow()).on("change keyup", ":input", function (e) {
+        var columnId = $(this).data("columnId");
+        if (columnId != null) {
+          columnFilters[columnId] = $.trim($(this).val());
+          dataView.refresh();
+        }
+      });
+
+      grid.onHeaderRowCellRendered.subscribe(function(e, args) {
+        $(args.node).empty();
+        $("<input type='text'>")
+            .data("columnId", args.column.id)
+            .val(columnFilters[args.column.id])
+            .appendTo(args.node);
+      });
+
+      // initialize the model after all the events have been hooked up
+      grid.init();
+      dataView.beginUpdate();
+      dataView.setItems(data);
+      dataView.setFilter(filter);
+      dataView.endUpdate();
     });
-  })
-</script>
+  </script>
 </body>
 </html>

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -208,9 +208,7 @@
 
           // IMPORTANT with Row Detail View plugin
           // if the row is a padding row, we just get the value we're filtering on from it's parent
-          if (item._isPadding && item._parent) {
-            item = item._parent;
-          }
+          item = detailView.getFilterItem(item);
 
           if (item[column.field] !== undefined) {
             var filterResult = typeof item[column.field].indexOf === 'function'

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -103,11 +103,23 @@
       <button onclick="detailView.setOptions({ loadOnce: true, useRowClick: detailView.useRowClick })">Load Once ON</button>
       &nbsp;
       <button onclick="detailView.setOptions({ loadOnce: false, useRowClick: detailView.useRowClick})">Load Once OFF</button>
-      <p>
+      
+	  <p>
+	  <input type="number" id="panelRowInput"/> <button onclick="setPanelRows()">Set Panel Rows Option</button>
+	  </p>
+	  
+	  <p>
+	  <input type="number" id="maxRowInput"/> <button onclick="setMaxRows()">Set Max Panel Rows Option</button>
+	  </p>
+	  
+	  <p>
         <button onclick="detailView.setOptions({ loadOnce: detailView.loadOnce, useRowClick: true })">Row Click ON</button>
         &nbsp;
         <button onclick="detailView.setOptions({ loadOnce: detailView.loadOnce, useRowClick: false })">Row Click OFF</button>
-        <h2>View Source:</h2>
+        
+		
+		
+		<h2>View Source:</h2>
         <ul>
           <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example16-row-detail.html" target="_sourcewindow"> View the source for this example on Github</a></li>
         </ul>
@@ -169,6 +181,34 @@
       this.duration = "5 days";
     }
 
+	function setMaxRows(amount){
+		var value = $("#maxRowInput").val();		
+		var maxRows = parseInt(value);
+		
+		var options = detailView.getOptions();
+				
+		if(!isNaN(maxRows))
+		{
+			options.maxRows = maxRows;	
+		}
+		
+		detailView.setOptions(options);
+	}
+	
+	function setPanelRows(amount){
+		var value = $("#panelRowInput").val();		
+		var panelRows = parseInt(value);
+		
+		var options = detailView.getOptions();
+				
+		if(!isNaN(panelRows))
+		{
+			options.panelRows = panelRows;	
+		}
+		
+		detailView.setOptions(options);
+	}	
+	
     function hookAssigneeOnClick(itemId) {
       $("#who-is-assignee_" + itemId).off("click").on("click", function() {
         alert("Assignee is " + $("#assignee_" + itemId).val());
@@ -262,6 +302,7 @@
 		"<div id=\"London\" class=\"tabcontent\">" +
 		"<h3>London</h3>" +
 		"<p>London is the capital city of England.</p>" +
+		"<button onclick=\"detailView.resizeDetailView(data[" + rowIdx + "])\">Resize detail view</button>" +
 		"</div>" +
 
 		"<div id=\"Paris\" class=\"tabcontent\">" +
@@ -336,8 +377,8 @@
 
         // how many grid rows do we want to use for the detail panel
         // also note that the detail view adds an extra 1 row for padding purposes
-        // example, if you choosed 4 panelRows, the display will in fact use 5 rows
-        panelRows: 4
+        // example, if you choosed 6 panelRows, the display will in fact use 5 rows
+        panelRows: 6
       });
 
       // push the plugin as the first column

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -290,21 +290,22 @@
       }, undefined, this);
     }
 
-	function openCity(evt, cityName, rowIdx) {
-    var i, tabcontent, tablinks;
-    tabcontent = document.getElementsByClassName("tabcontent");
-    for (i = 0; i < tabcontent.length; i++) {
-        tabcontent[i].style.display = "none";
+    /** Callback to open a city from row detail "Task 5" */
+    function openCity(evt, cityName, rowIdx) {
+      var i, tabcontent, tablinks;
+      tabcontent = document.getElementsByClassName("tabcontent");
+      for (i = 0; i < tabcontent.length; i++) {
+          tabcontent[i].style.display = "none";
+      }
+      tablinks = document.getElementsByClassName("tablinks");
+      for (i = 0; i < tablinks.length; i++) {
+          tablinks[i].className = tablinks[i].className.replace(" active", "");
+      }
+      document.getElementById(cityName).style.display = "block";
+      evt.currentTarget.className += " active";
+
+      // detailView.saveDetailView(data[rowIdx]);
     }
-    tablinks = document.getElementsByClassName("tablinks");
-    for (i = 0; i < tablinks.length; i++) {
-        tablinks[i].className = tablinks[i].className.replace(" active", "");
-    }
-    document.getElementById(cityName).style.display = "block";
-    evt.currentTarget.className += " active";
-	
-		detailView.saveDetailView(data[rowIdx]);
-	}
 
     function randomNumber(min, max) {
       return Math.floor(Math.random() * (max - min + 1) + min);
@@ -383,6 +384,13 @@
       $(grid.getHeaderRow()).on("change keyup", ":input", function (e) {
         var columnId = $(this).data("columnId");
         if (columnId != null) {
+          // we can save the detail view content before filtering
+          var expandedRows = detailView.getExpandedRows();
+          expandedRows.forEach(function (row) {
+            detailView.saveDetailView(row);
+          });
+
+          // keep filter in global variable & filter dataset by calling a refresh
           columnFilters[columnId] = $.trim($(this).val());
           dataView.refresh();
         }

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -359,7 +359,6 @@
         postTemplate: loadView,
         process: simulateServerCall,
         useRowClick: true,
-        outOfVisibleDetectEarlierRows: 7, // for an earlier detection (out of visible range)
 
         // how many grid rows do we want to use for the detail panel
         // also note that the detail view adds an extra 1 row for padding purposes
@@ -395,12 +394,12 @@
       });
 
       // the following subscribers can be useful to Save/Re-Render a View
-      // when it goes out of visible or back to visible range
-      detailView.onRowOutOfVisibleRange.subscribe(function(e, args) {
+      // when it goes out of viewport or back to viewport range
+      detailView.onRowOutOfViewportRange.subscribe(function(e, args) {
         destroyAssigneeOnClick(args.item.id);
       });
 
-      detailView.onRowBackToVisibleRange.subscribe(function(e, args) {
+      detailView.onRowBackToViewportRange.subscribe(function(e, args) {
         hookAssigneeOnClick(args.item.id);
       });
 

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -253,12 +253,12 @@
     // notify the onAsyncResponse with the "args.item" (required property)
     // the plugin will then use itemDetail to populate the detail panel with "postTemplate"
     function notifyNonTemplatedView(itemDetail) {
-
+	var rowIdx = grid.getData().getIdxById(itemDetail.id);
 	var temp =
 		"<div class=\"tab\">"+
-		"<button class=\"tablinks\" onclick=\"openCity(event, 'London')\">London</button>" +
-		"<button class=\"tablinks\" onclick=\"openCity(event, 'Paris')\">Paris</button>" +
-		"<button class=\"tablinks\" onclick=\"openCity(event, 'Tokyo')\">Tokyo</button>" +
+		"<button class=\"tablinks\" onclick=\"openCity(event, 'London'," + rowIdx +")\">London</button>" +
+		"<button class=\"tablinks\" onclick=\"openCity(event, 'Paris'," + rowIdx +")\">Paris</button>" +
+		"<button class=\"tablinks\" onclick=\"openCity(event, 'Tokyo'," + rowIdx +")\">Tokyo</button>" +
 		"</div>" +
 
 		"<div id=\"London\" class=\"tabcontent\">" +
@@ -275,7 +275,7 @@
 			"<div>" +
 				"<h4>Direct view inserting without template</h4>" +
 				"<span>This is not using the template</span><br/>" +
-				"<button onclick=\"detailView.resizeDetailView(data[" + itemDetail.id + "])\">Resize detail view</button>" +
+				"<button onclick=\"detailView.resizeDetailView(data[" + rowIdx + "])\">Resize detail view</button>" +
 				"<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
 				"This is to make the loaded area longer" +
 				"<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
@@ -290,7 +290,7 @@
       }, undefined, this);
     }
 
-	function openCity(evt, cityName) {
+	function openCity(evt, cityName, rowIdx) {
     var i, tabcontent, tablinks;
     tabcontent = document.getElementsByClassName("tabcontent");
     for (i = 0; i < tabcontent.length; i++) {
@@ -302,7 +302,9 @@
     }
     document.getElementById(cityName).style.display = "block";
     evt.currentTarget.className += " active";
-}
+	
+		detailView.saveDetailView(data[rowIdx]);
+	}
 
     function randomNumber(min, max) {
       return Math.floor(Math.random() * (max - min + 1) + min);

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -217,17 +217,17 @@
         "item": itemDetail,
 
         // detailView Ignores any template and use what's passed through instead
-        "detailView": "<div>" + 
+        "detailView": "<div>" +
 					  "<h4>Direct view inserting without template</h4>" +
-					  "<span>This is not using the template</span><br/>" + 
+					  "<span>This is not using the template</span><br/>" +
 					  "<button onclick=\"detailView.resizeDetailView(data[" + itemDetail.id + "])\">Resize detail view</button>" +
-					  "<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" + 
+					  "<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
 					  "This is to make the loaded area longer" +
 					  "<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
 					  "And Loooooonnnnnggggerrr<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
 					  "Nearly there<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>" +
 					  "One more to go<br/><br/><br/><br/>" +
-					  "Done Yay" + 
+					  "Done Yay" +
 					  "</div>"
       }, undefined, this);
     }

--- a/plugins/slick.rowdetailview.css
+++ b/plugins/slick.rowdetailview.css
@@ -1,23 +1,21 @@
-.detailView-toggle
-{
+.detailView-toggle {
     display:          inline-block;
     cursor:            pointer;
 }
-.detailView-toggle.expand
-{
+
+.detailView-toggle.expand {
     height:           20px;
     width:            20px;
     background: url(../images/arrow-right.gif) no-repeat center center;
 }
 
-.detailView-toggle.collapse
-{
+.detailView-toggle.collapse {
     height:           20px;
     width:            20px;
     background: url(../images/sort-desc.gif) no-repeat center center;
 }
-.dynamic-cell-detail
-{
+
+.dynamic-cell-detail {
     z-index:            10000;
     position:           absolute;
     background-color:   #dae5e8;
@@ -26,9 +24,8 @@
     width:              100%;
     overflow:           auto;
 }
- 
-.dynamic-cell-detail > :first-child
-{
+
+.dynamic-cell-detail > :first-child {
     vertical-align:     middle;
     line-height:        13px;
 }

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -3,50 +3,69 @@
  * Original StackOverflow question & article making this possible (thanks to violet313)
  * https://stackoverflow.com/questions/10535164/can-slickgrids-row-height-be-dynamically-altered#29399927
  * http://violet313.org/slickgrids/#intro
- * 
+ *
  *
  * USAGE:
  *
  * Add the slick.rowDetailView.(js|css) files and register the plugin with the grid.
  *
  * AVAILABLE ROW DETAIL OPTIONS:
- *    cssClass:         A CSS class to be added to the row detail
- *    loadOnce:         Booleang flag, when True will load the data once and then reuse it.
- *    preTemplate:      Template that will be used before the async process (typically used to show a spinner/loading)
- *    postTemplate:     Template that will be loaded once the async function finishes
- *    process:          Async server function call
- *    panelRows:        Row count to use for the template panel
- *    useRowClick:      Boolean flag, when True will open the row detail on a row click (from any column), default to False
- * 
+ *    cssClass:               A CSS class to be added to the row detail
+ *    loadOnce:               Defaults to false, when set to True it will load the data once and then reuse it.
+ *    preTemplate:            Template that will be used before the async process (typically used to show a spinner/loading)
+ *    postTemplate:           Template that will be loaded once the async function finishes
+ *    process:                Async server function call
+ *    panelRows:              Row count to use for the template panel
+ *    useRowClick:            Boolean flag, when True will open the row detail on a row click (from any column), default to False
+ *    keyPrefix:              Defaults to '_', prefix used for all the plugin metadata added to the item object (meta e.g.: padding, collapsed, parent)
+ *    collapseAllOnSort:      Defaults to true, which will collapse all row detail views when user calls a sort. Unless user implements a sort to deal with padding
+ *    saveDetailViewOnScroll: Defaults to true, which will save the row detail view in a cache when it detects that it will become out of the viewport buffer
+ *
  * AVAILABLE PUBLIC OPTIONS:
  *    init:                 initiliaze the plugin
  *    destroy:              destroy the plugin and it's events
  *    collapseAll:          collapse all opened row detail panel
- *    getColumnDefinition:  get the column definitions 
+ *    getColumnDefinition:  get the column definitions
  *    getOptions:           get current plugin options
  *    setOptions:           set or change some of the plugin options
- * 
+ *
  * THE PLUGIN EXPOSES THE FOLLOWING SLICK EVENTS:
- *    onAsyncResponse:  This event must be used with the "notify" by the end user once the Asynchronous Server call returns the item detail 
- *       Event args:
- *          itemDetail: Item detail returned from the async server call
- *          detailView:  An explicit view to use instead of template (Optional)
+ *    onAsyncResponse:  This event must be used with the "notify" by the end user once the Asynchronous Server call returns the item detail
+ *      Event args:
+ *        item:         Item detail returned from the async server call
+ *        detailView:   An explicit view to use instead of template (Optional)
  *
  *    onAsyncEndUpdate: Fired when the async response finished
- *       Event args:
- *         grid:        Reference to the grid.
- *         itemDetail:  Column definition.
- * 
- *    onBeforeRowDetailToggle: Fired before the row detail gets toggled
- *       Event args:
- *         grid:        Reference to the grid.
- *         item:  Column definition.
- * 
- *    onAfterRowDetailToggle: Fired after the row detail gets toggled
- *       Event args:
- *         grid:        Reference to the grid.
- *         item:  Column definition.
+ *      Event args:
+ *        grid:         Reference to the grid.
+ *        item:         Item data context
  *
+ *    onBeforeRowDetailToggle: Fired before the row detail gets toggled
+ *      Event args:
+ *        grid:         Reference to the grid.
+ *        item:         Item data context
+ *
+ *    onAfterRowDetailToggle: Fired after the row detail gets toggled
+ *      Event args:
+ *        grid:         Reference to the grid.
+ *        item:         Item data context
+ *        expandedRows: Array of the Expanded Rows
+ *
+ *    onRowOutOfVisibleRange: Fired after a row becomes out of visible range (user can't see the row anymore)
+ *      Event args:
+ *        grid:         Reference to the grid.
+ *        item:         Item data context
+ *        rowIndex:     Index of the Row in the Grid
+ *        expandedRows: Array of the Expanded Rows
+ *        outOfVisibleRangeRows: Array of the Out of Visible Range Rows
+ *
+ *    onRowBackToVisibleRange: Fired after the row detail gets toggled
+ *      Event args:
+ *        grid:         Reference to the grid.
+ *        item:         Item data context
+ *        rowIndex:     Index of the Row in the Grid
+ *        expandedRows: Array of the Expanded Rows
+ *        outOfVisibleRangeRows: Array of the Out of Visible Range Rows
  */
 (function ($) {
   // register namespace
@@ -58,38 +77,64 @@
     }
   });
 
-
   function RowDetailView(options) {
     var _grid;
+    var _gridOptions;
     var _self = this;
     var _expandedRows = [];
     var _handler = new Slick.EventHandler();
     var _defaults = {
       columnId: "_detail_selector",
-      cssClass: null,
+      cssClass: "detailView-toggle",
+      keyPrefix: "_",
+      loadOnce: false,
+      collapseAllOnSort: true,
+      saveDetailViewOnScroll: true,
       toolTip: "",
       width: 30
     };
-
+    var _keyPrefix = _defaults.keyPrefix;
+    var _gridRowBuffer = 0;
+    var _outOfVisibleRangeRows = [];
+    var _visibleRenderedCellCount = 0;
     var _options = $.extend(true, {}, _defaults, options);
 
     function init(grid) {
       _grid = grid;
+      _gridOptions = grid.getOptions() || {};
       _dataView = _grid.getData();
+      _keyPrefix = _options && _options.keyPrefix || "_";
 
       // Update the minRowBuffer so that the view doesn't disappear when it's at top of screen + the original default 3
-      _grid.getOptions().minRowBuffer = _options.panelRows + 3;
+      _gridRowBuffer = _gridOptions.minRowBuffer;
+      options.minRowBuffer = _options.panelRows + 3;
 
       _handler
         .subscribe(_grid.onClick, handleClick)
-        .subscribe(_grid.onSort, handleSort)
-		.subscribe(_grid.onScroll, handleScroll);
+        .subscribe(_grid.onScroll, handleScroll);
 
-      _grid.getData().onRowCountChanged.subscribe(function () { _grid.updateRowCount(); _grid.render(); });
-      _grid.getData().onRowsChanged.subscribe(function (e, a) { _grid.invalidateRows(a.rows); _grid.render(); });
+      // Sort will, by default, Collapse all of the open items (unless user implements his own onSort which deals with open row and padding)
+      if (_options.collapseAllOnSort) {
+        _handler.subscribe(_grid.onSort, collapseAll);
+        _expandedRows = [];
+        _outOfVisibleRangeRows = [];
+      }
+
+      _grid.getData().onRowCountChanged.subscribe(function () {
+        _grid.updateRowCount();
+        _grid.render();
+      });
+
+      _grid.getData().onRowsChanged.subscribe(function (e, a) {
+        _grid.invalidateRows(a.rows);
+        _grid.render();
+      });
 
       // subscribe to the onAsyncResponse so that the plugin knows when the user server side calls finished
       subscribeToOnAsyncResponse();
+
+      setTimeout(calculateVisibleRenderedCount, 250);
+      $(window).on("resize", calculateVisibleRenderedCount);
     }
 
     function destroy() {
@@ -98,19 +143,33 @@
       _self.onAsyncEndUpdate.unsubscribe();
       _self.onAfterRowDetailToggle.unsubscribe();
       _self.onBeforeRowDetailToggle.unsubscribe();
+      _self.onRowOutOfVisibleRange.unsubscribe();
+      _self.onRowBackToVisibleRange.unsubscribe();
+      $(window).off('resize');
     }
 
-    function getOptions(options) {
+    function getOptions() {
       return _options;
     }
 
     function setOptions(options) {
       _options = $.extend(true, {}, _options, options);
     }
-  
+
+    function arrayFindIndex(sourceArray, value) {
+      if (sourceArray) {
+        for (var i = 0; i < sourceArray.length; i++) {
+          if (sourceArray[i] === value) {
+            return i;
+          }
+        }
+      }
+      return -1;
+    }
+
     function handleClick(e, args) {
       // clicking on a row select checkbox
-      if (_options.useRowClick || _grid.getColumns()[args.cell].id === _options.columnId && $(e.target).hasClass("detailView-toggle")) {
+      if (_options.useRowClick || _grid.getColumns()[args.cell].id === _options.columnId && $(e.target).hasClass(_options.cssClass)) {
         // if editing, try to commit
         if (_grid.getEditorLock().isActive() && !_grid.getEditorLock().commitCurrentEdit()) {
           e.preventDefault();
@@ -131,7 +190,8 @@
         // trigger an event after toggling
         _self.onAfterRowDetailToggle.notify({
           "grid": _grid,
-          "item": item
+          "item": item,
+          "expandedRows": _expandedRows,
         }, e, _self);
 
         e.stopPropagation();
@@ -139,113 +199,176 @@
       }
     }
 
-    // Sort will just collapse all of the open items
-    function handleSort(e, args) {
-      collapseAll();
-    }
-
-	// If we scroll save detail views that go out of cache range
+    // If we scroll save detail views that go out of cache range
     function handleScroll(e, args) {
-        
-        var range = _grid.getRenderedRange();
-
-        var start = (range.top > 0 ? range.top : 0);
-        var end = (range.bottom > _dataView.getLength() ? range.bottom : _dataView.getLength());
-        
-        // Get the item at the top of the view
-        var topMostItem = _dataView.getItemByIdx(start);
-
-        // Check it is a parent item
-        if (topMostItem && topMostItem._parent == undefined)
-        {
-            // This is a standard row as we have no parent.
-            var nextItem = _dataView.getItemByIdx(start + 1);
-            if(nextItem !== undefined && nextItem._parent !== undefined)
-            {
-                // This is likely the expanded Detail Row View
-                // Check for safety
-                if(nextItem._parent == topMostItem)
-                {
-                    saveDetailView(topMostItem);
-                }
-            }
-        }
-
-        // Find the bottom most item that is likely to go off screen
-        var bottomMostItem = _dataView.getItemByIdx(end - 1);
-
-        // If we are a detailView and we are about to go out of cache view
-        if (bottomMostItem && bottomMostItem._parent !== undefined)
-        {
-            saveDetailView(bottomMostItem._parent);
-            
-        }
+      calculateOutOfRangeViews();
+      if (_options.saveDetailViewOnScroll) {
+        // handleOnScrollSaveDetailView();
+      }
     }
-	
+
+    function calculateVisibleRenderedCount() {
+      var renderedRange = _grid.getRenderedRange() || {};
+      _visibleRenderedCellCount = renderedRange.bottom - renderedRange.top - _gridRowBuffer;
+	    return _visibleRenderedCellCount;
+    }
+
+    function calculateOutOfRangeViews() {
+      if (_grid) {
+        var renderedRange = _grid.getRenderedRange();
+
+        _expandedRows.forEach((row) => {
+          var rowIndex = _dataView.getRowById(row.id);
+          var isOutOfVisibility = checkIsRowOutOfVisibleRange(rowIndex, renderedRange);
+
+          if (!isOutOfVisibility && arrayFindIndex(_outOfVisibleRangeRows, rowIndex) >= 0) {
+            notifyBackToVisibleWhenDomExist(row, rowIndex);
+          } else if (isOutOfVisibility) {
+            notifyOutOfVisibility(row, rowIndex);
+
+            // save the view when asked
+            if (_options.saveDetailViewOnScroll) {
+              saveDetailView(row);
+            }
+          }
+        });
+      }
+    }
+
+    /** Check if the row became out of visible range (when user can't see it anymore) */
+    function checkIsRowOutOfVisibleRange(rowIndex, renderedRange) {
+  	  if (Math.abs(renderedRange.bottom - _gridRowBuffer - rowIndex) > _visibleRenderedCellCount * 2) {
+        return true;
+      }
+      return false;
+    }
+
+    function notifyOutOfVisibility(item, rowIndex) {
+      _self.onRowOutOfVisibleRange.notify({
+        "grid": _grid,
+        "item": item,
+        "rowIndex": rowIndex,
+        "expandedRows": _expandedRows,
+        "outOfVisibleRangeRows": updateOutOfVisibleArrayWhenNecessary(rowIndex, true)
+      }, null, _self);
+    }
+
+    function notifyBackToVisibleWhenDomExist(item, rowIndex) {
+      var rowIndex = item.rowIndex || _dataView.getRowById(item.id);
+      setTimeout(function() {
+        // make sure View Row DOM Element really exist before notifying that it's a row that is visible again
+        if ($('.cellDetailView_' + item.id).length) {
+          _self.onRowBackToVisibleRange.notify({
+            "grid": _grid,
+            "item": item,
+            "rowIndex": rowIndex,
+            "expandedRows": _expandedRows,
+            "outOfVisibleRangeRows": updateOutOfVisibleArrayWhenNecessary(rowIndex, false)
+          }, null, _self);
+        }
+      }, 100);
+    }
+
+    function updateOutOfVisibleArrayWhenNecessary(rowIndex, isAdding) {
+      var arrayRowIndex = arrayFindIndex(_outOfVisibleRangeRows, rowIndex);
+
+      if (isAdding && arrayRowIndex < 0) {
+        _outOfVisibleRangeRows.push(rowIndex);
+      } else if (!isAdding && arrayRowIndex >= 0) {
+        _outOfVisibleRangeRows.splice(arrayRowIndex, 1);
+      }
+      return _outOfVisibleRangeRows;
+    }
+
+    function handleOnScrollSaveDetailView() {
+      var range = _grid.getRenderedRange();
+      var start = (range.top > 0 ? range.top : 0);
+      var end = (range.bottom > _dataView.getLength() ? range.bottom : _dataView.getLength());
+
+      // Get the item at the top of the view
+      var topMostItem = _dataView.getItemByIdx(start);
+
+      // Check it is a parent item
+      if (topMostItem && topMostItem[_keyPrefix + 'parent'] == undefined) {
+        // This is a standard row as we have no parent.
+        var nextItem = _dataView.getItemByIdx(start + 1);
+        if (nextItem !== undefined && nextItem[_keyPrefix + 'parent'] !== undefined) {
+          // This is likely the expanded Detail Row View
+          // Check for safety
+          if (nextItem[_keyPrefix + 'parent'] == topMostItem) {
+            saveDetailView(topMostItem);
+          }
+        }
+      }
+
+      // Find the bottom most item that is likely to go off screen
+      var bottomMostItem = _dataView.getItemByIdx(end - 1);
+
+      // If we are a detailView and we are about to go out of cache view
+      if (bottomMostItem && bottomMostItem[_keyPrefix + 'parent'] !== undefined) {
+        saveDetailView(bottomMostItem[_keyPrefix + 'parent']);
+      }
+    }
+
     // Toggle between showing and hiding a row
     function toggleRowSelection(row) {
-      _grid.getData().beginUpdate();
+      _dataView.beginUpdate();
       HandleAccordionShowHide(row);
-      _grid.getData().endUpdate();
+      _dataView.endUpdate();
     }
 
     // Collapse all of the open items
     function collapseAll() {
+      _dataView.beginUpdate();
       for (var i = _expandedRows.length - 1; i >= 0; i--) {
-        collapseItem(_expandedRows[i]);
+        collapseItem(_expandedRows[i], true);
       }
+      _dataView.endUpdate();
     }
-	
-    // Saves the current state of the detail view
-    function saveDetailView(item)
-    {
-        var view = $("#innerDetailView_" + item.id);
-        if (view)
-        {
-            var html = $("#innerDetailView_" + item.id).html();
-            if(html !== undefined)
-            {
-                item._detailContent = html;
-            }
-        }   
-    }
-	
-    // Colapse an Item so it is notlonger seen
-    function collapseItem(item) {
-	  
+
+    // Colapse an Item so it is not longer seen
+    function collapseItem(item, multipleCollapse) {
+      if (!multipleCollapse) {
+        _dataView.beginUpdate();
+      }
       // Save the details on the collapse assuming onetime loading
       if (_options.loadOnce) {
-          saveDetailView(item);
+        saveDetailView(item);
       }
-		
-      item._collapsed = true;
-      for (var idx = 1; idx <= item._sizePadding; idx++) {
+
+      item[_keyPrefix + 'collapsed'] = true;
+      for (var idx = 1; idx <= item[_keyPrefix + 'sizePadding']; idx++) {
         _dataView.deleteItem(item.id + "." + idx);
       }
-      item._sizePadding = 0;
+      item[_keyPrefix + 'sizePadding'] = 0;
       _dataView.updateItem(item.id, item);
 
       // Remove the item from the expandedRows
       _expandedRows = _expandedRows.filter(function (r) {
         return r.id !== item.id;
       });
+
+      if (!multipleCollapse) {
+        _dataView.endUpdate();
+      }
     }
 
     // Expand a row given the dataview item that is to be expanded
     function expandItem(item) {
-      item._collapsed = false;
+      item[_keyPrefix + 'collapsed'] = false;
       _expandedRows.push(item);
-      
+
       // In the case something went wrong loading it the first time such a scroll of screen before loaded
-      if (!item._detailContent) item._detailViewLoaded = false;	  
-	   
+      if (!item[_keyPrefix + 'detailContent']) item[_keyPrefix + 'detailViewLoaded'] = false;
+
       // display pre-loading template
-      if (!item._detailViewLoaded || _options.loadOnce !== true) {
-        item._detailContent = _options.preTemplate(item);
+      if (!item[_keyPrefix + 'detailViewLoaded'] || _options.loadOnce !== true) {
+        item[_keyPrefix + 'detailContent'] = _options.preTemplate(item);
       } else {
         _self.onAsyncResponse.notify({
+          "item": item,
           "itemDetail": item,
-          "detailView": item._detailContent
+          "detailView": item[_keyPrefix + 'detailContent']
         }, undefined, this);
         applyTemplateNewLineHeight(item);
         _dataView.updateItem(item.id, item);
@@ -260,39 +383,52 @@
       _options.process(item);
     }
 
+    // Saves the current state of the detail view
+    function saveDetailView(item) {
+      var view = $(".innerDetailView_" + item.id);
+      if (view) {
+        var html = $(".innerDetailView_" + item.id).html();
+        if (html !== undefined) {
+          item[_keyPrefix + 'detailContent'] = html;
+        }
+      }
+    }
+
     /**
      * subscribe to the onAsyncResponse so that the plugin knows when the user server side calls finished
-     * the response has to be as "args.itemDetail" with it's data back
+     * the response has to be as "args.item" (or "args.itemDetail") with it's data back
      */
-    function subscribeToOnAsyncResponse() {      
-      _self.onAsyncResponse.subscribe(function (e, args) {      
-        if (!args || !args.itemDetail) {
-          throw 'Slick.RowDetailView plugin requires the onAsyncResponse() to supply "args.itemDetail" property.'
+    function subscribeToOnAsyncResponse() {
+      _self.onAsyncResponse.subscribe(function (e, args) {
+        if (!args || (!args.item && !args.itemDetail)) {
+          throw 'Slick.RowDetailView plugin requires the onAsyncResponse() to supply "args.item" property.'
         }
+
+        // we accept item/itemDetail, just get the one which has data
+        var itemDetail = args.item || args.itemDetail;
 
         // If we just want to load in a view directly we can use detailView property to do so
         if (args.detailView) {
-          args.itemDetail._detailContent = args.detailView;
+          itemDetail[_keyPrefix + 'detailContent'] = args.detailView;
         } else {
-          args.itemDetail._detailContent = _options.postTemplate(args.itemDetail);
+          itemDetail[_keyPrefix + 'detailContent'] = _options.postTemplate(itemDetail);
         }
 
-        args.itemDetail._detailViewLoaded = true;
-
-        var idxParent = _dataView.getIdxById(args.itemDetail.id);
-        _dataView.updateItem(args.itemDetail.id, args.itemDetail);
+        itemDetail[_keyPrefix + 'detailViewLoaded'] = true;
+        _dataView.updateItem(itemDetail.id, itemDetail);
 
         // trigger an event once the post template is finished loading
         _self.onAsyncEndUpdate.notify({
-            "grid": _grid,
-            "itemDetail": args.itemDetail
+          "grid": _grid,
+          "item": itemDetail,
+          "itemDetail": itemDetail
         }, e, _self);
       });
     }
 
     function HandleAccordionShowHide(item) {
       if (item) {
-        if (!item._collapsed) {
+        if (!item[_keyPrefix + 'collapsed']) {
           collapseItem(item);
         } else {
           expandItem(item);
@@ -310,30 +446,29 @@
       }
       item.id = parent.id + "." + offset;
 
-      //additional hidden padding metadata fields
-      item._collapsed = true;
-      item._isPadding = true;
-      item._parent = parent;
-      item._offset = offset;
+      // additional hidden padding metadata fields
+      item[_keyPrefix + 'collapsed'] = true;
+      item[_keyPrefix + 'isPadding'] = true;
+      item[_keyPrefix + 'parent'] = parent;
+      item[_keyPrefix + 'offset'] = offset;
 
       return item;
     }
 
     //////////////////////////////////////////////////////////////
-    //create the detail ctr node. this belongs to the dev & can be custom-styled as per
+    // create the detail ctr node. this belongs to the dev & can be custom-styled as per
     //////////////////////////////////////////////////////////////
     function applyTemplateNewLineHeight(item) {
-      // the height seems to be calculated by the template row count (how many line of items does the template have)
+      // the height is calculated by the template row count (how many line of items does the template view have)
       var rowCount = _options.panelRows;
 
-      //calculate padding requirements based on detail-content..
-      //ie. worst-case: create an invisible dom node now &find it's height.
-      var lineHeight = 13; //we know cuz we wrote the custom css innit ;)
-      item._sizePadding = Math.ceil(((rowCount * 2) * lineHeight) / _grid.getOptions().rowHeight);
-      item._height = (item._sizePadding * _grid.getOptions().rowHeight);
-
+      // calculate padding requirements based on detail-content..
+      // ie. worst-case: create an invisible dom node now & find it's height.
+      var lineHeight = 13; // we know cuz we wrote the custom css init ;)
+      item[_keyPrefix + 'sizePadding'] = Math.ceil(((rowCount * 2) * lineHeight) / _gridOptions.rowHeight);
+      item[_keyPrefix + 'height'] = (item[_keyPrefix + 'sizePadding'] * _gridOptions.rowHeight);
       var idxParent = _dataView.getIdxById(item.id);
-      for (var idx = 1; idx <= item._sizePadding; idx++) {
+      for (var idx = 1; idx <= item[_keyPrefix + 'sizePadding']; idx++) {
         _dataView.insertItem(idxParent + idx, getPaddingItem(item, idx));
       }
     }
@@ -354,24 +489,22 @@
     }
 
     function detailSelectionFormatter(row, cell, value, columnDef, dataContext) {
-
-      if (dataContext._collapsed == undefined) {
-        dataContext._collapsed = true,
-          dataContext._sizePadding = 0,     //the required number of pading rows
-          dataContext._height = 0,     //the actual height in pixels of the detail field
-          dataContext._isPadding = false,
-          dataContext._parent = undefined,
-          dataContext._offset = 0
+      if (dataContext[_keyPrefix + 'collapsed'] == undefined) {
+        dataContext[_keyPrefix + 'collapsed'] = true,
+        dataContext[_keyPrefix + 'sizePadding'] = 0,     //the required number of pading rows
+        dataContext[_keyPrefix + 'height'] = 0,     //the actual height in pixels of the detail field
+        dataContext[_keyPrefix + 'isPadding'] = false,
+        dataContext[_keyPrefix + 'parent'] = undefined,
+        dataContext[_keyPrefix + 'offset'] = 0
       }
 
-      if (dataContext._isPadding == true) {
+      if (dataContext[_keyPrefix + 'isPadding'] == true) {
         //render nothing
-      } else if (dataContext._collapsed) {
-        return "<div class='detailView-toggle expand'></div>";
+      } else if (dataContext[_keyPrefix + 'collapsed']) {
+        return "<div class='" + _options.cssClass + " expand'></div>";
       } else {
         var html = [];
-        var rowHeight = _grid.getOptions().rowHeight;
-        var bottomMargin = 5;
+        var rowHeight = _gridOptions.rowHeight;
 
         //V313HAX:
         //putting in an extra closing div after the closing toggle div and ommiting a
@@ -382,13 +515,13 @@
         //slick-cell to escape the cell overflow clipping.
 
         //sneaky extra </div> inserted here-----------------v
-        html.push("<div class='detailView-toggle collapse'></div></div>");
+        html.push("<div class='" + _options.cssClass + " collapse'></div></div>");
 
-        html.push("<div id='cellDetailView_", dataContext.id, "' class='dynamic-cell-detail' ");   //apply custom css to detail
-        html.push("style='height:", dataContext._height, "px;"); //set total height of padding
+        html.push("<div class='dynamic-cell-detail cellDetailView_", dataContext.id, "' ");   //apply custom css to detail
+        html.push("style='height:", dataContext[_keyPrefix + 'height'], "px;"); //set total height of padding
         html.push("top:", rowHeight, "px'>");             //shift detail below 1st row
-        html.push("<div id='detailViewContainer_", dataContext.id, "'  class='detail-container' style='max-height:" + (dataContext._height - rowHeight + bottomMargin) + "px'>"); //sub ctr for custom styling
-        html.push("<div id='innerDetailView_" , dataContext.id , "'>" , dataContext._detailContent, "</div></div>"); 
+        html.push("<div class='detail-container detailViewContainer_", dataContext.id, "'>"); //sub ctr for custom styling
+        html.push("<div class='innerDetailView_", dataContext.id, "'>", dataContext[_keyPrefix + 'detailContent'], "</div></div>");
         //&omit a final closing detail container </div> that would come next
 
         return html.join("");
@@ -398,50 +531,50 @@
 
     function resizeDetailView(item) {
       if (!item) return;
-      
-      // Grad each of the dom items
-      var mainContainer = document.getElementById('detailViewContainer_' + item.id);
-      var cellItem = document.getElementById('cellDetailView_' + item.id);
-      var inner = document.getElementById('innerDetailView_' + item.id);
-      
+
+      // Grad each of the DOM elements
+      var mainContainer = document.getElementsByClassName('detailViewContainer_' + item.id);
+      var cellItem = document.getElementsByClassName('cellDetailView_' + item.id);
+      var inner = document.getElementsByClassName('innerDetailView_' + item.id);
+
       if (!mainContainer || !cellItem || !inner) return;
-      
-      for (var idx = 1; idx <= item._sizePadding; idx++) {
-          _dataView.deleteItem(item.id + "." + idx);
+
+      for (var idx = 1; idx <= item[_keyPrefix + 'sizePadding']; idx++) {
+        _dataView.deleteItem(item.id + "." + idx);
       }
-      
-      var rowHeight = _grid.getOptions().rowHeight; // height of a row
-      var lineHeight = 13; //we know cuz we wrote the custom css innit ;)
-      
+
+      var rowHeight = _gridOptions.rowHeight; // height of a row
+      var lineHeight = 13; // we know cuz we wrote the custom css innit ;)
+
       // Get the inner Item height as this will be the actual size
       var itemHeight = inner.clientHeight;
-      
-      // Now work out how many rows 
+
+      // Now work out how many rows
       var rowCount = Math.ceil(itemHeight / rowHeight) + 1;
-      
-      item._sizePadding = Math.ceil(((rowCount * 2) * lineHeight) / rowHeight);
-      item._height = (item._sizePadding * rowHeight);
-	  
-	  // If the padding is now more than the original minRowBuff we need to increase it
-      if (_grid.getOptions().minRowBuffer < item._sizePadding)
-      {
-          // Update the minRowBuffer so that the view doesn't disappear when it's at top of screen + the original default 3
-          _grid.getOptions().minRowBuffer =item._sizePadding + 3;
+
+      item[_keyPrefix + 'sizePadding'] = Math.ceil(((rowCount * 2) * lineHeight) / rowHeight);
+      item[_keyPrefix + 'height'] = (item[_keyPrefix + 'sizePadding'] * rowHeight);
+
+      // If the padding is now more than the original minRowBuff we need to increase it
+      if (_gridOptions.minRowBuffer < item[_keyPrefix + 'sizePadding']) {
+        // Update the minRowBuffer so that the view doesn't disappear when it's at top of screen + the original default 3
+        _gridOptions.minRowBuffer = item[_keyPrefix + 'sizePadding'] + 3;
       }
-      
-      mainContainer.setAttribute("style", "max-height: " + item._height + "px");
-      if (cellItem) cellItem.setAttribute("style", "height: " + item._height + "px;top:" + rowHeight + "px");
-      
+
+      mainContainer.setAttribute("style", "max-height: " + item[_keyPrefix + 'height'] + "px");
+      if (cellItem) cellItem.setAttribute("style", "height: " + item[_keyPrefix + 'height'] + "px;top:" + rowHeight + "px");
+
       var idxParent = _dataView.getIdxById(item.id);
-      for (var idx = 1; idx <= item._sizePadding; idx++) {
-          _dataView.insertItem(idxParent + idx, getPaddingItem(item, idx));
+      for (var idx = 1; idx <= item[_keyPrefix + 'sizePadding']; idx++) {
+        _dataView.insertItem(idxParent + idx, getPaddingItem(item, idx));
       }
     }
-	
+
     $.extend(this, {
       "init": init,
       "destroy": destroy,
       "collapseAll": collapseAll,
+      "collapseItem": collapseItem,
       "getColumnDefinition": getColumnDefinition,
       "getOptions": getOptions,
       "setOptions": setOptions,
@@ -449,7 +582,9 @@
       "onAsyncEndUpdate": new Slick.Event(),
       "onAfterRowDetailToggle": new Slick.Event(),
       "onBeforeRowDetailToggle": new Slick.Event(),
-	  "resizeDetailView": resizeDetailView
+      "onRowOutOfVisibleRange": new Slick.Event(),
+      "onRowBackToVisibleRange": new Slick.Event(),
+      "resizeDetailView": resizeDetailView
     });
   }
 })(jQuery);

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -92,6 +92,7 @@
     var _lastRange = null;
     var _expandedRows = [];
     var _handler = new Slick.EventHandler();
+	var _outsideRange = 5;
     var _defaults = {
       columnId: '_detail_selector',
       cssClass: 'detailView-toggle',
@@ -258,18 +259,17 @@
                 var rowPadding = row[_keyPrefix + 'sizePadding'];
                 var rowOutOfRange = arrayFindIndex(_outOfVisibleRangeRows, rowIndex) >= 0;
 
-                // save the view when asked
-                if (_options.saveDetailViewOnScroll) {
-                    // If the top or bottom item of the range is an expanded row save it.
-                    // This may need to be updated to check within current view port instead
-                    if (rowIndex <= renderedRange.top + _gridRowBuffer || rowIndex >= renderedRange.bottom - _gridRowBuffer) {
-                        saveDetailView(row);
-                    }
-                }
-
-                if (scrollDir === 'UP') {
+                if (scrollDir === 'UP') {					
+					// save the view when asked
+					if (_options.saveDetailViewOnScroll) {
+						// If the bottom item within buffer range is an expanded row save it.
+						if (rowIndex >= renderedRange.bottom - _gridRowBuffer) {
+							saveDetailView(row);
+						}
+					}					
+					
                     // If the row expanded area is within the buffer notify that it is back in range
-                    if (rowOutOfRange && rowIndex - 5 < renderedRange.top && rowIndex >= renderedRange.top) {
+                    if (rowOutOfRange && rowIndex - _outsideRange < renderedRange.top && rowIndex >= renderedRange.top) {
                         notifyBackToVisibleWhenDomExist(row, rowIndex);
                         console.log("BACK", rowIndex);
                     }
@@ -282,8 +282,16 @@
                 }
                 else if (scrollDir === 'DOWN') {
 
+					// save the view when asked
+					if (_options.saveDetailViewOnScroll) {
+						// If the top item within buffer range is an expanded row save it.
+						if (rowIndex <= renderedRange.top + _gridRowBuffer) {
+							saveDetailView(row);
+						}
+					}
+				
                     // If row index is i higher than bottom with some added value (To ignore top rows off view) and is with view and was our of range
-                    if (rowOutOfRange && (rowIndex + rowPadding + 5) > renderedRange.bottom && rowIndex < rowIndex + rowPadding) {
+                    if (rowOutOfRange && (rowIndex + rowPadding + _outsideRange) > renderedRange.bottom && rowIndex < rowIndex + rowPadding) {
                         notifyBackToVisibleWhenDomExist(row, rowIndex);
                         console.log("BACK", rowIndex);
                     }

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -234,16 +234,16 @@
                 // Assume scroll direction is down by default.
                 var scrollDir = 'DOWN';
                 if (_lastRange) {
+					// Some scrolling isn't anything as the range is the same
+                    if (_lastRange.top === renderedRange.top && _lastRange.bottom === renderedRange.bottom) {
+                        return;
+                    }
+					
                     // If our new top is smaller we are scrolling up
                     if (_lastRange.top > renderedRange.top ||
                         // Or we are at very top but our bottom is increasing
                         (_lastRange.top === 0 && renderedRange.top === 0) && _lastRange.bottom > renderedRange.bottom) {
                         scrollDir = 'UP';
-                    }
-
-                    // Some scrolling isn't anything as the range is the same
-                    if (_lastRange.top === renderedRange.top && _lastRange.bottom === renderedRange.bottom) {
-                        return;
                     }
                 }
             }
@@ -269,9 +269,9 @@
                         notifyBackToVisibleWhenDomExist(row, rowIndex);
                         console.log("BACK", rowIndex);
                     }
-                                            
+					
                     // if our first expanded row is about to go off the bottom
-                    if (!rowOutOfRange && (rowIndex + rowPadding) > renderedRange.bottom) {
+                    else if (!rowOutOfRange && (rowIndex + rowPadding) > renderedRange.bottom) {
                         notifyOutOfVisibility(row, rowIndex);
                         console.log("NOTIFY", rowIndex);
                     }
@@ -285,7 +285,7 @@
                     }
 
                     // if our row is outside top of and the buffering zone but not in the array of outOfVisable range notify it
-                    if (!rowOutOfRange && rowIndex < renderedRange.top) {
+                    else if (!rowOutOfRange && rowIndex < renderedRange.top) {
                         notifyOutOfVisibility(row, rowIndex);
                         console.log("NOTIFY", rowIndex);
                     }

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -28,7 +28,11 @@
  *    init:                 initiliaze the plugin
  *    destroy:              destroy the plugin and it's events
  *    collapseAll:          collapse all opened row detail panel
+ *    collapseItem:         collapse a row by passing the item object (row detail)
  *    getColumnDefinition:  get the column definitions
+ *    getExpandedRows:      get all the expanded rows
+ *    resizeDetailView:     resize a row detail view, it will auto-calculate the number of rows it needs
+ *    saveDetailView:       save a row detail view content by passing the row object
  *    getOptions:           get current plugin options
  *    setOptions:           set or change some of the plugin options
  *
@@ -227,7 +231,7 @@
 
 
     function calculateOutOfRangeViews() {
-        if (_grid) {                
+        if (_grid) {
             var renderedRange = _grid.getRenderedRange();
            // Only check if we have expanded rows
             if (_expandedRows.length > 0) {
@@ -238,7 +242,7 @@
                     if (_lastRange.top === renderedRange.top && _lastRange.bottom === renderedRange.bottom) {
                         return;
                     }
-					
+
                     // If our new top is smaller we are scrolling up
                     if (_lastRange.top > renderedRange.top ||
                         // Or we are at very top but our bottom is increasing
@@ -262,14 +266,14 @@
                         saveDetailView(row);
                     }
                 }
-                                    
+
                 if (scrollDir === 'UP') {
                     // If the row expanded area is within the buffer notify that it is back in range
                     if (rowOutOfRange && rowIndex - 5 < renderedRange.top && rowIndex >= renderedRange.top) {
                         notifyBackToVisibleWhenDomExist(row, rowIndex);
                         console.log("BACK", rowIndex);
                     }
-					
+
                     // if our first expanded row is about to go off the bottom
                     else if (!rowOutOfRange && (rowIndex + rowPadding) > renderedRange.bottom) {
                         notifyOutOfVisibility(row, rowIndex);
@@ -277,8 +281,8 @@
                     }
                 }
                 else if (scrollDir === 'DOWN') {
-                    
-                    // If row index is i higher than bottom with some added value (To ignore top rows off view) and is with view and was our of range                    
+
+                    // If row index is i higher than bottom with some added value (To ignore top rows off view) and is with view and was our of range
                     if (rowOutOfRange && (rowIndex + rowPadding + 5) > renderedRange.bottom && rowIndex < rowIndex + rowPadding) {
                         notifyBackToVisibleWhenDomExist(row, rowIndex);
                         console.log("BACK", rowIndex);
@@ -566,6 +570,10 @@
       };
     }
 
+    function getExpandedRows() {
+      return _expandedRows;
+    }
+
     function detailSelectionFormatter(row, cell, value, columnDef, dataContext) {
       if (dataContext[_keyPrefix + 'collapsed'] == undefined) {
         dataContext[_keyPrefix + 'collapsed'] = true,
@@ -667,6 +675,7 @@
       "collapseAll": collapseAll,
       "collapseItem": collapseItem,
       "getColumnDefinition": getColumnDefinition,
+      "getExpandedRows": getExpandedRows,
       "getOptions": getOptions,
       "setOptions": setOptions,
       "onAsyncResponse": new Slick.Event(),
@@ -676,7 +685,7 @@
       "onRowOutOfVisibleRange": new Slick.Event(),
       "onRowBackToVisibleRange": new Slick.Event(),
       "resizeDetailView": resizeDetailView,
-	  "saveDetailView": saveDetailView
+	    "saveDetailView": saveDetailView
     });
   }
 })(jQuery);

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -252,6 +252,11 @@
      * @param rowCountToDetectEarlier, number of Rows if we want an earlier detection of the out of visible range
      */
     function checkIsRowOutOfVisibleRange(rowIndex, renderedRange, rowCountToDetectEarlier) {
+      // calculate when scrolling up
+  	  if (Math.abs(renderedRange.top - _gridRowBuffer - rowIndex - rowCountToDetectEarlier) > _visibleRenderedCellCount * 2) {
+        return true;
+      }
+      // calculate when scrolling down
   	  if (Math.abs(renderedRange.bottom - _gridRowBuffer - rowIndex + rowCountToDetectEarlier) > _visibleRenderedCellCount * 2) {
         return true;
       }

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -676,6 +676,14 @@
 	    // Lastly save the updated state
       saveDetailView(item);
     }
+	
+	//Takes in the item we are filtering and if it is an expanded row returns it's parents row to filter on
+	function getFilterItem(item){
+		if (item[_keyPrefix + 'isPadding'] && item[_keyPrefix + 'parent']) {
+			item = item[_keyPrefix + 'parent'];
+		}
+		return item;
+	}
 
     $.extend(this, {
       "init": init,
@@ -693,7 +701,8 @@
       "onRowOutOfVisibleRange": new Slick.Event(),
       "onRowBackToVisibleRange": new Slick.Event(),
       "resizeDetailView": resizeDetailView,
-	    "saveDetailView": saveDetailView
+	  "saveDetailView": saveDetailView,
+	  "getFilterItem": getFilterItem
     });
   }
 })(jQuery);

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -209,10 +209,9 @@
 
     // If we scroll save detail views that go out of cache range
     function handleScroll(e, args) {
-      console.log($('.detailViewContainer_5').length)
-      // calculateOutOfRangeViews();
+      calculateOutOfRangeViews();
       if (_options.saveDetailViewOnScroll) {
-        handleOnScrollSaveDetailView();
+        // handleOnScrollSaveDetailView();
       }
     }
 

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -12,7 +12,7 @@
  * AVAILABLE ROW DETAIL OPTIONS:
  *    cssClass:               A CSS class to be added to the row detail
  *    expandedClass:          Extra classes to be added to the expanded Toggle
- *    collapsedClass:         Extra classes to be added to the expanded Toggle
+ *    collapsedClass:         Extra classes to be added to the collapse Toggle
  *    loadOnce:               Defaults to false, when set to True it will load the data once and then reuse it.
  *    preTemplate:            Template that will be used before the async process (typically used to show a spinner/loading)
  *    postTemplate:           Template that will be loaded once the async function finishes

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -11,6 +11,8 @@
  *
  * AVAILABLE ROW DETAIL OPTIONS:
  *    cssClass:               A CSS class to be added to the row detail
+ *    expandedClass:          Extra classes to be added to the expanded Toggle
+ *    collapsedClass:         Extra classes to be added to the expanded Toggle
  *    loadOnce:               Defaults to false, when set to True it will load the data once and then reuse it.
  *    preTemplate:            Template that will be used before the async process (typically used to show a spinner/loading)
  *    postTemplate:           Template that will be loaded once the async function finishes
@@ -86,6 +88,8 @@
     var _defaults = {
       columnId: "_detail_selector",
       cssClass: "detailView-toggle",
+      expandedClass: null,
+      collapsedClass: null,
       keyPrefix: "_",
       loadOnce: false,
       collapseAllOnSort: true,
@@ -501,7 +505,9 @@
       if (dataContext[_keyPrefix + 'isPadding'] == true) {
         //render nothing
       } else if (dataContext[_keyPrefix + 'collapsed']) {
-        return "<div class='" + _options.cssClass + " expand'></div>";
+		var collapsedClasses = _options.cssClass + " expand ";
+		if (_options.collapsedClass) collapsedClasses += _options.collapsedClass;
+		return "<div class='" + collapsedClasses + "'></div>";
       } else {
         var html = [];
         var rowHeight = _gridOptions.rowHeight;
@@ -515,7 +521,9 @@
         //slick-cell to escape the cell overflow clipping.
 
         //sneaky extra </div> inserted here-----------------v
-        html.push("<div class='" + _options.cssClass + " collapse'></div></div>");
+        var expandedClasses = _options.cssClass + " collapse ";
+        if (_options.expandedClass) expandedClasses += _options.expandedClass;
+        html.push("<div class='" + expandedClasses + "'></div></div>");
 
         html.push("<div class='dynamic-cell-detail cellDetailView_", dataContext.id, "' ");   //apply custom css to detail
         html.push("style='height:", dataContext[_keyPrefix + 'height'], "px;"); //set total height of padding

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -209,9 +209,10 @@
 
     // If we scroll save detail views that go out of cache range
     function handleScroll(e, args) {
-      calculateOutOfRangeViews();
+      console.log($('.detailViewContainer_5').length)
+      // calculateOutOfRangeViews();
       if (_options.saveDetailViewOnScroll) {
-        // handleOnScrollSaveDetailView();
+        handleOnScrollSaveDetailView();
       }
     }
 
@@ -321,7 +322,7 @@
     // Toggle between showing and hiding a row
     function toggleRowSelection(row) {
       _dataView.beginUpdate();
-      HandleAccordionShowHide(row);
+      handleAccordionShowHide(row);
       _dataView.endUpdate();
     }
 
@@ -393,9 +394,9 @@
 
     // Saves the current state of the detail view
     function saveDetailView(item) {
-      var view = $('.innerDetailView_' + item.id);
+      var view = $('.' + _gridUid + ' .innerDetailView_' + item.id);
       if (view) {
-        var html = $('.innerDetailView_' + item.id).html();
+        var html = $('.' + _gridUid + ' .innerDetailView_' + item.id).html();
         if (html !== undefined) {
           item[_keyPrefix + 'detailContent'] = html;
         }
@@ -434,7 +435,7 @@
       });
     }
 
-    function HandleAccordionShowHide(item) {
+    function handleAccordionShowHide(item) {
       if (item) {
         if (!item[_keyPrefix + 'collapsed']) {
           collapseItem(item);
@@ -544,7 +545,9 @@
     }
 
     function resizeDetailView(item) {
-      if (!item) return;
+      if (!item) {
+        return;
+      }
 
       // Grad each of the DOM elements
       var mainContainer = document.querySelector('.' + _gridUid + ' .detailViewContainer_' + item.id);
@@ -585,7 +588,7 @@
         _dataView.insertItem(idxParent + idx, getPaddingItem(item, idx));
       }
 
-	  // Lastly save the updated state
+	    // Lastly save the updated state
       saveDetailView(item);
     }
 

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -116,6 +116,7 @@
       _keyPrefix = _options && _options.keyPrefix || '_';
 
       // Update the minRowBuffer so that the view doesn't disappear when it's at top of screen + the original default 3
+      _gridRowBuffer = _grid.getOptions().minRowBuffer;
       _grid.getOptions().minRowBuffer = _options.panelRows + 3;
 
       _handler

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -82,19 +82,20 @@
   function RowDetailView(options) {
     var _grid;
     var _gridOptions;
+    var _gridUid;
     var _self = this;
     var _expandedRows = [];
     var _handler = new Slick.EventHandler();
     var _defaults = {
-      columnId: "_detail_selector",
-      cssClass: "detailView-toggle",
+      columnId: '_detail_selector',
+      cssClass: 'detailView-toggle',
       expandedClass: null,
       collapsedClass: null,
-      keyPrefix: "_",
+      keyPrefix: '_',
       loadOnce: false,
       collapseAllOnSort: true,
       saveDetailViewOnScroll: true,
-      toolTip: "",
+      toolTip: '',
       width: 30
     };
     var _keyPrefix = _defaults.keyPrefix;
@@ -104,14 +105,17 @@
     var _options = $.extend(true, {}, _defaults, options);
 
     function init(grid) {
+      if (!grid) {
+        throw new Error('RowDetailView Plugin requires the Grid instance to be passed as argument to the "init()" method');
+      }
       _grid = grid;
+      _gridUid = grid.getUID();
       _gridOptions = grid.getOptions() || {};
       _dataView = _grid.getData();
-      _keyPrefix = _options && _options.keyPrefix || "_";
+      _keyPrefix = _options && _options.keyPrefix || '_';
 
       // Update the minRowBuffer so that the view doesn't disappear when it's at top of screen + the original default 3
-      _gridRowBuffer = _gridOptions.minRowBuffer;
-      options.minRowBuffer = _options.panelRows + 3;
+      _grid.getOptions().minRowBuffer = _options.panelRows + 3;
 
       _handler
         .subscribe(_grid.onClick, handleClick)
@@ -138,7 +142,7 @@
       subscribeToOnAsyncResponse();
 
       setTimeout(calculateVisibleRenderedCount, 250);
-      $(window).on("resize", calculateVisibleRenderedCount);
+      $(window).on('resize', calculateVisibleRenderedCount);
     }
 
     function destroy() {
@@ -185,17 +189,17 @@
 
         // trigger an event before toggling
         _self.onBeforeRowDetailToggle.notify({
-          "grid": _grid,
-          "item": item
+          'grid': _grid,
+          'item': item
         }, e, _self);
 
         toggleRowSelection(item);
 
         // trigger an event after toggling
         _self.onAfterRowDetailToggle.notify({
-          "grid": _grid,
-          "item": item,
-          "expandedRows": _expandedRows,
+          'grid': _grid,
+          'item': item,
+          'expandedRows': _expandedRows,
         }, e, _self);
 
         e.stopPropagation();
@@ -249,11 +253,11 @@
 
     function notifyOutOfVisibility(item, rowIndex) {
       _self.onRowOutOfVisibleRange.notify({
-        "grid": _grid,
-        "item": item,
-        "rowIndex": rowIndex,
-        "expandedRows": _expandedRows,
-        "outOfVisibleRangeRows": updateOutOfVisibleArrayWhenNecessary(rowIndex, true)
+        'grid': _grid,
+        'item': item,
+        'rowIndex': rowIndex,
+        'expandedRows': _expandedRows,
+        'outOfVisibleRangeRows': updateOutOfVisibleArrayWhenNecessary(rowIndex, true)
       }, null, _self);
     }
 
@@ -261,13 +265,13 @@
       var rowIndex = item.rowIndex || _dataView.getRowById(item.id);
       setTimeout(function() {
         // make sure View Row DOM Element really exist before notifying that it's a row that is visible again
-        if ($('.cellDetailView_' + item.id).length) {
+        if (document.querySelector('.cellDetailView_' + item.id).length) {
           _self.onRowBackToVisibleRange.notify({
-            "grid": _grid,
-            "item": item,
-            "rowIndex": rowIndex,
-            "expandedRows": _expandedRows,
-            "outOfVisibleRangeRows": updateOutOfVisibleArrayWhenNecessary(rowIndex, false)
+            'grid': _grid,
+            'item': item,
+            'rowIndex': rowIndex,
+            'expandedRows': _expandedRows,
+            'outOfVisibleRangeRows': updateOutOfVisibleArrayWhenNecessary(rowIndex, false)
           }, null, _self);
         }
       }, 100);
@@ -370,9 +374,9 @@
         item[_keyPrefix + 'detailContent'] = _options.preTemplate(item);
       } else {
         _self.onAsyncResponse.notify({
-          "item": item,
-          "itemDetail": item,
-          "detailView": item[_keyPrefix + 'detailContent']
+          'item': item,
+          'itemDetail': item,
+          'detailView': item[_keyPrefix + 'detailContent']
         }, undefined, this);
         applyTemplateNewLineHeight(item);
         _dataView.updateItem(item.id, item);
@@ -389,9 +393,9 @@
 
     // Saves the current state of the detail view
     function saveDetailView(item) {
-      var view = $(".innerDetailView_" + item.id);
+      var view = $('.innerDetailView_' + item.id);
       if (view) {
-        var html = $(".innerDetailView_" + item.id).html();
+        var html = $('.innerDetailView_' + item.id).html();
         if (html !== undefined) {
           item[_keyPrefix + 'detailContent'] = html;
         }
@@ -423,9 +427,9 @@
 
         // trigger an event once the post template is finished loading
         _self.onAsyncEndUpdate.notify({
-          "grid": _grid,
-          "item": itemDetail,
-          "itemDetail": itemDetail
+          'grid': _grid,
+          'item': itemDetail,
+          'itemDetail': itemDetail
         }, e, _self);
       });
     }
@@ -448,7 +452,7 @@
       for (var prop in _grid.getData()) {
         item[prop] = null;
       }
-      item.id = parent.id + "." + offset;
+      item.id = parent.id + '.' + offset;
 
       // additional hidden padding metadata fields
       item[_keyPrefix + 'collapsed'] = true;
@@ -481,9 +485,9 @@
     function getColumnDefinition() {
       return {
         id: _options.columnId,
-        name: "",
+        name: '',
         toolTip: _options.toolTip,
-        field: "sel",
+        field: 'sel',
         width: _options.width,
         resizable: false,
         sortable: false,
@@ -505,9 +509,11 @@
       if (dataContext[_keyPrefix + 'isPadding'] == true) {
         //render nothing
       } else if (dataContext[_keyPrefix + 'collapsed']) {
-		var collapsedClasses = _options.cssClass + " expand ";
-		if (_options.collapsedClass) collapsedClasses += _options.collapsedClass;
-		return "<div class='" + collapsedClasses + "'></div>";
+		    var collapsedClasses = _options.cssClass + ' expand ';
+		    if (_options.collapsedClass) {
+          collapsedClasses += _options.collapsedClass;
+        }
+		    return '<div class="' + collapsedClasses + '"></div>';
       } else {
         var html = [];
         var rowHeight = _gridOptions.rowHeight;
@@ -521,18 +527,18 @@
         //slick-cell to escape the cell overflow clipping.
 
         //sneaky extra </div> inserted here-----------------v
-        var expandedClasses = _options.cssClass + " collapse ";
+        var expandedClasses = _options.cssClass + ' collapse ';
         if (_options.expandedClass) expandedClasses += _options.expandedClass;
-        html.push("<div class='" + expandedClasses + "'></div></div>");
+        html.push('<div class="' + expandedClasses + '"></div></div>');
 
-        html.push("<div class='dynamic-cell-detail cellDetailView_", dataContext.id, "' ");   //apply custom css to detail
-        html.push("style='height:", dataContext[_keyPrefix + 'height'], "px;"); //set total height of padding
-        html.push("top:", rowHeight, "px'>");             //shift detail below 1st row
-        html.push("<div class='detail-container detailViewContainer_", dataContext.id, "' style = 'max-height:" + (dataContext._height - rowHeight + 5) + "px'>"); //sub ctr for custom styling
-        html.push("<div class='innerDetailView_", dataContext.id, "'>", dataContext[_keyPrefix + 'detailContent'], "</div></div>");
-        //&omit a final closing detail container </div> that would come next
+        html.push('<div class="dynamic-cell-detail cellDetailView_', dataContext.id, '" ');   //apply custom css to detail
+        html.push('style="height:', dataContext[_keyPrefix + 'height'], 'px;'); //set total height of padding
+        html.push('top:', rowHeight, 'px">');             //shift detail below 1st row
+        html.push('<div class="detail-container detailViewContainer_', dataContext.id, '" style="max-height:' + (dataContext._height - rowHeight + 5) + 'px">'); //sub ctr for custom styling
+        html.push('<div class="innerDetailView_', dataContext.id, '">', dataContext[_keyPrefix + 'detailContent'], '</div></div>');
+        // &omit a final closing detail container </div> that would come next
 
-        return html.join("");
+        return html.join('');
       }
       return null;
     }
@@ -541,14 +547,16 @@
       if (!item) return;
 
       // Grad each of the DOM elements
-      var mainContainer = document.getElementsByClassName('detailViewContainer_' + item.id)[0];
-      var cellItem = document.getElementsByClassName('cellDetailView_' + item.id)[0];
-      var inner = document.getElementsByClassName('innerDetailView_' + item.id)[0];
+      var mainContainer = document.querySelector('.' + _gridUid + ' .detailViewContainer_' + item.id);
+      var cellItem = document.querySelector('.' + _gridUid + ' .cellDetailView_' + item.id);
+      var inner = document.querySelector('.' + _gridUid + ' .innerDetailView_' + item.id);
 
-      if (!mainContainer || !cellItem || !inner) return;
+      if (!mainContainer || !cellItem || !inner) {
+        return;
+      }
 
       for (var idx = 1; idx <= item[_keyPrefix + 'sizePadding']; idx++) {
-        _dataView.deleteItem(item.id + "." + idx);
+        _dataView.deleteItem(item.id + '.' + idx);
       }
 
       var rowHeight = _gridOptions.rowHeight; // height of a row
@@ -564,19 +572,19 @@
       item[_keyPrefix + 'height'] = (item[_keyPrefix + 'sizePadding'] * rowHeight);
 
       // If the padding is now more than the original minRowBuff we need to increase it
-      if (_gridOptions.minRowBuffer < item[_keyPrefix + 'sizePadding']) {
+      if (_grid.getOptions().minRowBuffer < item[_keyPrefix + 'sizePadding']) {
         // Update the minRowBuffer so that the view doesn't disappear when it's at top of screen + the original default 3
-        _gridOptions.minRowBuffer = item[_keyPrefix + 'sizePadding'] + 3;
+        _grid.getOptions().minRowBuffer = item[_keyPrefix + 'sizePadding'] + 3;
       }
 
-      mainContainer.setAttribute("style", "max-height: " + item[_keyPrefix + 'height'] + "px");
-      if (cellItem) cellItem.setAttribute("style", "height: " + item[_keyPrefix + 'height'] + "px;top:" + rowHeight + "px");
+      mainContainer.setAttribute('style', 'max-height: ' + item[_keyPrefix + 'height'] + 'px');
+      if (cellItem) cellItem.setAttribute('style', 'height: ' + item[_keyPrefix + 'height'] + 'px; top:' + rowHeight + 'px');
 
       var idxParent = _dataView.getIdxById(item.id);
       for (var idx = 1; idx <= item[_keyPrefix + 'sizePadding']; idx++) {
         _dataView.insertItem(idxParent + idx, getPaddingItem(item, idx));
       }
-	  
+
 	  // Lastly save the updated state
       saveDetailView(item);
     }

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -617,7 +617,8 @@
       "onBeforeRowDetailToggle": new Slick.Event(),
       "onRowOutOfVisibleRange": new Slick.Event(),
       "onRowBackToVisibleRange": new Slick.Event(),
-      "resizeDetailView": resizeDetailView
+      "resizeDetailView": resizeDetailView,
+	  "saveDetailView": saveDetailView
     });
   }
 })(jQuery);

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -528,7 +528,7 @@
         html.push("<div class='dynamic-cell-detail cellDetailView_", dataContext.id, "' ");   //apply custom css to detail
         html.push("style='height:", dataContext[_keyPrefix + 'height'], "px;"); //set total height of padding
         html.push("top:", rowHeight, "px'>");             //shift detail below 1st row
-        html.push("<div class='detail-container detailViewContainer_", dataContext.id, "'>"); //sub ctr for custom styling
+        html.push("<div class='detail-container detailViewContainer_", dataContext.id, "' style = 'max-height:" + (dataContext._height - rowHeight + 5) + "px'>"); //sub ctr for custom styling
         html.push("<div class='innerDetailView_", dataContext.id, "'>", dataContext[_keyPrefix + 'detailContent'], "</div></div>");
         //&omit a final closing detail container </div> that would come next
 
@@ -554,8 +554,8 @@
       var rowHeight = _gridOptions.rowHeight; // height of a row
       var lineHeight = 13; // we know cuz we wrote the custom css innit ;)
 
-      // Get the inner Item height as this will be the actual size
-      var itemHeight = inner.clientHeight;
+      // Get the scroll height for the main container so we know the actual size of the view
+      var itemHeight = mainContainer.scrollHeight;
 
       // Now work out how many rows
       var rowCount = Math.ceil(itemHeight / rowHeight) + 1;
@@ -576,6 +576,9 @@
       for (var idx = 1; idx <= item[_keyPrefix + 'sizePadding']; idx++) {
         _dataView.insertItem(idxParent + idx, getPaddingItem(item, idx));
       }
+	  
+	  // Lastly save the updated state
+      saveDetailView(item);
     }
 
     $.extend(this, {

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -533,9 +533,9 @@
       if (!item) return;
 
       // Grad each of the DOM elements
-      var mainContainer = document.getElementsByClassName('detailViewContainer_' + item.id);
-      var cellItem = document.getElementsByClassName('cellDetailView_' + item.id);
-      var inner = document.getElementsByClassName('innerDetailView_' + item.id);
+      var mainContainer = document.getElementsByClassName('detailViewContainer_' + item.id)[0];
+      var cellItem = document.getElementsByClassName('cellDetailView_' + item.id)[0];
+      var inner = document.getElementsByClassName('innerDetailView_' + item.id)[0];
 
       if (!mainContainer || !cellItem || !inner) return;
 


### PR DESCRIPTION
This PR replaces [#281](https://github.com/6pac/SlickGrid/pull/281) which was fully tested by @ghiscoding and @satanEnglish

This PR might also close #252 

- add `onRowOutOfViewportRange` subscribe
- add `onRowBackToViewportRange` subscribe
- expose `collapseDetailView` public
- expose `expandDetailView` public
- add new `keyPrefix` property to change the key prefix of all metadata used by the plugin that appears on the item object
- add new `collapseAllOnSort` boolean flag to provide possibility to implement it's own code for on sort
- add new `saveDetailViewOnScroll` boolean flag because saving detail is not used by all frontend frameworks
- use `item` everywhere instead of `itemDetail` in some areas (however make it to work with both so that it doesn't break anyone's code)
- changed all containers to classes instead of ids (e.g. id="detailViewContainer_2" is now class"detailViewContainer_" on the DOM element)
- fixed `cssClass` which was not fully implemented in the code
- add `getFilterItem` to takes in the item we are filtering and if it is an expanded row returns it's parents row to filter on
- add Filter (row header) example and padding tweak
- add JS code with dynamic template examples
- fixed some issues found and cleaned up unused code
- provided more sample code in the `example16-row-detail.html`
   - added example with tabs (try opening 5th row to see) with saving the row before it goes out of viewport range. Prior code was not handling that very well when the row detail became out of the cached viewport
- made the `onScroll` code more efficient

There's a lot of changes, but I believe that it will be a simple plug & play for most users. The biggest feature is the additions of 2x new subscribe methods to let the user know when the Row Detail View is out or back to visible range. Also a working sample with Filters is a nice addition. 