### PR TITLE
add new event: onRenderedEvent

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2351,6 +2351,7 @@ if (typeof Slick === "undefined") {
       lastRenderedScrollTop = scrollTop;
       lastRenderedScrollLeft = scrollLeft;
       h_render = null;
+      trigger(self.onRendered, { startRow: visible.top, endRow: visible.bottom, grid: self });
     }
 
     function handleHeaderScroll() {
@@ -3945,6 +3946,7 @@ if (typeof Slick === "undefined") {
       "onSelectedRowsChanged": new Slick.Event(),
       "onCellCssStylesChanged": new Slick.Event(),
       "onAutosizeColumns": new Slick.Event(),
+      "onRendered": new Slick.Event(),
 
       // Methods
       "registerPlugin": registerPlugin,


### PR DESCRIPTION
A lot of time we want to know when the grid got rendered and there's no official way of knowing it (until this PR). This event also brings ability to know the top/bottom visible rows whenever they change. Code was copied from another fork.