### PR TITLE
fix(gridmenu): should be using grid UID for menu independence

### DIFF
--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -19,7 +19,7 @@
    *      iconCssClass: "fa fa-bars",                 // you can provide iconImage OR iconCssClass
    *      leaveOpen: false,                           // do we want to leave the Grid Menu open after a command execution? (false by default)
    *      menuWidth: 18,                              // width that will be use to resize the column header container (18 by default)
-   *      resizeOnShowHeaderRow: true,                // true by default
+   *      resizeOnShowHeaderRow: false,               // false by default
    *
    *      // the last 2 checkboxes titles
    *      hideForceFitButton: false,                  // show/hide checkbox near the end "Force Fit Columns"
@@ -123,7 +123,7 @@
         // if header row is enabled, we need to resize it's width also
         var enableResizeHeaderRow = (_options.gridMenu && _options.gridMenu.resizeOnShowHeaderRow != undefined) ? _options.gridMenu.resizeOnShowHeaderRow : _defaults.resizeOnShowHeaderRow;
         if(enableResizeHeaderRow && _options.showHeaderRow) {
-          var $headerrow = $('.slick-headerrow');
+          var $headerrow = $('.' + _gridUid + '.slick-headerrow');
           $headerrow.attr('style', 'width: calc(100% - ' + gridMenuWidth +'px)');
         }
 


### PR DESCRIPTION
- without the fix, if 2 grids exists in the same page and 1 has header row showing, and the 2nd grid is not, 1 grid will affect the other. The fix is to use the grid UID to avoid such problems.