### PR TITLE
Use $headerScroller to calculate height instead of $headers

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2864,10 +2864,14 @@ if (typeof Slick === "undefined") {
     }
 
     function getViewportHeight() {
+      var fullHeight = $paneHeaderL.outerHeight();
+      fullHeight += ( options.showHeaderRow ) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
+      fullHeight += ( options.showFooterRow ) ? options.footerRowHeight + getVBoxDelta($footerRowScroller) : 0;
+
       if (options.autoHeight) {
         viewportH = options.rowHeight
           * getDataLengthIncludingAddNew()
-          + ( ( options.frozenColumn == -1 ) ? $headerScroller.outerHeight() : 0 );
+          + ( ( options.frozenColumn == -1 ) ? fullHeight : 0 );
       } else {
         topPanelH = ( options.showTopPanel ) ? options.topPanelHeight + getVBoxDelta($topPanelScroller) : 0;
         headerRowH = ( options.showHeaderRow ) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2867,7 +2867,7 @@ if (typeof Slick === "undefined") {
       if (options.autoHeight) {
         viewportH = options.rowHeight
           * getDataLengthIncludingAddNew()
-          + ( ( options.frozenColumn == -1 ) ? $headers.outerHeight() : 0 );
+          + ( ( options.frozenColumn == -1 ) ? $headerScroller.outerHeight() : 0 );
       } else {
         topPanelH = ( options.showTopPanel ) ? options.topPanelHeight + getVBoxDelta($topPanelScroller) : 0;
         headerRowH = ( options.showHeaderRow ) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;


### PR DESCRIPTION
This fixes autoheight if there are multple header rows (e.g. column grouping).

With autoHeight set to true, and a plugin that creates column groups by adding an additional <div> to the `<div class="slick-header ui-state-default slick-header-left">` element, the calculated height was ignoring this additional space, resulting in the final row being hidden.

By using `$headerScroller`  to calculate the header height, we take the height of the containing element, which incorporates any additional column grouping headers and the height is set correctly.