### PR TITLE
fix(plugin): Row Detail always show a scroll even when has enough space

### DIFF
--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -651,7 +651,7 @@
           html.push('<div class="dynamic-cell-detail cellDetailView_', dataContext.id, '" ');   //apply custom css to detail
           html.push('style="height:', outterHeight, 'px;'); //set total height of padding
           html.push('top:', rowHeight, 'px">');             //shift detail below 1st row
-          html.push('<div class="detail-container detailViewContainer_', dataContext.id, '" style="min-height:' + dataContext[_keyPrefix + 'height'] + 'px">'); //sub ctr for custom styling
+          html.push('<div class="detail-container detailViewContainer_', dataContext.id, '">'); //sub ctr for custom styling
           html.push('<div class="innerDetailView_', dataContext.id, '">', dataContext[_keyPrefix + 'detailContent'], '</div></div>');
           // &omit a final closing detail container </div> that would come next
 


### PR DESCRIPTION
- this is a small fix that was already discussed in this [post](https://github.com/6pac/SlickGrid/pull/351#issuecomment-469947531) but I forgot to apply it earlier. 