### PR TITLE
fix frozenRow options not working when dataview is async

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1783,16 +1783,8 @@ if (typeof Slick === "undefined") {
     }
 
     function setFrozenOptions() {
-      options.frozenColumn = ( options.frozenColumn >= 0
-        && options.frozenColumn < columns.length
-        )
+      options.frozenColumn = (options.frozenColumn >= 0 && options.frozenColumn < columns.length)
         ? parseInt(options.frozenColumn)
-        : -1;
-
-      options.frozenRow = ( options.frozenRow >= 0
-        && options.frozenRow < numVisibleRows
-        )
-        ? parseInt(options.frozenRow)
         : -1;
 
       if (options.frozenRow > -1) {


### PR DESCRIPTION
- when data is loaded asynchronously, the options.frozenRow was reset to -1 before the data had a change to load, however this option should never changes by itself.
- all of my data is loaded asynchronously, so this was a huge problem in my case. I had to reload the option in a `setTimeout` delay but this was not a bulletproof solution and was only working half the time. 