### PR TITLE
fix(selection): copy text selection now working, closes #334

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2238,6 +2238,7 @@ if (typeof Slick === "undefined") {
     }
 
     function handleSelectedRangesChanged(e, ranges) {
+      var previousSelectedRows = selectedRows.slice(0); // shallow copy previously selected rows for later comparison
       selectedRows = [];
       var hash = {};
       for (var i = 0; i < ranges.length; i++) {
@@ -2256,7 +2257,14 @@ if (typeof Slick === "undefined") {
 
       setCellCssStyles(options.selectedCellCssClass, hash);
 
-      trigger(self.onSelectedRowsChanged, {rows: getSelectedRows()}, e);
+      if (simpleArrayEquals(previousSelectedRows, selectedRows)) {
+        trigger(self.onSelectedRowsChanged, {rows: getSelectedRows()}, e);
+      }
+    }
+
+    // compare 2 simple arrays (integers or strings only, do not use to compare object arrays)
+    function simpleArrayEquals(arr1, arr2) {
+      return Array.isArray(arr1) && Array.isArray(arr2) && arr2.sort().toString() !== arr1.sort().toString();
     }
 
     function getColumns() {


### PR DESCRIPTION
- [onSelectedRowsChanged](https://github.com/6pac/SlickGrid/blob/master/slick.grid.js#L2259) should ONLY trigger when new selected rows are different compare to previously selected rows
- the issue comes from "slick.checkboxselectcolumn.js" that has a subscribe to "onSelectedRowsChanged" and when copying text selection, this was triggering a row selection (which is incorrect when row was already selected and doesn't change) and this in turn was calling an "invalidateRow" which finally removes focus of the cell

This fixes issue #334 (and possibly #150), in brief user cannot copy text selection when row is the selected row (even when it's the same selected row). Also note that I have `enableTextSelectionOnCells` enable but that was not helping with my issue. This was also mentioned in a very old issue #9, this PR fixes exactly that but at the source instead of in each plugins (checkbox selector was not covered in #9 fix).

#### Origin of the issue
`handleSelectedRangesChanged` was always triggering the event `onSelectedRowsChanged`, even when the row selected is exactly the same. That was doing a cascading effect of triggering  `handleSelectedRowsChanged` of `slick.checkboxselectcolumn.js`, which inside had an [grid.invalidateRow(row)](https://github.com/6pac/SlickGrid/blob/master/plugins/slick.checkboxselectcolumn.js#L99) that was doing the blur effect since the row was getting re-rendered and when that happens it obviously remove text selection focus since the DOM element gets recreated. 

#### Fix 
We should trigger an `onSelectedRowsChanged` event ONLY when the previously selected row(s) is not the same as the newly selected row(s) and that's it, we don't need to re-render and that fixes text selection. 

Before the fix (I cannot keep text selection, it always blur away on the selected row)
![2019-02-05_18-42-29](https://user-images.githubusercontent.com/643976/52311743-064b7900-2976-11e9-99d8-980a26c6db07.gif)

With FIX
![2019-02-05_18-43-12](https://user-images.githubusercontent.com/643976/52311753-12cfd180-2976-11e9-8da1-3146a16b76f6.gif)
