### PR TITLE
feat(selectable): add override method to know which row is selectable

### DIFF
--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -24,7 +24,7 @@
       -moz-box-sizing: border-box;
       box-sizing: border-box;
     }
-    
+
     .slick-cell-checkboxsel {
       background: #f0f0f0;
       border-right-color: silver;
@@ -107,6 +107,11 @@
     hideInFilterHeaderRow: isSelectAllShownAsColumnTitle
   });
 
+  // make only Even Rows selectable by using the override function
+  checkboxSelector.selectableOverride(function(row, columnDef, dataContext, grid) {
+    return dataContext.id % 2;
+  });
+
   columns.push(checkboxSelector.getColumnDefinition());
 
   for (var i = 0; i < 10; i++) {
@@ -137,7 +142,7 @@
 
   function toggleWhichRowToShowSelectAll() {
     isSelectAllShownAsColumnTitle = !isSelectAllShownAsColumnTitle;
-    checkboxSelector.setOptions({ 
+    checkboxSelector.setOptions({
       hideInColumnTitleRow: !isSelectAllShownAsColumnTitle,
       hideInFilterHeaderRow: isSelectAllShownAsColumnTitle,
     });

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -107,9 +107,9 @@
     hideInFilterHeaderRow: isSelectAllShownAsColumnTitle
   });
 
-  // make only Even Rows selectable by using the override function
-  checkboxSelector.selectableOverride(function(row, columnDef, dataContext, grid) {
-    return dataContext.id % 2;
+  // make only Odd Rows selectable by using the override function
+  checkboxSelector.selectableOverride(function(row, dataContext, grid) {
+    return (dataContext.id % 2 === 1);
   });
 
   columns.push(checkboxSelector.getColumnDefinition());

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -57,6 +57,7 @@
       <li>Using a fixed header row to implement column-level filters with Checkbox Selector</li>
       <li>Type numbers in textboxes to filter grid data</li>
       <li>Checkbox row select column</li>
+      <li>Override the "canRowBeSelected" with user's custom logic. e.g. every 2nd rows is selectable</li>
       <p>
         <button onclick="toggleHideSelectAllCheckbox()">Toggle show/hide "Select All" checkbox</button>
       </p>
@@ -108,7 +109,7 @@
   });
 
   // make only Odd Rows selectable by using the override function
-  checkboxSelector.selectableOverride(function(row, dataContext, grid) {
+  checkboxSelector.canRowBeSelected(function(row, dataContext, grid) {
     return (dataContext.id % 2 === 1);
   });
 

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -175,6 +175,9 @@
       grid.render();
     });
 
+    grid.onSelectedRowsChanged.subscribe(function (e, args) {
+      console.log("Selected Rows: " + args.rows.toString());
+    });
 
     $(grid.getHeaderRow()).on("change keyup", ":input", function (e) {
       var columnId = $(this).data("columnId");

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -10,7 +10,6 @@
   function CheckboxSelectColumn(options) {
     var _grid;
     var _selectableOverride = null;
-    var _selectableRows = []; // which rows are selectable, default would be all rows when no override is provided
     var _selectAll_UID = createUID();
     var _handler = new Slick.EventHandler();
     var _selectedRowsLookup = {};
@@ -193,8 +192,11 @@
           var rows = [];
           for (var i = 0; i < _grid.getDataLength(); i++) {
             if (typeof _selectableOverride === 'function') {
-              if (_selectableRows.indexOf(i) >= 0) {
-                rows.push(i);
+              var dataContext = _grid.getDataItem(i);
+              if (typeof _selectableOverride === 'function') {
+                if (_selectableOverride(i, dataContext, grid)) {
+                  rows.push(i);
+                }
               }
             } else {
               rows.push(i);
@@ -261,14 +263,12 @@
 
       if (dataContext) {
         if (typeof _selectableOverride === 'function') {
-          if (_selectableOverride(row, columnDef, dataContext, grid)) {
-            _selectableRows.push(row);
+          if (_selectableOverride(row, dataContext, grid)) {
             return _selectedRowsLookup[row]
                 ? "<input id='selector" + UID + "' type='checkbox' checked='checked'><label for='selector" + UID + "'></label>"
                 : "<input id='selector" + UID + "' type='checkbox'><label for='selector" + UID + "'></label>";
           }
         } else {
-          _selectableRows.push(row);
           return _selectedRowsLookup[row]
               ? "<input id='selector" + UID + "' type='checkbox' checked='checked'><label for='selector" + UID + "'></label>"
               : "<input id='selector" + UID + "' type='checkbox'><label for='selector" + UID + "'></label>";

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -290,12 +290,8 @@
       var UID = createUID() + row;
 
       if (dataContext) {
-        if (typeof _selectableOverride === 'function') {
-          if (_selectableOverride(row, dataContext, grid)) {
-            return _selectedRowsLookup[row]
-                ? "<input id='selector" + UID + "' type='checkbox' checked='checked'><label for='selector" + UID + "'></label>"
-                : "<input id='selector" + UID + "' type='checkbox'><label for='selector" + UID + "'></label>";
-          }
+        if (!checkSelectableOverride(row, dataContext, grid)) {
+          return null;
         } else {
           return _selectedRowsLookup[row]
               ? "<input id='selector" + UID + "' type='checkbox' checked='checked'><label for='selector" + UID + "'></label>"


### PR DESCRIPTION
- provide a way to define if a row can be selectable or not through a method that can be override
- fixes #343

```js
  var checkboxSelector = new Slick.CheckboxSelectColumn({ ... });

  // make only Even Rows selectable by overriding canRowBeSelected callback
  checkboxSelector.canRowBeSelected(function(row, columnDef, dataContext, grid) {
    return dataContext.id % 2;
  });
```

What do people prefer to use as the method to override? 
1. `selectableOverride` 
2. `canRowBeSelected`

We are going with `canRowBeSelected` as this is more readable and obvious. 

![selectable_override](https://user-images.githubusercontent.com/643976/53313145-01e3f300-3886-11e9-917e-35180a26e23b.png)