### PR TITLE
Ability to add custom attributes to cells

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1254,6 +1254,14 @@ if (typeof Slick === "undefined") {
             .on('mouseleave', onMouseLeave);
         }
 
+        if(m.hasOwnProperty('headerCellAttrs') && m.headerCellAttrs instanceof Object) {
+          for (var key in m.headerCellAttrs) {
+            if (m.headerCellAttrs.hasOwnProperty(key)) {
+              header.attr(key, m.headerCellAttrs[key]);
+            }
+          }
+        }
+	      
         if (m.sortable) {
           header.addClass("slick-header-sortable");
           header.append("<span class='slick-sort-indicator"
@@ -3121,7 +3129,7 @@ if (typeof Slick === "undefined") {
       var toolTip = formatterResult && formatterResult.toolTip ? "title='" + formatterResult.toolTip + "'" : '';
 
       var customAttrStr = '';
-      if(m.cellAttrs) {
+      if(m.hasOwnProperty('cellAttrs') && m.cellAttrs instanceof Object) {
         for (var key in m.cellAttrs) {
           if (m.cellAttrs.hasOwnProperty(key)) {
             customAttrStr += ' ' + key + '="' + m.cellAttrs[key] + '" ';

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3120,7 +3120,16 @@ if (typeof Slick === "undefined") {
       addlCssClasses += (formatterResult && formatterResult.addClasses ? (addlCssClasses ? ' ' : '') + formatterResult.addClasses : '');
       var toolTip = formatterResult && formatterResult.toolTip ? "title='" + formatterResult.toolTip + "'" : '';
 
-      stringArray.push("<div class='" + cellCss + (addlCssClasses ? ' ' + addlCssClasses : '') + "' " + toolTip + ">");
+      var customAttrStr = '';
+      if(m.cellAttrs) {
+        for (var key in m.cellAttrs) {
+          if (m.cellAttrs.hasOwnProperty(key)) {
+            customAttrStr += ' ' + key + '="' + m.cellAttrs[key] + '" ';
+          }
+        }
+      }
+
+      stringArray.push("<div class='" + cellCss + (addlCssClasses ? ' ' + addlCssClasses : '') + "' " + toolTip + customAttrStr + ">");
 
       // if there is a corresponding row (if not, this is the Add New row or this data hasn't been loaded yet)
       if (item) {


### PR DESCRIPTION
The colDef.cellAttrs option allows addition of custom attributes to cells. For example, you could add the "col-id" attribute shown here:

<div class="slick-cell l0 r0" col-id="COUNTRY.COUNTRY_DESCR">Algeria</div>

by adding this to the colDef:
cellAttrs: {
     'col-id': 'COUNTRY.COUNTRY_DESCR'
}