### PR TITLE
fix(rowDetail): override formatter, don't use global grid instance

### DIFF
--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -364,13 +364,14 @@
         // how many grid rows do we want to use for the detail panel
         // also note that the detail view adds an extra 1 row for padding purposes
         // example, if you choosed 6 panelRows, the display will in fact use 5 rows
-        panelRows: 6
-      });
+        panelRows: 6,
 
-      // make only every 2nd row an expandable row,
-      // by using the override function to provide custom logic of which row is expandale
-      detailView.expandableOverride(function(row, dataContext, grid) {
-        return (dataContext.id % 2 === 1);
+        // make only every 2nd row an expandable row,
+        // by using the override function to provide custom logic of which row is expandable
+        // you can override it here in the options or externally by calling the method on the plugin instance
+        expandableOverride: function(row, dataContext, grid) {
+          return (dataContext.id % 2 === 1);
+        }
       });
 
       // push the plugin as the first column

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -10,6 +10,7 @@
  * AVAILABLE ROW DETAIL OPTIONS:
  *    cssClass:               A CSS class to be added to the row detail
  *    expandedClass:          Extra classes to be added to the expanded Toggle
+ *    expandableOverride:     callback method that user can override the default behavior of making every row an expandable row (the logic to show or not the expandable icon).
  *    collapsedClass:         Extra classes to be added to the collapse Toggle
  *    loadOnce:               Defaults to false, when set to True it will load the data once and then reuse it.
  *    preTemplate:            Template that will be used before the async process (typically used to show a spinner/loading)
@@ -22,7 +23,7 @@
  *    saveDetailViewOnScroll: Defaults to true, which will save the row detail view in a cache when it detects that it will become out of the viewport buffer
  *    useSimpleViewportCalc:  Defaults to false, which will use simplified calculation of out or back of viewport visibility
  *
- * AVAILABLE PUBLIC OPTIONS:
+ * AVAILABLE PUBLIC METHODS:
  *    init:                 initiliaze the plugin
  *    expandableOverride:   callback method that user can override the default behavior of making every row an expandable row (the logic to show or not the expandable icon).
  *    destroy:              destroy the plugin and it's events
@@ -118,6 +119,11 @@
     var _gridRowBuffer = 0;
     var _rowIdsOutOfViewport = [];
     var _options = $.extend(true, {}, _defaults, options);
+
+    // user could override the expandable icon logic from within the options or after instantiating the plugin
+    if(typeof _options.expandableOverride === 'function') {
+      expandableOverride(_options.expandableOverride);
+    }
 
     /**
      * Initialize the plugin, which requires user to pass the SlickGrid Grid object
@@ -596,7 +602,7 @@
     }
 
     /** The Formatter of the toggling icon of the Row Detail */
-    function detailSelectionFormatter(row, cell, value, columnDef, dataContext) {
+    function detailSelectionFormatter(row, cell, value, columnDef, dataContext, grid) {
       if (!checkExpandableOverride(row, dataContext, grid)) {
         return null;
       } else {


### PR DESCRIPTION
- this was throwing an error when user doesn't have a global "grid" instance, this was not showing up in the example 16 because it has a "grid" global variable
- also add new way of passing the override method, user can now also pass it directly in the plugin options. So we can now override via the options or via the plugin instance.