### PR TITLE
Prevent offset+getClientRects error when elem is document

### DIFF
--- a/lib/jquery.event.drop-2.3.0.js
+++ b/lib/jquery.event.drop-2.3.0.js
@@ -162,7 +162,7 @@ drop = $.event.special.drop = {
 	locate: function( elem, index ){
 		var data = $.data( elem, drop.datakey ),
 		$elem = $( elem ),
-		posi = $elem.offset() || {},
+		posi = $elem.length && !$elem.is(document) ? $elem.offset() : {},
 		height = $elem.outerHeight(),
 		width = $elem.outerWidth(),
 		location = {


### PR DESCRIPTION
Sometimes when dragging & dropping rows, elem is document and offset can't be calculated on document