### PR TITLE
feat(gridMenu): add grid UID to the GridMenu control

### DIFF
--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -145,7 +145,7 @@
         }
         $button.insertBefore($header);
 
-        $menu = $('<div class="slick-gridmenu" style="display: none" />').appendTo(document.body);
+        $menu = $('<div class="slick-gridmenu ' + _gridUid + '" style="display: none" />').appendTo(document.body);
         var $close = $('<button type="button" class="close" data-dismiss="slick-gridmenu" aria-label="Close"><span class="close" aria-hidden="true">&times;</span></button>').appendTo($menu);
 
         var $customMenu = $('<div class="slick-gridmenu-custom" />');
@@ -178,7 +178,7 @@
         _grid.onColumnsReordered.unsubscribe(updateColumnOrder);
         _grid.onBeforeDestroy.unsubscribe();
         $(document.body).off("mousedown." + _gridUid, handleBodyMouseDown);
-        $("div.slick-gridmenu").hide(_options.fadeSpeed);
+        $("div.slick-gridmenu." + _gridUid).hide(_options.fadeSpeed);
         $menu.remove();
         $button.remove();
       }


### PR DESCRIPTION
- we do this because the GridMenu is pushed on the body so adding this adds a way to associuate the grid menu with the correct grid

![image](https://user-images.githubusercontent.com/643976/54872215-09b88980-4d97-11e9-996b-6c9c4e970806.png)
