### PR TITLE
Fixed an issue with getPluginByName function

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -616,7 +616,7 @@ if (typeof Slick === "undefined") {
     }
 
     function getPluginByName(name) {
-      for (var i = plugins.length; i >= 0; i--) {
+      for (var i = plugins.length-1; i >= 0; i--) {
         if (plugins[i].pluginName === name) {
           return plugins[i];
         }


### PR DESCRIPTION
There was an small issue with getPluginByName function which eventually never returns plugin. It starts with index equals to the length of plugins array and throw undefined error on line 620 due to index out of range