### PR TITLE
fix(examples): simple button alignement fixes

### DIFF
--- a/examples/example-frozen-columns-and-rows.html
+++ b/examples/example-frozen-columns-and-rows.html
@@ -76,11 +76,11 @@
     <hr/>
     <div style="padding:6px;">
       <label style="width:200px;float:left">Frozen Row:</label>
-      <input type=text id="frozenRow" style="width:100px;" value=5>
+      <input type=text id="frozenRow" style="width:60px;" value="5">
       <button id="setFrozenRow">Set</button>
       <br/><br/>
       <label style="width:200px;float:left">Frozen Column:</label>
-      <input type=text id="frozenColumn" style="width:100px;" value=2>
+      <input type=text id="frozenColumn" style="width:60px;" value="2">
       <button id="setFrozenColumn">Set</button>
       <br/><br/>
       <button id="btnSelectRows">Select first 10 rows</button>

--- a/examples/example-frozen-columns-tabs.html
+++ b/examples/example-frozen-columns-tabs.html
@@ -63,7 +63,7 @@
         <input type=text id="txtSearch" style="width:100px;">
         <br/><br/>
         <label style="width:200px;float:left">Frozen Column:</label>
-        <input type=text id="frozenColumn" style="width:100px;" value=-1>
+        <input type=text id="frozenColumn" style="width:60px;" value=-1>
         <button id="setFrozenColumn">Set</button>
         <br/><br/>
         <button id="btnSelectRows">Select first 10 rows</button>

--- a/examples/example-frozen-columns.html
+++ b/examples/example-frozen-columns.html
@@ -62,7 +62,7 @@
     <input type=text id="txtSearch" style="width:100px;">
     <br/><br/>
     <label style="width:200px;float:left">Frozen Column:</label>
-    <input type=text id="frozenColumn" style="width:100px;" value=-1>
+    <input type=text id="frozenColumn" style="width:60px;" value="-1">
     <button id="setFrozenColumn">Set</button>
     <br/><br/>
     <button id="btnSelectRows">Select first 10 rows</button>

--- a/examples/example-frozen-rows.html
+++ b/examples/example-frozen-rows.html
@@ -58,11 +58,11 @@
     <input type=text id="txtSearch" style="width:100px;">
     <br/><br/>
     <label style="width:200px;float:left">Frozen Row:</label>
-    <input type=text id="frozenRow" style="width:100px;" value=5>
+    <input type=text id="frozenRow" style="width:60px;" value="5">
     <button id="setFrozenRow">Set</button>
     <br>
     <label style="width:200px;float:left">Frozen Bottom Rows:</label>
-    <input type=checkbox id="frozenBottomRows" checked=checked>
+    <input type=checkbox id="frozenBottomRows" style="width:58px;" checked=checked>
     <button id="setFrozenBottomRows">Set</button>
     <br/><br/>
     <button id="btnSelectRows">Select first 10 rows</button>


### PR DESCRIPTION
- all frozen examples have the "set" button in the wrong location, it's a simply styling visual fix

I will merge this PR right away since it's simply cosmetic styling fixes, it only put the button "Set" at a proper location (on the right side of each inputs). See below for the differences

Before
![frozen_before](https://user-images.githubusercontent.com/643976/52313450-8e348180-297c-11e9-9243-3d3fd10cbfed.png)

After
![frozen_after](https://user-images.githubusercontent.com/643976/52313456-94c2f900-297c-11e9-9c49-cbbe7a8b7810.png)
