### PR TITLE
Fix grid scrolling using mouse wheel, when frozen column/row is set after the grid is initialised

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -539,9 +539,8 @@ if (typeof Slick === "undefined") {
         $viewport
             .on("scroll", handleScroll);
 
-        if (jQuery.fn.mousewheel && ( options.frozenColumn > -1 || hasFrozenRows )) {
-          $viewport
-            .on("mousewheel", handleMouseWheel);
+        if (jQuery.fn.mousewheel) {
+          $viewport.on("mousewheel", handleMouseWheel);
         }
 
         $headerScroller


### PR DESCRIPTION
When the grid initialises it only handles the mouse wheel if either frozen columns or frozen rows have been set.  This results in a bug, whereby if frozen columns or rows are set after the grid has initialised, then placing the mouse over the frozen area and using the scroll wheel results in no scrolling.  In this circumstance it will only scroll when the mouse is placed in the non frozen area.  

Always handling the mousewheel, when the jQuery mouseWheel plugin is set, fixes this issue.