### PR TITLE
Group Header Totals

### DIFF
--- a/slick.groupitemmetadataprovider.js
+++ b/slick.groupitemmetadataprovider.js
@@ -38,7 +38,8 @@
       toggleCollapsedCssClass: "collapsed",
       enableExpandCollapse: true,
       groupFormatter: defaultGroupCellFormatter,
-      totalsFormatter: defaultTotalsCellFormatter
+      totalsFormatter: defaultTotalsCellFormatter,
+      includeHeaderTotals: false
     };
 
     options = $.extend(true, {}, _defaults, options);
@@ -137,13 +138,15 @@
     }
 
     function getGroupRowMetadata(item) {
+      var groupLevel = item && item.level;
       return {
         selectable: false,
         focusable: options.groupFocusable,
-        cssClasses: options.groupCssClass,
+        cssClasses: options.groupCssClass + ' slick-group-level-' + groupLevel,
+        formatter: options.includeHeaderTotals && options.totalsFormatter,
         columns: {
           0: {
-            colspan: "*",
+            colspan: options.includeHeaderTotals?"1":"*",
             formatter: options.groupFormatter,
             editor: null
           }


### PR DESCRIPTION
Option called includeHeaderTotals to show totals in group header row. When combined with "aggregateCollapsed: false", it makes for a very clean look when collapsed.

![image](https://user-images.githubusercontent.com/11670864/63617815-4cc59580-c59f-11e9-9453-2d5486e50923.png)
