### PR TITLE
fix(selector): cell range selector was not working when at bottom

### DIFF
--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -108,12 +108,24 @@
         e.pageY - _$activeCanvas.offset().top + _rowOffset
       );
 
-      if ((!_grid.canCellBeSelected(end.row, end.cell) )
-        || ( !_isRightCanvas && ( end.cell > _gridOptions.frozenColumn ) )
-        || ( _isRightCanvas && ( end.cell <= _gridOptions.frozenColumn ) )
-        || ( !_isBottomCanvas && ( end.row >= _gridOptions.frozenRow ) )
-        || ( _isBottomCanvas && ( end.row < _gridOptions.frozenRow ) )
+      // ... frozen column(s), 
+      if (_gridOptions.frozenColumn >= 0) {
+        if ((!_isRightCanvas && (end.cell > _gridOptions.frozenColumn)) ||
+            (_isRightCanvas && (end.cell <= _gridOptions.frozenColumn))
         ) {
+            return;
+        }
+      }
+      // ... or frozen row(s)
+      else if (_gridOptions.frozenRow >= 0) {
+        if ((!_isBottomCanvas && (end.row >= _gridOptions.frozenRow)) ||
+            (_isBottomCanvas && (end.row < _gridOptions.frozenRow))
+        ) {
+            return;
+        }
+      }
+      // ... or regular grid (without any frozen options)
+      else if (!_grid.canCellBeSelected(end.row, end.cell)) {
         return;
       }
 

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -113,11 +113,11 @@
         return;
       }
       // ... or frozen row(s)
-      else if (_gridOptions.frozenRow >= 0 && (!_isBottomCanvas && (end.row >= _gridOptions.frozenRow)) || (_isBottomCanvas && (end.row < _gridOptions.frozenRow))) {
+      if (_gridOptions.frozenRow >= 0 && (!_isBottomCanvas && (end.row >= _gridOptions.frozenRow)) || (_isBottomCanvas && (end.row < _gridOptions.frozenRow))) {
         return;
       }
       // ... or regular grid (without any frozen options)
-      else if (!_grid.canCellBeSelected(end.row, end.cell)) {
+      if (!_grid.canCellBeSelected(end.row, end.cell)) {
         return;
       }
 

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -69,7 +69,7 @@
       if ( _gridOptions.frozenColumn > -1 && _isRightCanvas ) {
           _columnOffset = $('.grid-canvas-left').width();
       }
-            
+
       // prevent the grid from cancelling drag'n'drop by default
       e.stopImmediatePropagation();
     }
@@ -108,24 +108,17 @@
         e.pageY - _$activeCanvas.offset().top + _rowOffset
       );
 
-      if (_gridOptions.frozenColumn < 0) {
-        if (!_grid.canCellBeSelected(end.row, end.cell)) {
-          return;
-        }
-      } else {
-        // when having frozen column(s), we need to do extra checks
-        if ( (!_grid.canCellBeSelected( end.row, end.cell ) ) 
-          || ( !_isRightCanvas && ( end.cell > _gridOptions.frozenColumn ) )
-          || ( _isRightCanvas && ( end.cell <= _gridOptions.frozenColumn ) )
-          || ( !_isBottomCanvas && ( end.row >= _gridOptions.frozenRow ) )
-          || ( _isBottomCanvas && ( end.row < _gridOptions.frozenRow ) )
+      if ((!_grid.canCellBeSelected(end.row, end.cell) )
+        || ( !_isRightCanvas && ( end.cell > _gridOptions.frozenColumn ) )
+        || ( _isRightCanvas && ( end.cell <= _gridOptions.frozenColumn ) )
+        || ( !_isBottomCanvas && ( end.row >= _gridOptions.frozenRow ) )
+        || ( _isBottomCanvas && ( end.row < _gridOptions.frozenRow ) )
         ) {
-         return;
-        }
+        return;
       }
 
       dd.range.end = end;
-      
+
       _decorator.show(new Slick.Range(dd.range.start.row, dd.range.start.cell, end.row, end.cell));
     }
 

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -52,22 +52,22 @@
     function handleDragInit(e, dd) {
       // Set the active canvas node because the decorator needs to append its
       // box to the correct canvas
-      _$activeCanvas = $( _grid.getActiveCanvasNode( e ) );
+      _$activeCanvas = $(_grid.getActiveCanvasNode(e));
 
       var c = _$activeCanvas.offset();
 
       _rowOffset = 0;
       _columnOffset = 0;
-      _isBottomCanvas = _$activeCanvas.hasClass( 'grid-canvas-bottom' );
+      _isBottomCanvas = _$activeCanvas.hasClass('grid-canvas-bottom');
 
-      if ( _gridOptions.frozenRow > -1 && _isBottomCanvas ) {
-          _rowOffset = ( _gridOptions.frozenBottom ) ? $('.grid-canvas-bottom').height() : $('.grid-canvas-top').height();
+      if (_gridOptions.frozenRow > -1 && _isBottomCanvas) {
+        _rowOffset = (_gridOptions.frozenBottom) ? $('.grid-canvas-bottom').height() : $('.grid-canvas-top').height();
       }
-      
-      _isRightCanvas = _$activeCanvas.hasClass( 'grid-canvas-right' );
-      
-      if ( _gridOptions.frozenColumn > -1 && _isRightCanvas ) {
-          _columnOffset = $('.grid-canvas-left').width();
+
+      _isRightCanvas = _$activeCanvas.hasClass('grid-canvas-right');
+
+      if (_gridOptions.frozenColumn > -1 && _isRightCanvas) {
+        _columnOffset = $('.grid-canvas-left').width();
       }
 
       // prevent the grid from cancelling drag'n'drop by default
@@ -92,7 +92,7 @@
         dd.startX - $(_canvas).offset().left,
         dd.startY - $(_canvas).offset().top);
 
-      dd.range = {start: start, end: {}};
+      dd.range = { start: start, end: {} };
       _currentlySelectedRange = dd.range;
       return _decorator.show(new Slick.Range(start.row, start.cell));
     }
@@ -109,20 +109,12 @@
       );
 
       // ... frozen column(s), 
-      if (_gridOptions.frozenColumn >= 0) {
-        if ((!_isRightCanvas && (end.cell > _gridOptions.frozenColumn)) ||
-            (_isRightCanvas && (end.cell <= _gridOptions.frozenColumn))
-        ) {
-            return;
-        }
+      if (_gridOptions.frozenColumn >= 0 && (!_isRightCanvas && (end.cell > _gridOptions.frozenColumn)) || (_isRightCanvas && (end.cell <= _gridOptions.frozenColumn))) {
+        return;
       }
       // ... or frozen row(s)
-      else if (_gridOptions.frozenRow >= 0) {
-        if ((!_isBottomCanvas && (end.row >= _gridOptions.frozenRow)) ||
-            (_isBottomCanvas && (end.row < _gridOptions.frozenRow))
-        ) {
-            return;
-        }
+      else if (_gridOptions.frozenRow >= 0 && (!_isBottomCanvas && (end.row >= _gridOptions.frozenRow)) || (_isBottomCanvas && (end.row < _gridOptions.frozenRow))) {
+        return;
       }
       // ... or regular grid (without any frozen options)
       else if (!_grid.canCellBeSelected(end.row, end.cell)) {


### PR DESCRIPTION
- the issue was that if user open the example "example-frozen-columns-and-rows-spreadsheet.html" and he scrolls completely at the bottom of the frozen grid (bottom right) and try to select a cell range, it was not selecting properly

reference issue #329

This is a Work in Progress (DO NOT MERGE YET)
We need to do some more test before merging
