### PR TITLE
fix(picker): column exclude from ColumnPicker, GridMenu caussing issue

### DIFF
--- a/controls/slick.columnpicker.css
+++ b/controls/slick.columnpicker.css
@@ -44,3 +44,8 @@
 .slick-columnpicker li a:hover {
   background: white;
 }
+
+/* Excluded item from Column Picker will be hidden */
+.slick-columnpicker-list li.hidden {
+  display: none;
+}

--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -32,6 +32,7 @@
     var _grid = grid;
     var _options = options;
     var $columnTitleElm;
+    var columns;
     var $list;
     var $menu;
     var columnCheckboxes;
@@ -97,9 +98,10 @@
       columnCheckboxes = [];
 
       var $li, $input;
-      var columnLabel;
+      var columnLabel, excludeCssClass;
       for (var i = 0; i < columns.length; i++) {
-        $li = $("<li />").appendTo($list);
+        excludeCssClass = columns[i].excludeFromColumnPicker ? "hidden" : "";
+        $li = $('<li class="' + excludeCssClass + '" />').appendTo($list);
         $input = $("<input type='checkbox' />").data("column-id", columns[i].id);
         columnCheckboxes.push($input);
 
@@ -177,16 +179,7 @@
           ordered[i] = current.shift();
         }
       }
-
-      // filter out excluded column header when necessary
-      // (works with IE9+, older browser requires a polyfill for the filter to work, visit MDN for more info)
-      if (Array.isArray(ordered) && typeof ordered.filter === 'function') {
-        columns = ordered.filter(function (columnDef) {
-          return !columnDef.excludeFromColumnPicker;
-        });
-      } else {
-        columns = ordered;
-      }
+      columns = ordered;
     }
 
     /** Update the Titles of each sections (command, customTitle, ...) */

--- a/controls/slick.gridmenu.css
+++ b/controls/slick.gridmenu.css
@@ -106,10 +106,14 @@
   vertical-align: middle;
 }
 
-
 /* Disabled */
 .slick-gridmenu-item-disabled {
   color: silver;
+}
+
+/* Excluded item from Grid Menu will be hidden */
+.slick-gridmenu-list li.hidden {
+  display: none;
 }
 
 /* Divider */

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -105,6 +105,7 @@
     var $list;
     var $button;
     var $menu;
+    var columns;
     var columnCheckboxes;
     var _defaults = {
       hideForceFitButton: false,
@@ -262,9 +263,11 @@
         }
       }
 
-      var $li, $input;
+      var $li, $input, excludeCssClass;
       for (var i = 0; i < columns.length; i++) {
-        $li = $("<li />").appendTo($list);
+        excludeCssClass = columns[i].excludeFromGridMenu ? "hidden" : "";
+        $li = $('<li class="' + excludeCssClass + '" />').appendTo($list);
+
         $input = $("<input type='checkbox' />").data("column-id", columns[i].id);
         columnCheckboxes.push($input);
 
@@ -395,16 +398,7 @@
           ordered[i] = current.shift();
         }
       }
-
-      // filter out excluded column header when necessary
-      // (works with IE9+, older browser requires a polyfill for the filter to work, visit MDN for more info)
-      if (Array.isArray(ordered) && typeof ordered.filter === 'function') {
-        columns = ordered.filter(function (columnDef) {
-          return !columnDef.excludeFromGridMenu;
-        });
-      } else {
-        columns = ordered;
-      }
+      columns = ordered;
     }
 
     function updateColumn(e) {


### PR DESCRIPTION
- found this issue by looking into adding Cypress E2E tests, ref PR #399
- because there is a grid `setColumns`, we cannot just remove the excluded columns, if we do it causes some issues when clicking checkbox to show/hide columns later. It removes the excluded column completely from the grid as soon as we click on the checkbox of any item, that is because we call the `setColumns` without the excluded item.
- what is better is to simply keep excluded item in the list but simply hide the checkbox from the picker list.

From the animated gif below, you can see the 2 first columns ("#" and "A") hides when clicking only item "A"
![A6txVdqyiS](https://user-images.githubusercontent.com/643976/61602488-c3215180-ac07-11e9-90d9-07876703f691.gif)
