### PR TITLE
Add slick-group-level-n class

### DIFF
--- a/slick.groupitemmetadataprovider.js
+++ b/slick.groupitemmetadataprovider.js
@@ -140,7 +140,7 @@
       return {
         selectable: false,
         focusable: options.groupFocusable,
-        cssClasses: options.groupCssClass,
+        cssClasses: options.groupCssClass + ' slick-group-level-' + item.level,
         columns: {
           0: {
             colspan: "*",
@@ -155,7 +155,7 @@
       return {
         selectable: false,
         focusable: options.totalsFocusable,
-        cssClasses: options.totalsCssClass,
+        cssClasses: options.totalsCssClass + ' slick-group-level-' + item.group.level,
         formatter: options.totalsFormatter,
         editor: null
       };

--- a/slick.groupitemmetadataprovider.js
+++ b/slick.groupitemmetadataprovider.js
@@ -137,10 +137,11 @@
     }
 
     function getGroupRowMetadata(item) {
+      var groupLevel = item && item.level;      
       return {
         selectable: false,
         focusable: options.groupFocusable,
-        cssClasses: options.groupCssClass + ' slick-group-level-' + item.level,
+        cssClasses: options.groupCssClass + ' slick-group-level-' + groupLevel,
         columns: {
           0: {
             colspan: "*",
@@ -152,10 +153,11 @@
     }
 
     function getTotalsRowMetadata(item) {
+      var groupLevel = item && item.group && item.group.level;      
       return {
         selectable: false,
         focusable: options.totalsFocusable,
-        cssClasses: options.totalsCssClass + ' slick-group-level-' + item.group.level,
+        cssClasses: options.totalsCssClass + ' slick-group-level-' + groupLevel,
         formatter: options.totalsFormatter,
         editor: null
       };


### PR DESCRIPTION
Add slick-group-level-n class to group header and total/footer rows. This will allow people to add style to various levels of the group rows, enabling users to distinguish between regular rows and group rows and much more.

In this screenshot, you can easily target the level 0 and 1 group totals:
![image](https://user-images.githubusercontent.com/11670864/63545258-cf851c80-c4db-11e9-8fc2-922ec24cdcec.png)
