### PR TITLE
feat(gridState): add a new Grid State plugin with example

### DIFF
--- a/examples/example-0070-plugin-state.html
+++ b/examples/example-0070-plugin-state.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <title>SlickGrid example: Plugin: State</title>
+  <link rel="stylesheet" href="../css/smoothness/jquery-ui-1.11.3.custom.css" type="text/css"/>
+  <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
+  <link rel="stylesheet" href="../plugins/slick.headerbuttons.css" type="text/css"/>
+  <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
+  <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <style>
+    .icon-highlight-off,
+    .icon-highlight-on {
+      background-image: url(../images/bullet_blue.png);
+    }
+
+    .icon-highlight-off {
+      opacity: 0.2;
+    }
+
+    .negative-highlight {
+      background: red;
+    }
+
+    .slick-header-column.filtered {
+      background: #D8E2FF;
+    }
+  </style>
+</head>
+<body>
+<div style="position:relative">
+  <div id="gridContainer">
+    <div id="myGrid" style="width:600px;height:500px;"></div>
+  </div>
+
+  <div class="options-panel">
+    <h2>About</h2>
+    <p>
+      This example demonstrates using the <b>Slick.State</b> plugin persisting grid column width, order, visibility and sort order using Local Storage.
+      For this demo, we use Local Storage, but you could technically save this data into a database and reload at any time your previous session.
+    </p>
+  </div>
+</div>
+
+<script src="../lib/firebugx.js"></script>
+
+<script src="../lib/jquery-1.11.2.min.js"></script>
+<script src="../lib/jquery-ui-1.11.3.js"></script>
+<script src="../lib/jquery.event.drag-2.3.0.js"></script>
+
+<script src="../slick.core.js"></script>
+<script src="../slick.dataview.js"></script>
+<script src="../slick.grid.js"></script>
+<script src="../plugins/slick.state.js"></script>
+<script src="../controls/slick.columnpicker.js"></script>
+
+<script id="script_tag_example" type="text/javascript">
+  var grid;
+  var data = [];
+  var options = {
+    enableColumnReorder: true,
+    multiColumnSort: true,
+    enableCellNavigation: true
+  };
+  var columns = [];
+  var columnsWithHighlightingById = {};
+
+
+  // Set up some test columns.
+  for (var i = 0; i < 10; i++) {
+    columns.push({
+      id: i,
+      name: String.fromCharCode("A".charCodeAt(0) + i),
+      field: i,
+      width: 90,
+      sortable: true
+    });
+  }
+
+  // Set up some test data.
+  for (var i = 0; i < 100; i++) {
+    var d = (data[i] = {});
+    d.id = i;
+    for (var j = 0; j < columns.length; j++) {
+      d[j] = Math.round(Math.random() * 10) - 5;
+    }
+  }
+
+  $(function () {
+    var dataView = new Slick.Data.DataView();
+    var statePersistor = new Slick.State({
+      cid: 'sample-grid',
+      defaultColumns: columns
+    });
+
+    statePersistor.onStateChanged.subscribe(function (e, args) {
+      console.log("onStateChanged", args);
+    });
+
+    grid = new Slick.Grid("#myGrid", dataView, columns, options);
+    var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
+    columnpicker.onColumnsChanged.subscribe(function () {
+      statePersistor.save();
+    });
+
+    grid.registerPlugin(statePersistor);
+
+    dataView.onRowCountChanged.subscribe(function (e, args) {
+      grid.updateRowCount();
+      grid.render();
+    });
+
+    dataView.onRowsChanged.subscribe(function (e, args) {
+      grid.invalidateRows(args.rows);
+      grid.render();
+    });
+
+    function sortDataView(cols) {
+      dataView.sort(function (dataRow1, dataRow2) {
+        for (var i = 0, l = cols.length; i < l; i++) {
+          if (!cols[i].sortCol) continue;
+          var field = cols[i].sortCol.field;
+          var sign = cols[i].sortAsc ? 1 : -1;
+          var value1 = dataRow1[field], value2 = dataRow2[field];
+          var result = (value1 === value2 ? 0 : (value1 > value2 ? 1 : -1)) * sign;
+          if (result !== 0) {
+            return result;
+          }
+        }
+        return 0;
+      });
+      grid.invalidate();
+      grid.render();
+    }
+
+    grid.onSort.subscribe(function (e, args) {
+      sortDataView(args.sortCols);
+    });
+
+    grid.init();
+
+    dataView.beginUpdate();
+    dataView.setItems(data);
+    dataView.endUpdate();
+
+    statePersistor.restore()
+      .then(function (state) {
+        grid.setSortColumns(state.sortcols);
+        var columns = grid.getColumns();
+        var sortCols = $.map(grid.getSortColumns(), function (col) {
+          return {
+            sortCol: columns[grid.getColumnIndex(col.columnId)],
+            sortAsc: col.sortAsc
+          };
+        });
+        sortDataView(sortCols);
+      });
+  });
+</script>
+</body>
+</html>

--- a/plugins/slick.state.js
+++ b/plugins/slick.state.js
@@ -1,0 +1,153 @@
+(function ($) {
+  // register namespace
+  $.extend(true, window, {
+    Slick: {
+      State: State
+    }
+  });
+
+  var localStorageWrapper = function() {
+    var localStorage = window.localStorage;
+
+    if (typeof localStorage === 'undefined') {
+      console.error('localStorage is not available. slickgrid statepersistor disabled.');
+    }
+
+    return {
+      get: function(key) {
+        return $.Deferred(function(dfd) {
+          if (!localStorage) return dfd.reject("missing localStorage");
+          try {
+            var d = localStorage.getItem(key);
+            if (d) {
+              return dfd.resolve(JSON.parse(d));
+            }
+            dfd.resolve();
+          }
+          catch (exc) {
+            dfd.reject(exc);
+          }
+        });
+      },
+      set: function(key, obj) {
+        if (!localStorage) return;
+        if (typeof obj !== 'undefined') {
+          obj = JSON.stringify(obj);
+        }
+        localStorage.setItem(key, obj);
+      }
+    };
+  };
+
+  var defaults = {
+    key_prefix: "slickgrid:",
+    storage: new localStorageWrapper()
+  };
+
+  function State(options) {
+    options = $.extend(true, {}, defaults, options);
+
+    var _grid, _cid,
+      _store = options.storage,
+      onStateChanged = new Slick.Event();
+
+    function init(grid) {
+      _grid = grid;
+      _cid = grid.cid || options.cid;
+      if (_cid) {
+        grid.onColumnsResized.subscribe(save);
+        grid.onColumnsReordered.subscribe(save);
+        grid.onSort.subscribe(save);
+      } else {
+        console.warn("grid has no client id. state persisting is disabled.");
+      }
+    }
+
+    function destroy() {
+      grid.onSort.unsubscribe(save);
+      grid.onColumnsReordered.unsubscribe(save);
+      grid.onColumnsResized.unsubscribe(save);
+      save();
+    }
+
+    function save() {
+      if (_cid && _store) {
+        var state = {
+          sortcols: getSortColumns(),
+          viewport: _grid.getViewport(),
+          columns: getColumns()
+        };
+        onStateChanged.notify(state);
+        return _store.set(options.key_prefix + _cid, state);
+      }
+    }
+
+    function restore() {
+      return $.Deferred(function(dfd) {
+        if (!_cid) { return dfd.reject("missing client id"); }
+        if (!_store) { return dfd.reject("missing store"); }
+
+        _store.get(options.key_prefix + _cid)
+          .then(function success(state) {
+            if (state) {
+              if (state.sortcols) {
+                _grid.setSortColumns(state.sortcols);
+              }
+              if (state.viewport) {
+                _grid.scrollRowIntoView(state.viewport.top, true);
+              }
+              if (state.columns) {
+                var defaultColumns = options.defaultColumns;
+                if (defaultColumns) {
+                  var defaultColumnsLookup = {};
+                  $.each(defaultColumns, function(idx, colDef) {
+                    defaultColumnsLookup[colDef.id] = colDef;
+                  });
+
+                  var cols = [];
+                  $.each(state.columns, function(idx, columnDef) {
+                    if (defaultColumnsLookup[columnDef.id]) {
+                      cols.push($.extend(true, {}, defaultColumnsLookup[columnDef.id], {
+                        width: columnDef.width,
+                        headerCssClass: columnDef.headerCssClass
+                      }));
+                    }
+                  });
+
+                  state.columns = cols;
+                }
+
+                _grid.setColumns(state.columns);
+              }
+            }
+            dfd.resolve(state);
+          }, dfd.reject);
+      });
+    }
+
+    function getColumns() {
+      return $.map(_grid.getColumns(), function(col) {
+        return {
+          id: col.id,
+          width: col.width
+        };
+      });
+    }
+
+    function getSortColumns() {
+      var sortCols = _grid.getSortColumns();
+      return sortCols;
+    }
+
+    /*
+     *  API
+     */
+    $.extend(this, {
+      "init": init,
+      "destroy": destroy,
+      "save": save,
+      "restore": restore,
+      "onStateChanged": onStateChanged
+    });
+  }
+})(jQuery);


### PR DESCRIPTION
Grid State plugin, uses Local Storage to keep the state of the grid and reloads the state when refreshing the grid. 

This is a simple copy/paste of the the [GerHobbelt - SlickGrid](https://github.com/GerHobbelt/SlickGrid/blob/k0stya-rowspan/plugins/slick.state.js) fork

See animated gif for a demo, the demo is to resize a few columns, change position and sort them, then refresh and everything comes back since we use Local Storage to save/restore the Grid State
![xSCN89IFEu](https://user-images.githubusercontent.com/643976/63901516-daa3e500-c9d2-11e9-8a95-e3b2853ed991.gif)

