### PR TITLE
fix style of undefined rowNode

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3441,7 +3441,7 @@ if (typeof Slick === "undefined") {
 
     function updateRowPositions() {
       for (var row in rowsCache) {
-        rowsCache[row].rowNode.style.top = getRowTop(row) + "px";
+        rowsCache[parseRowToNumber(row)].rowNode[0].style.top = getRowTop(parseRowToNumber(row)) + "px";
       }
     }
 
@@ -4112,10 +4112,14 @@ if (typeof Slick === "undefined") {
       for (var row in rowsCache) {
         for (var i in rowsCache[row].rowNode) {
           if (rowsCache[row].rowNode[i] === rowNode)
-          return (row ? parseInt(row) : 0);
+          return parseRowToNumber(row);
         }
       }
       return null;
+    }
+
+    function parseRowToNumber(row) {
+      return (row ? parseInt(row) : 0);
     }
 
     function getFrozenRowOffset(row) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3441,7 +3441,8 @@ if (typeof Slick === "undefined") {
 
     function updateRowPositions() {
       for (var row in rowsCache) {
-        rowsCache[parseRowToNumber(row)].rowNode[0].style.top = getRowTop(parseRowToNumber(row)) + "px";
+        var rowNumber = row ? parseInt(row) : 0;
+        rowsCache[rowNumber].rowNode[0].style.top = getRowTop(rowNumber) + "px";
       }
     }
 
@@ -4112,14 +4113,10 @@ if (typeof Slick === "undefined") {
       for (var row in rowsCache) {
         for (var i in rowsCache[row].rowNode) {
           if (rowsCache[row].rowNode[i] === rowNode)
-          return parseRowToNumber(row);
+          return (row ? parseInt(row) : 0);
         }
       }
       return null;
-    }
-
-    function parseRowToNumber(row) {
-      return (row ? parseInt(row) : 0);
     }
 
     function getFrozenRowOffset(row) {


### PR DESCRIPTION
When calling `updateRowPositions()` on a large table it was not appropriately getting the `rowNode` which caused a `could not get style of undefined` error. Getting the first element of the rowNode array fixes the issue.

Note: I refactored the row parseInt logic into a function to prevent the duplication of code.

Thanks!