### PR TITLE
feat(columnPicker): add columnDef option to exclude a column from picker

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -111,7 +111,7 @@
         } else {
           columnLabel = defaults.headerColumnValueExtractor(columns[i]);
         }
-        
+
         $("<label />")
           .html(columnLabel)
           .prepend($input)
@@ -176,7 +176,16 @@
           ordered[i] = current.shift();
         }
       }
-      columns = ordered;
+
+      // filter out excluded column header when necessary
+      // (works with IE9+, older browser requires a polyfill for the filter to work, visit MDN for more info)
+      if (Array.isArray(ordered) && typeof ordered.filter === 'function') {
+        columns = ordered.filter(function(columnDef) {
+          return !columnDef.excludeFromColumnPicker;
+        });
+      } else {
+        columns = ordered;
+      }
     }
 
     function updateColumn(e) {

--- a/examples/example4-model.html
+++ b/examples/example4-model.html
@@ -115,7 +115,7 @@ var dataView;
 var grid;
 var data = [];
 var columns = [
-  {id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 40, cannotTriggerInsert: true, resizable: false, selectable: false },
+  {id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 40, cannotTriggerInsert: true, resizable: false, selectable: false, excludeFromColumnPicker: true },
   {id: "title", name: "Title", field: "title", width: 120, minWidth: 120, cssClass: "cell-title", editor: Slick.Editors.Text, validator: requiredFieldValidator, sortable: true},
   {id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Text, sortable: true},
   {id: "%", defaultSortAsc: false, name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete, sortable: true},
@@ -128,7 +128,7 @@ var options = {
   columnPicker: {
     columnTitle: "Columns",
     hideForceFitButton: false,
-    hideSyncResizeButton: false, 
+    hideSyncResizeButton: false,
     forceFitTitle: "Force fit columns",
     syncResizeTitle: "Synchronous resize",
   },


### PR DESCRIPTION
Similar to PR #376 but for the Column Picker

Option to exclude certain column header(s) from the Column Picker. 
For example, print screen below shows that the "#" column header is excluded from the Column Picker.

The code is the following: 
```js
var columns = [
   { id: 'id', field: 'id', name: 'Id', width: 40, excludeFromColumnPicker: true },
   // ...
];
```

![image](https://user-images.githubusercontent.com/643976/58044900-f9125e80-7b0e-11e9-92bb-99b8919ac091.png)
