### PR TITLE
appendCellHtml: allow function valued cssClass

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3090,8 +3090,12 @@ if (typeof Slick === "undefined") {
       // item: grid data for row
 
       var m = columns[cell];
-      var cellCss = "slick-cell l" + cell + " r" + Math.min(columns.length - 1, cell + colspan - 1) +
-          (m.cssClass ? " " + m.cssClass : "");
+      var cellCss = "slick-cell l" + cell + " r" + Math.min(columns.length - 1, cell + colspan - 1);
+      
+      if (m.cssClass) {
+        cellCss += " ";
+        cellCss += (typeof m.cssClass === "function" ? m.cssClass (row, cell, item) : m.cssClass);
+      }
 
       if (hasFrozenColumns() && cell <= options.frozenColumn) {
         cellCss += (" frozen");


### PR DESCRIPTION
Hello 6pac,

Let me propose a minor improvement to SlickGrid column definition: allowing function values for `cssClass` that provide computable UI options for individual cells.

This is useful for:
* displaying icons in a "Status" column based on the corresponding field value;
* colorizing "Gain/Loss" as green/red;
and so on.

Currently, such tasks are only achievable with `asyncPostRender`, that seems a bit too heavy.