### PR TITLE
fix(selector): cell selector throws error in console when no scroll

### DIFF
--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -29,8 +29,8 @@
     var _isBottomCanvas;
 
     // Scrollings
-    var _scrollTop;
-    var _scrollLeft;
+    var _scrollTop = 0;
+    var _scrollLeft = 0;
 
     function init(grid) {
       options = $.extend(true, {}, _defaults, options);

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -99,12 +99,12 @@
       _grid.focus();
 
       var startX = dd.startX - $(_canvas).offset().left;
-      if (_gridOptions.frozenColumn >= 0) {
+      if (_gridOptions.frozenColumn >= 0 && _isRightCanvas) {
         startX += _scrollLeft;
       }
 
       var startY = dd.startY - $(_canvas).offset().top;
-      if (_gridOptions.frozenRow >= 0) {
+      if (_gridOptions.frozenRow >= 0 && _isBottomCanvas) {
         startY += _scrollTop;
       }
 


### PR DESCRIPTION
This fix a small issue found that the selection was incorrect on the top section (frozen) after scrolling in a non-frozen area. See animated gif

Relates to previous PR #331

Issue
![2019-02-07_15-04-36](https://user-images.githubusercontent.com/643976/52439697-33209d00-2aea-11e9-9d5f-fe8aec3ab6df.gif)

After Fix
![2019-02-07_15-05-09](https://user-images.githubusercontent.com/643976/52439706-387de780-2aea-11e9-8eb1-25b98111abb7.gif)
