### PR TITLE
fix(autoheight): updateRowCount shouldn't set virtual height, fixes #364

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3074,18 +3074,23 @@ if (typeof Slick === "undefined") {
         resetActiveCell();
       }
 
-      th = Math.max(options.rowHeight * numberOfRows, tempViewportH - scrollbarDimensions.height);
-      if (th < maxSupportedCssHeight) {
-        // just one page
-        h = ph = th;
-        n = 1;
-        cj = 0;
+      var oldH = h;
+      if (options.autoHeight) {
+        h =  options.rowHeight * numberOfRows;
       } else {
-        // break into pages
-        h = maxSupportedCssHeight;
-        ph = h / 100;
-        n = Math.floor(th / ph);
-        cj = (th - h) / (n - 1);
+        th = Math.max(options.rowHeight * numberOfRows, tempViewportH - scrollbarDimensions.height);
+        if (th < maxSupportedCssHeight) {
+          // just one page
+          h = ph = th;
+          n = 1;
+          cj = 0;
+        } else {
+          // break into pages
+          h = maxSupportedCssHeight;
+          ph = h / 100;
+          n = Math.floor(th / ph);
+          cj = (th - h) / (n - 1);
+        }
       }
 
       if (h !== oldH) {


### PR DESCRIPTION
- supersede PR #209 (that older PR was done prior to the frozen feature)
- this fix avoid some grid using autoheight to go circular reference (2 references calling each other).

The infinite loop comes from 2 references calling each other until the browser crashes with maximum calls. The reference is `updateRowCount()` calls `resizeCanvas()` which calls `updateRowCount()`, and so on... This only happen, and is only possible, with the flag `autoHeight` enabled. 