### PR TITLE
fix(header): remove all showColumnLabels and replace by showColumnHeader

### DIFF
--- a/examples/example8-alternative-display.html
+++ b/examples/example8-alternative-display.html
@@ -156,7 +156,6 @@
     enableCellNavigation: false,
     enableColumnReorder: false,
     showColumnHeader: false,
-	  showColumnLabels: false,
   };
 
   var compiled_template = tmpl("cell_template");

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -77,7 +77,6 @@ if (typeof Slick === "undefined") {
       autoHeight: false,
       editorLock: Slick.GlobalEditorLock,
       showColumnHeader: true,
-      showColumnLabels: true,
       showHeaderRow: false,
       headerRowHeight: 25,
       createFooterRow: false,
@@ -2826,8 +2825,8 @@ if (typeof Slick === "undefined") {
     }
 
     function setColumnHeaderVisibility(visible, animate) {
-      if (options.showColumnLabels != visible) {
-        options.showColumnLabels = visible;
+      if (options.showColumnHeader != visible) {
+        options.showColumnHeader = visible;
         if (visible) {
           if (animate) {
             $headerScroller.slideDown("fast", resizeCanvas);
@@ -3301,7 +3300,7 @@ if (typeof Slick === "undefined") {
           * getDataLengthIncludingAddNew()
           + ( ( options.frozenColumn == -1 ) ? fullHeight : 0 );
       } else {
-        columnNamesH = ( options.showColumnLabels ) ? parseFloat($.css($headerScroller[0], "height"))
+        columnNamesH = ( options.showColumnHeader ) ? parseFloat($.css($headerScroller[0], "height"))
           + getVBoxDelta($headerScroller) : 0;
         topPanelH = ( options.showTopPanel ) ? options.topPanelHeight + getVBoxDelta($topPanelScroller) : 0;
         headerRowH = ( options.showHeaderRow ) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;


### PR DESCRIPTION
As discussed in this [post](https://github.com/6pac/SlickGrid/issues/392#issuecomment-512641456), 
remove all `showColumnLabels` and replace by `showColumnHeader`, also tested the `example8-alternative-display.html`. My repos are also all working as expected, so that does seem like a typo and using only `showColumnHeader` is what we needed from the start.

@6pac 
Can we remove all the `LogColWidths()` calls or do you still need them? I don't mind leaving the method there, but I'd like to at least comment out the method calls.