### PR TITLE
add option to hide column names

### DIFF
--- a/examples/example8-alternative-display.html
+++ b/examples/example8-alternative-display.html
@@ -73,6 +73,9 @@
                                                            target=_blank>micro-templates</a> while still using
           SlickGrid's virtual rendering technology.
         </li>
+        <li>
+          Hiding column names
+        </li>
       </ul>
         <h2>View Source:</h2>
         <ul>
@@ -151,7 +154,8 @@
     editable: false,
     enableAddRow: false,
     enableCellNavigation: false,
-    enableColumnReorder: false
+    enableColumnReorder: false,
+    showColumnNames: false
   };
 
   var compiled_template = tmpl("cell_template");

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -76,6 +76,7 @@ if (typeof Slick === "undefined") {
       asyncPostRenderCleanupDelay: 40,
       autoHeight: false,
       editorLock: Slick.GlobalEditorLock,
+      showColumnNames: true,
       showHeaderRow: false,
       headerRowHeight: 25,
       createFooterRow: false,
@@ -409,6 +410,10 @@ if (typeof Slick === "undefined") {
       $topPanelR = $("<div class='slick-top-panel' style='width:10000px' />").appendTo($topPanelScrollerR);
 
       $topPanel = $().add($topPanelL).add($topPanelR);
+
+      if (!options.showColumnNames) {
+        $headerScroller.hide();
+      }
 
       if (!options.showTopPanel) {
         $topPanelScroller.hide();
@@ -2353,6 +2358,10 @@ if (typeof Slick === "undefined") {
 
       makeActiveCellNormal();
 
+      if (args.showColumnNames !== undefined) {
+        setColumnHeaderVisibility(args.showColumnNames);
+      };
+
       if (options.enableAddRow !== args.enableAddRow) {
         invalidateRow(getDataLength());
       }
@@ -2433,6 +2442,27 @@ if (typeof Slick === "undefined") {
           $headerRowScroller.slideDown("fast", resizeCanvas);
         } else {
           $headerRowScroller.slideUp("fast", resizeCanvas);
+        }
+      }
+    }
+
+    function setColumnHeaderVisibility(visible, animate) {
+      if (options.showColumnLabels != visible) {
+        options.showColumnLabels = visible;
+        if (visible) {
+          if (animate) {
+            $headerScroller.slideDown("fast", resizeCanvas);
+          } else {
+            $headerScroller.show();
+            resizeCanvas();
+          }
+        } else {
+          if (animate) {
+            $headerScroller.slideUp("fast", resizeCanvas);
+          } else {
+            $headerScroller.hide();
+            resizeCanvas();
+          }
         }
       }
     }
@@ -2892,6 +2922,8 @@ if (typeof Slick === "undefined") {
           * getDataLengthIncludingAddNew()
           + ( ( options.frozenColumn == -1 ) ? fullHeight : 0 );
       } else {
+        columnNamesH = ( options.showColumnLabels ) ? parseFloat($.css($headerScroller[0], "height"))
+          + getVBoxDelta($headerScroller) : 0;
         topPanelH = ( options.showTopPanel ) ? options.topPanelHeight + getVBoxDelta($topPanelScroller) : 0;
         headerRowH = ( options.showHeaderRow ) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
         footerRowH = ( options.showFooterRow ) ? options.footerRowHeight + getVBoxDelta($footerRowScroller) : 0;
@@ -2900,8 +2932,7 @@ if (typeof Slick === "undefined") {
         viewportH = parseFloat($.css($container[0], "height", true))
           - parseFloat($.css($container[0], "paddingTop", true))
           - parseFloat($.css($container[0], "paddingBottom", true))
-          - parseFloat($.css($headerScroller[0], "height"))
-          - getVBoxDelta($headerScroller)
+          - columnNamesH
           - topPanelH
           - headerRowH
           - footerRowH
@@ -5353,6 +5384,7 @@ if (typeof Slick === "undefined") {
       "removeCellCssStyles": removeCellCssStyles,
       "getCellCssStyles": getCellCssStyles,
       "getFrozenRowOffset": getFrozenRowOffset,
+      "setColumnHeaderVisibility": setColumnHeaderVisibility,
 
       "init": finishInitialization,
       "destroy": destroy,


### PR DESCRIPTION
I have a use case where I need to display one record per a cell rather than the usual per a row. This means the column title is superfulous and I want to remove it (also saves some UI space).
Another use case could be where the cell content is almost self-expanitory like in [example8](http://6pac.github.io/SlickGrid/examples/example8-alternative-display.html).
I haven't tested this much but the option defaults to off so it shouldn't affect any existing code.

