### PR TITLE
fix(selector): cell selector throws error in console when no scroll

### DIFF
--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -29,8 +29,8 @@
     var _isBottomCanvas;
 
     // Scrollings
-    var _scrollTop;
-    var _scrollLeft;
+    var _scrollTop = 0;
+    var _scrollLeft = 0;
 
     function init(grid) {
       options = $.extend(true, {}, _defaults, options);


### PR DESCRIPTION
- the error is not showing up if user tried scrolling at first, the small issue is related to the fact that 2 variables scrollTop, scrollLeft were not initialized

closes #336 