### PR TITLE
fix grid variable not exist in setSelectedRows, closes issue #301

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3871,7 +3871,7 @@ if (typeof Slick === "undefined") {
       if (!selectionModel) {
         throw new Error("Selection model is not set");
       }
-      if (!grid.getEditorLock().isActive()) {
+      if (self && self.getEditorLock && !self.getEditorLock().isActive()) {
         selectionModel.setSelectedRanges(rowsToRanges(rows));
       }
     }


### PR DESCRIPTION
@6pac 
I'm so sorry, I don't know how I could have missed this (lack of coffee). I totally broke the `setSelectedRows` and that could impact lot of users. Could you merge this, which I fully tested locally, and release another version. 

This PR is to close issue #301