### PR TITLE
feat(divider): add divider option to Grid Menu & Column Header Menu

### DIFF
--- a/controls/slick.gridmenu.css
+++ b/controls/slick.gridmenu.css
@@ -93,8 +93,8 @@
 
 .slick-gridmenu-icon {
   display: inline-block;
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   vertical-align: middle;
   margin-right: 4px;
   background-repeat: no-repeat;
@@ -110,4 +110,18 @@
 /* Disabled */
 .slick-gridmenu-item-disabled {
   color: silver;
+}
+
+/* Divider */
+.slick-gridmenu-item.slick-gridmenu-item-divider {
+  cursor: default;
+  border: none;
+  overflow: hidden;
+  padding: 0;
+  height: 1px;
+  margin: 8px 2px;
+  background-color: #cecece;
+}
+.slick-gridmenu-item-divider.slick-gridmenu-item:hover {
+  background-color: #cecece;
 }

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -203,6 +203,7 @@
 
           if (item.divider) {
             $li.addClass("slick-gridmenu-item-divider");
+            continue;
           }
 
           if (item.tooltip) {

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -41,6 +41,7 @@
    *
    * Available custom menu item options:
    *    title:        Menu item text.
+   *    divider:      Whether the current item is a divider, not an actual command.
    *    disabled:     Whether the item is disabled.
    *    tooltip:      Item tooltip.
    *    command:      A command identifier to be passed to the onCommand event handlers.
@@ -123,7 +124,7 @@
           $header = $('.' + _gridUid + ' .slick-header-left');
         }
         $header.attr('style', 'width: calc(100% - ' + gridMenuWidth +'px)');
-		
+
         // subscribe to the grid, when it's destroyed, we should also destroy the Grid Menu
         grid.onBeforeDestroy.subscribe(destroy);
 
@@ -198,6 +199,10 @@
 
           if (item.disabled) {
             $li.addClass("slick-gridmenu-item-disabled");
+          }
+
+          if (item.divider) {
+            $li.addClass("slick-gridmenu-item-divider");
           }
 
           if (item.tooltip) {
@@ -322,7 +327,7 @@
         var command = $(this).data("command");
         var item = $(this).data("item");
 
-        if (item.disabled) {
+        if (item.disabled || item.divider) {
           return;
         }
 

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -87,7 +87,7 @@
     explicitInitialization: true,
     forceFitColumns: false,
     alwaysShowVerticalScroll: true, // this is necessary when using Grid Menu with a small dataset
-    
+
     // gridMenu Object is optional
     // when not passed, it will act as a regular Column Picker (with default Grid Menu image of drag-handle.png)
     gridMenu: {
@@ -118,6 +118,10 @@
           title: "Toggle Top Panel",
           disabled: false,
           command: "toggle-toppanel"
+        },
+        {
+          divider: true,
+          command: ""
         },
         {
           iconCssClass: "icon-help",

--- a/examples/example-plugin-headermenu.html
+++ b/examples/example-plugin-headermenu.html
@@ -59,8 +59,8 @@
       <hr>
       <h3>Auto-align option</h3>
       <p>
-        Auto-align (defaults to True), will calculate whether it has enough space to show the drop menu to the right. 
-        If it calculates that the drop menu is to fall outside of the viewport, it will automatically align the drop menu to the left.        
+        Auto-align (defaults to True), will calculate whether it has enough space to show the drop menu to the right.
+        If it calculates that the drop menu is to fall outside of the viewport, it will automatically align the drop menu to the left.
       </p>
       <hr>
       <h3>Auto-Align Header Menu Drop</h3>
@@ -115,6 +115,10 @@
             title: "Hide Column",
             command: "hide",
             tooltip: "Can't hide this column"
+          },
+          {
+            divider: true,
+            command: ""
           },
           {
             iconCssClass: "icon-help",
@@ -228,7 +232,7 @@
           return args.columns.reduce(function(inc, c) {
             return inc + (el.columnId === c.id ? 1 : 0);
             }, 0) !== 0;
-        }));	    
+        }));
       console.log('Columns changed via the menu', args.columns);
     });
 

--- a/plugins/slick.headermenu.css
+++ b/plugins/slick.headermenu.css
@@ -57,3 +57,17 @@
 .slick-header-menuitem-disabled {
   color: silver;
 }
+
+/* Divider */
+.slick-header-menuitem.slick-header-menuitem-divider {
+  cursor: default;
+  border: none;
+  overflow: hidden;
+  padding: 0;
+  height: 1px;
+  margin: 8px 2px;
+  background-color: #cecece;
+}
+.slick-header-menuitem-divider.slick-header-menuitem:hover {
+  background-color: #cecece;
+}

--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -46,6 +46,7 @@
    *
    * Available menu item options:
    *    title:            Menu item text.
+   *    divider:          Whether the current item is a divider, not an actual command.
    *    disabled:         Whether the item is disabled.
    *    tooltip:          Item tooltip.
    *    command:          A command identifier to be passed to the onCommand event handlers.
@@ -212,6 +213,11 @@
           $li.addClass("slick-header-menuitem-disabled");
         }
 
+        if (item.divider) {
+          $li.addClass("slick-header-menuitem-divider");
+          continue;
+        }
+
         if (item.tooltip) {
           $li.attr("title", item.tooltip);
         }
@@ -241,9 +247,9 @@
         var gridPos = _grid.getGridPosition();
         if ((leftPos + options.minWidth) >= gridPos.width) {
           leftPos = leftPos - options.minWidth + options.autoAlignOffset;
-        }  
+        }
       }
-      
+
       $menu
         .offset({ top: $(this).offset().top + $(this).height(), left: leftPos });
 
@@ -264,7 +270,7 @@
       var columnDef = $(this).data("column");
       var item = $(this).data("item");
 
-      if (item.disabled) {
+      if (item.disabled || item.divider) {
         return;
       }
 


### PR DESCRIPTION
This brings the possibility to add a `divider` between Header Menu & Grid Menu items, see print screen below (where the red arrow points to). This helps with very long list of menu commands. 

![header_menu_divider](https://user-images.githubusercontent.com/643976/51068662-60635380-15ef-11e9-8cc7-4f88c9337147.png)
![grid_menu_divider](https://user-images.githubusercontent.com/643976/51068667-78d36e00-15ef-11e9-93f8-c650b3d15e24.png)

