### PR TITLE
refactor(selection): rename override to selectableOverride

### DIFF
--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -57,7 +57,7 @@
       <li>Using a fixed header row to implement column-level filters with Checkbox Selector</li>
       <li>Type numbers in textboxes to filter grid data</li>
       <li>Checkbox row select column</li>
-      <li>Override the "canRowBeSelected" with user's custom logic. e.g. every 2nd rows is selectable</li>
+      <li>User can override the logic to display the row checkbox with "selectableOverride". e.g. every 2nd rows is selectable</li>
       <p>
         <button onclick="toggleHideSelectAllCheckbox()">Toggle show/hide "Select All" checkbox</button>
       </p>
@@ -109,7 +109,7 @@
   });
 
   // make only Odd Rows selectable by using the override function
-  checkboxSelector.canRowBeSelected(function(row, dataContext, grid) {
+  checkboxSelector.selectableOverride(function(row, dataContext, grid) {
     return (dataContext.id % 2 === 1);
   });
 


### PR DESCRIPTION
- to stick with a convention having the word override in the method name to easily identify what the method does

This is just a rename for convention purposes, it renames the override method previously added in PR #343 to the new name `selectableOverride`, to easily identify what the method does

Example with the new name
```js
  var checkboxSelector = new Slick.CheckboxSelectColumn({ ... });

  // make every 2nd selectable by providing custom logic
  checkboxSelector.selectableOverride(function(row, columnDef, dataContext, grid) {
    return dataContext.id % 2;
  });
```