### PR TITLE
feat(gridMenu): add columnDef option to exclude a column from grid menu

### DIFF
--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -384,7 +384,16 @@
             ordered[i] = current.shift();
           }
         }
-        columns = ordered;
+
+        // filter out excluded column header when necessary
+        // (works with IE9+, older browser requires a polyfill for the filter to work, visit MDN for more info)
+        if (Array.isArray(ordered) && typeof ordered.filter === 'function') {
+          columns = ordered.filter(function(columnDef) {
+            return !columnDef.excludeFromGridMenu;
+          });
+        } else {
+          columns = ordered;
+        }
       }
 
       function updateColumn(e) {

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -137,7 +137,7 @@
       ]
     }
   };
-  var columns = [];
+  var columns = [{ id: 'id', field: 'id', name: 'Id', width: 40, excludeFromGridMenu: true }];
   var columnFilters = {};
 
   for (var i = 0; i < 10; i++) {

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -137,7 +137,7 @@
       ]
     }
   };
-  var columns = [{ id: 'id', field: 'id', name: 'Id', width: 40, excludeFromGridMenu: true }];
+  var columns = [{ id: 'id', field: 'id', name: '#', width: 40, excludeFromGridMenu: true }];
   var columnFilters = {};
 
   for (var i = 0; i < 10; i++) {


### PR DESCRIPTION
Option to exclude certain column header(s) from the Grid Menu. 
For example, print screen below shows that the "Id" column header is excluded from the Grid Menu.
Another PR for the same feature on the Column Picker will follow.

The code is the following: 
```js
var columns = [
   { id: 'id', field: 'id', name: 'Id', width: 40, excludeFromGridMenu: true },
   // ...
];
```

@6pac 
Also note, that I slipped a [commit](https://github.com/6pac/SlickGrid/commit/bfe6512b3dc6c5ea2585661bd134dff56ec335b0) about Row Detail without a PR by mistake (forgot to create a new branch on my local before I push). Sorry about that, the info is all in the PR.


![image](https://user-images.githubusercontent.com/643976/58045370-45aa6980-7b10-11e9-8c16-2e3fcdfcebb5.png)
