### PR TITLE
WIP - row detail view - provide alternative calculation

### DIFF
--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -243,7 +243,7 @@
 	
 	  function calculateViewportRenderedCount() {
       var renderedRange = _grid.getRenderedRange() || {};
-      _visibleRenderedCellCount = renderedRange.bottom - renderedRange.top - (_gridRowBuffer * 2);
+      _visibleRenderedCellCount = renderedRange.bottom - renderedRange.top - _gridRowBuffer;
     }
 
     /** Calculate when expanded rows become out of view range */


### PR DESCRIPTION
The function `calculateOutOfRangeViews()` is somehow complex and doesn't work correctly on my side, however a much simpler version always work for me and I'm providing it as an alternative calculation method that can be enabled by a new flag `useSimpleViewportCalc` (which is disabled by default to keep previous behavior). Providing an alternative has the benefit of not breaking the old code while making my side work as intended without breaking anyone else code.