### PR TITLE
Add missings var which cause troubles to terser when parsing es2015.

### DIFF
--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -91,7 +91,7 @@
       var lookup = {}, row, i;
       var disabledCount = 0;
       if (typeof _selectableOverride === 'function') {
-        for (k = 0; k < _grid.getDataLength(); k++) {
+        for (var k = 0; k < _grid.getDataLength(); k++) {
           // If we are allowed to select the row
           var dataItem = _grid.getDataItem(k);
           if (!checkSelectableOverride(i, dataItem, _grid)) {

--- a/plugins/slick.draggablegrouping.js
+++ b/plugins/slick.draggablegrouping.js
@@ -260,7 +260,7 @@
     }
 
     function setDroppedGroups(groupingInfo) {
-      groupingInfos = (groupingInfo instanceof Array) ? groupingInfo : [groupingInfo];
+      var groupingInfos = (groupingInfo instanceof Array) ? groupingInfo : [groupingInfo];
       dropboxPlaceholder.hide()
       for (var i = 0; i < groupingInfos.length; i++) {
         var column = $(_grid.getHeaderColumn(groupingInfos[i]));

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -94,6 +94,7 @@
     var _grid;
     var _gridOptions;
     var _gridUid;
+    var _dataView;
     var _expandableOverride = null;
     var _self = this;
     var _lastRange = null;

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2919,7 +2919,7 @@ if (typeof Slick === "undefined") {
         topPanelH = ( options.showTopPanel ) ? options.topPanelHeight + getVBoxDelta($topPanelScroller) : 0;
         headerRowH = ( options.showHeaderRow ) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
         footerRowH = ( options.showFooterRow ) ? options.footerRowHeight + getVBoxDelta($footerRowScroller) : 0;
-        preHeaderH = (options.createPreHeaderPanel && options.showPreHeaderPanel) ? options.preHeaderPanelHeight + getVBoxDelta($preHeaderPanelScroller) : 0;
+        var preHeaderH = (options.createPreHeaderPanel && options.showPreHeaderPanel) ? options.preHeaderPanelHeight + getVBoxDelta($preHeaderPanelScroller) : 0;
 
         viewportH = parseFloat($.css($container[0], "height", true))
           - parseFloat($.css($container[0], "paddingTop", true))
@@ -4290,7 +4290,7 @@ if (typeof Slick === "undefined") {
             : frozenRowsHeight;
         }
 
-        cell = getCellFromPoint($activeCellOffset.left, Math.ceil($activeCellOffset.top) - rowOffset);
+        var cell = getCellFromPoint($activeCellOffset.left, Math.ceil($activeCellOffset.top) - rowOffset);
 
         activeRow = cell.row;
         activeCell = activePosX = activeCell = activePosX = getCellFromNode(activeCellNode);


### PR DESCRIPTION
It happens when building an angular project that run terser multiple times to reduce the size of the bundle.