### PR TITLE
fix(cellSelection): deep copy so we can use of shift+arrow, closes #341

### DIFF
--- a/plugins/slick.cellselectionmodel.js
+++ b/plugins/slick.cellselectionmodel.js
@@ -13,7 +13,7 @@
     var _self = this;
     var _selector;
 
-    if (typeof options === "undefined" || typeof options.cellRangeSelector === "undefined") {    
+    if (typeof options === "undefined" || typeof options.cellRangeSelector === "undefined") {
       _selector = new Slick.CellRangeSelector({
         "selectionCss": {
           "border": "2px solid black"
@@ -84,7 +84,7 @@
 
       // if range has not changed, don't fire onSelectedRangesChanged
       var rangeHasChanged = !rangesAreEqual(_ranges, ranges);
-      
+
       _ranges = removeInvalidRanges(ranges);
       if (rangeHasChanged) { _self.onSelectedRangesChanged.notify(_ranges); }
     }
@@ -130,11 +130,11 @@
       if (active && e.shiftKey && !metaKey && !e.altKey &&
         (e.which == 37 || e.which == 39 || e.which == 38 || e.which == 40)) {
 
-        ranges = getSelectedRanges();
+        ranges = getSelectedRanges().slice();
         if (!ranges.length)
           ranges.push(new Slick.Range(active.row, active.cell));
 
-        // keyboard can work with last range only          
+        // keyboard can work with last range only
         last = ranges.pop();
 
         // can't handle selection out of active cell
@@ -157,7 +157,7 @@
           dRow += dirRow;
         }
 
-        // define new selection range 
+        // define new selection range
         var new_last = new Slick.Range(active.row, active.cell, active.row + dirRow * dRow, active.cell + dirCell * dCell);
         if (removeInvalidRanges([new_last]).length) {
           ranges.push(new_last);


### PR DESCRIPTION
- summary of the issue explained: The ranges variable returned from getSelectedRanges() is a member variable, which is being passed to the setSelectedRanges function on line 172. In the setSelectedRanges, the same member variable is being compared to itself, resulting rangeHasChanged false. So, I can't change selected range using keyboard with shift Key.

Thanks for the help of @SatanEnglish, I tested the small change and confirm what we see below with the animated gif. Doing a deep copy with `slice()` does fix the issue. 

Using Shift + Arrow keys, Before the fix
![2019-03-01_20-32-38](https://user-images.githubusercontent.com/2100563/53623160-2adafe00-3c61-11e9-9c39-957825dada82.gif)


Using Shift + Arrow keys, **After** the fix
![2019-03-01_20-31-46](https://user-images.githubusercontent.com/2100563/53623128-0da62f80-3c61-11e9-9ab2-b198d9a830b6.gif)
