### PR TITLE
Bug in getRowDiffs() causing incorrect filter

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -905,7 +905,7 @@
 
     function getRowDiffs(rows, newRows) {
       var item, r, eitherIsNonData, diff = [];
-      var from = 0, to = newRows.length;
+      var from = 0, to = Math.max(newRows.length,rows.length);
 
       if (refreshHints && refreshHints.ignoreDiffsBefore) {
         from = Math.max(0,
@@ -924,7 +924,7 @@
           item = newRows[i];
           r = rows[i];
 
-          if ((groupingInfos.length && (eitherIsNonData = (item.__nonDataRow) || (r.__nonDataRow)) &&
+          if (!item || (groupingInfos.length && (eitherIsNonData = (item.__nonDataRow) || (r.__nonDataRow)) &&
               item.__group !== r.__group ||
               item.__group && !item.equals(r))
               || (eitherIsNonData &&


### PR DESCRIPTION
In getRowDiffs(), the "to" variable is set to newRows.length. As an example, if newRows.length is 1 and rows.length is 2, the for loop only iterates from 0 to 1, and thus not detecting any difference so long as the first item in both newRows and rows remain the same.

I also had to add a check for !item. In the example above, newRows[1] would not exist.

Here's an example of the bug in action. Notice when I type "af", it shows two rows for Afghanistan and Africa, but when I add "afg" it does not get rid of Africa:
![2019-08-29_13-17-09](https://user-images.githubusercontent.com/11670864/63973846-7a5b8480-ca60-11e9-8e52-33d63107011c.gif)
