### PR TITLE
feat(e2e): add Cypress to the project for E2E testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .gitk*
 .idea/*
 .DS_Store
+yarn-error.log
+yarn.lock
 node_modules/*
 SlickgridRelease*
 nuget*
+testresult.xml

--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ examples
 nuget*
 SlickgridRelease*
 tests
+testresult.xml

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Cypress Open GUI",
+      "type": "shell",
+      "command": "yarn run cypress:open",
+      "problemMatcher": []
+    },
+    {
+      "label": "Cypress CI",
+      "type": "shell",
+      "command": "yarn run cypress:ci",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,7 @@
+{
+    "baseUrl": "https://6pac.github.io/SlickGrid",
+    "baseExampleUrl": "https://6pac.github.io/SlickGrid/examples",
+    "video": false,
+    "viewportWidth": 1200,
+    "viewportHeight": 800
+  }

--- a/cypress/integration/exampleGridMenu.spec.js
+++ b/cypress/integration/exampleGridMenu.spec.js
@@ -1,0 +1,70 @@
+/// <reference types="Cypress" />
+
+describe('Example - Grid Menu', () => {
+  const fullTitles = ['#', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];
+  const titlesWithoutId = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];
+
+
+  it('should display Example Grid Menu', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example-grid-menu.html`);
+    cy.get('h2').should('contain', 'Demonstrates:');
+    cy.contains('This example demonstrates using the Slick.Controls.GridMenu ');
+  });
+
+  it('should have exact Column Titles in the grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+  });
+
+  it('should click on the Grid Menu to hide the column A from being displayed', () => {
+    cy.get('#myGrid')
+      .find('button.slick-gridmenu-button')
+      .trigger('click')
+      .click();
+
+    cy.get('#myGrid')
+      .get('.slick-gridmenu:visible')
+      .find('.slick-gridmenu-list')
+      .children('li:nth-child(1)')
+      .children('label')
+      .should('contain', 'A')
+      .click();
+
+    cy.get('#myGrid')
+      .get('.slick-gridmenu:visible')
+      .find('span.close')
+      .trigger('click')
+      .click();
+
+    const smallerTitleList = titlesWithoutId.slice(1);
+    cy.get('#myGrid')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(smallerTitleList[index]));
+  });
+
+  it('should click on the External Grid Menu to show the column A as 1st column again', () => {
+    cy.get('button')
+      .contains('Grid Menu')
+      .trigger('click')
+      .click();
+
+    cy.get('#myGrid')
+      .get('.slick-gridmenu:visible')
+      .find('.slick-gridmenu-list')
+      .children('li:nth-child(1)')
+      .children('label')
+      .should('contain', 'A')
+      .click();
+
+    cy.get('[data-dismiss=slick-gridmenu]')
+      .click({ force: true });
+
+    cy.get('#myGrid')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(titlesWithoutId[index]));
+  });
+});

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,0 +1,17 @@
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This is will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -46,7 +46,7 @@
       <li>Possibility to attach the Grid Menu to an external button (try clicking on the button below).</li>
       <li>You can also use some events like "onMenuClose()" and to trigger a resize of the columns with "autosizeColumns()" when "forceFitColumns: false"</li>
       <p>
-        <button onclick="toggleGridMenu(event)"><img src="../images/drag-handle.png"/> Grid Menu</button>
+        <button id="external-gridmenu" onclick="toggleGridMenu(event)"><img src="../images/drag-handle.png"/> Grid Menu</button>
       </p>
       <p>
         Always show vertical scroll (with "alwaysShowVerticalScroll" flag), so that it works with small and large dataset.

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "grid"
   ],
   "author": "Michael Leibman <michael.leibman@gmail.com>",
-  "contributors": [ 
-    "Ben McIntyre <email.ben.mcintyre@gmail.com>" 
+  "contributors": [
+    "Ben McIntyre <email.ben.mcintyre@gmail.com>"
   ],
   "license": "MIT",
   "bugs": {
@@ -25,10 +25,14 @@
   },
   "homepage": "https://github.com/6pac/SlickGrid#readme",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "cypress:ci": "node node_modules/cypress/bin/cypress run --reporter xunit --reporter-options output=testresult.xml",
+    "cypress:open": "node node_modules/cypress/bin/cypress open"
   },
   "dependencies": {
     "jquery": ">=1.8.0",
     "jquery-ui": ">=1.8.0"
+  },
+  "devDependencies": {
+    "cypress": "^3.3.1"
   }
 }


### PR DESCRIPTION
I think it's time to start looking at adding E2E tests (UI testing). We used to have Selenium back in the days, but that was hard to install and run. The JavaScript world have come a long way and new tools, the best tool that I've found so far and is super easy to install (it's all in the PR) is [Cypress.io](https://www.cypress.io), it's quite easy to program tests and it works universally. It doesn't need any framework or anything except running an npm command to install it, just run `npm install` (or `yarn`) and then run `npm run cypress:open` or even better if you have VScode, just run the task "Cypress Open GUI" that I added. Here's a quick [intro video](https://www.youtube.com/watch?v=VvLocgtCQnY) of Cypress

There's a ton of things we can do with Cypress, drag & drop, click buttons, scroll, etc... and what is funny is that while doing this very quick and basic test, I actually found a bug in the Grid Menu which I'll have to fix later (now fixed in PR #402). 

See animated GIF of the very simple test I added for the Grid Menu example. It runs the tests against the GitHub demo page. 

Also note, this is just a structure to start with, I intend to add more in the future and also wish (plan) to add this to our build process, so there would be less surprises. First thing to do in the future, would be to start looking into running this locally instead of the now github demo page. 

![1Zj4DhGOx1](https://user-images.githubusercontent.com/643976/61429183-3fa7ed80-a8f3-11e9-870d-c06db325aa24.gif)
