### PR TITLE
feat(grouping): add caller/originator to updateGroupBy on Draggable Grouping

### DIFF
--- a/plugins/slick.draggablegrouping.js
+++ b/plugins/slick.draggablegrouping.js
@@ -193,7 +193,7 @@
             }
           }
           columnsGroupBy = newGroupingOrder;
-          updateGroupBy();
+          updateGroupBy("sort-group");
         }
       });
       emptyDropbox = dropbox.html();
@@ -248,7 +248,7 @@
 
     function addColumnGroupBy(column) {
       columnsGroupBy.push(column);
-      updateGroupBy();
+      updateGroupBy("add-group");
     }
 
     function addGroupByRemoveClickHandler(id, container, column, entry) {
@@ -269,7 +269,7 @@
     }
     function clearDroppedGroups() {
       columnsGroupBy = [];
-      updateGroupBy();
+      updateGroupBy("clear-all");
       dropbox.find(".slick-dropped-grouping").remove();
       groupToggler.css("display", "none");
       dropboxPlaceholder.show()
@@ -298,13 +298,13 @@
       if(columnsGroupBy.length == 0){
         dropboxPlaceholder.show();
       }
-      updateGroupBy();
+      updateGroupBy("remove-group");
     }
 
-    function updateGroupBy() {
+    function updateGroupBy(originator) {
       if (columnsGroupBy.length == 0) {
         _dataView.setGrouping([]);
-        onGroupChanged.notify({ groupColumns: [] });
+        onGroupChanged.notify({ caller: originator, groupColumns: [] });
         return;
       }
       var groupingArray = [];
@@ -315,7 +315,7 @@
       /*
       collapseAllGroups();
       */
-      onGroupChanged.notify({ groupColumns: groupingArray})
+      onGroupChanged.notify({ caller: originator, groupColumns: groupingArray})
     }
     
     // Public API


### PR DESCRIPTION
- this helps in knowing who caller the update action and user can do certain thing accordingly with this new info

Small improvement, and help for the first issue I had opened earlier #299. 
I want to know who called the update (is it the group sort, add group, remove group, ...) and this PR does exactly that.