### PR TITLE
Enable Frozen Columns with Column Grouping

### DIFF
--- a/examples/example-frozen-columns-and-column-group.html
+++ b/examples/example-frozen-columns-and-column-group.html
@@ -1,0 +1,150 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
+  <link rel="stylesheet" href="../css/smoothness/jquery-ui-1.11.3.custom.css" type="text/css"/>
+  <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
+  <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <style>
+    .slick-preheader-panel.ui-state-default  {
+      width: 100%;
+      overflow: hidden;
+      border-left: 0px !important;
+      border-bottom: 0px !important;
+    }
+    .slick-preheader-panel .slick-header-columns {
+      border-bottom: 0px !important;
+    }
+  </style>
+</head>
+<body>
+<div style="position:relative">
+  <div style="width:600px;">
+    <div id="myGrid" style="width:100%;height:500px;"></div>
+  </div>
+
+  <div class="options-panel">
+    <h2>Demonstrates:</h2>
+    <ul>
+      <li>Frozen columns with extra header row grouping columns into categories</li>
+    </ul>
+      <h2>View Source:</h2>
+      <ul>
+          <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-column-group.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+      </ul>
+  </div>
+</div>
+
+<script src="../lib/firebugx.js"></script>
+
+<script src="../lib/jquery-1.11.2.min.js"></script>
+<script src="../lib/jquery-ui-1.11.3.min.js"></script>
+<script src="../lib/jquery.event.drag-2.3.0.js"></script>
+
+<script src="../slick.core.js"></script>
+<script src="../slick.dataview.js"></script>
+<script src="../slick.grid.js"></script>
+
+<script>
+  function CreateAddlHeaderRow() {
+    // Add column groups to left panel
+    var $preHeaderPanel = $(grid.getPreHeaderPanel());
+    renderHeaderGroups($preHeaderPanel, 0, options.frozenColumn + 1);
+
+    // Add column groups to right panel
+    $preHeaderPanel = $(grid.getPreHeaderPanelR());
+    renderHeaderGroups($preHeaderPanel, options.frozenColumn + 1, columns.length);
+
+    function renderHeaderGroups(preHeaderPanel, start, end) {
+      preHeaderPanel.empty()
+                    .addClass("slick-header-columns")
+                    .css('left','-1000px')
+                    .width(grid.getHeadersWidth());
+      preHeaderPanel.parent().addClass("slick-header");
+
+      var headerColumnWidthDiff = grid.getHeaderColumnWidthDiff();
+      var m, header, lastColumnGroup = '', widthTotal = 0;
+      
+      for (var i = start; i < end; i++) {
+        m = columns[i];
+        if (lastColumnGroup === m.columnGroup && i>start) {
+          widthTotal += m.width;
+          header.width(widthTotal - headerColumnWidthDiff)
+        } else {
+            widthTotal = m.width;
+            header = $("<div class='ui-state-default slick-header-column' />")
+              .html("<span class='slick-column-name'>" + (m.columnGroup || '') + "</span>")
+              .width(m.width - headerColumnWidthDiff)
+              .appendTo(preHeaderPanel);
+        }
+        lastColumnGroup = m.columnGroup;
+      }
+    }
+  }
+
+  var dataView;
+  var grid;
+  var data = [];
+  var options = {
+    enableCellNavigation: true,
+    enableColumnReorder: false,
+    createPreHeaderPanel: true,
+    showPreHeaderPanel: true,
+    preHeaderPanelHeight: 23,
+    explicitInitialization: true,
+    frozenColumn: 2
+  };
+  var columns = [
+    {id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 40, resizable: false, selectable: false },
+    {id: "title", name: "Title", field: "title", width: 120, minWidth: 120, cssClass: "cell-title", columnGroup:"Common Factor"},
+    {id: "duration", name: "Duration", field: "duration", columnGroup:"Common Factor"},
+    {id: "start", name: "Start", field: "start", minWidth: 140, columnGroup:"Period"},
+    {id: "finish", name: "Finish", field: "finish", minWidth: 140, columnGroup:"Period"},
+    {id: "%", defaultSortAsc: false, name: "% Complete", field: "percentComplete", width: 140, resizable: false, columnGroup:"Analysis"},
+    {id: "effort-driven", name: "Effort Driven", width: 140, minWidth: 20, maxWidth: 140, field: "effortDriven", columnGroup:"Analysis"}
+  ];
+
+  $(function () {
+    for (var i = 0; i < 50000; i++) {
+      var d = (data[i] = {});
+
+      d["id"] = "id_" + i;
+      d["num"] = i;
+      d["title"] = "Task " + i;
+      d["duration"] = "5 days";
+      d["start"] = "01/01/2009";
+      d["finish"] = "01/05/2009";
+      d["percentComplete"] = Math.round(Math.random() * 100);
+      d["effortDriven"] = (i % 5 == 0);
+    }
+
+    dataView = new Slick.Data.DataView();
+    grid = new Slick.Grid("#myGrid", dataView, columns, options);
+
+    dataView.onRowCountChanged.subscribe(function (e, args) {
+      grid.updateRowCount();
+      grid.render();
+    });
+
+    dataView.onRowsChanged.subscribe(function (e, args) {
+      grid.invalidateRows(args.rows);
+      grid.render();
+    });
+
+    grid.init();
+
+    grid.onColumnsResized.subscribe(function (e, args) {
+      CreateAddlHeaderRow();
+    });
+    
+    // Initialise data
+    dataView.beginUpdate();
+    dataView.setItems(data);
+    dataView.endUpdate();
+    
+    CreateAddlHeaderRow();
+  })
+</script>
+</body>
+</html>

--- a/examples/example-frozen-columns-and-column-group.html
+++ b/examples/example-frozen-columns-and-column-group.html
@@ -31,7 +31,7 @@
     </ul>
       <h2>View Source:</h2>
       <ul>
-          <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-column-group.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+          <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-frozen-columns-and-column-group.html" target="_sourcewindow"> View the source for this example on Github</a></li>
       </ul>
   </div>
 </div>
@@ -49,11 +49,11 @@
 <script>
   function CreateAddlHeaderRow() {
     // Add column groups to left panel
-    var $preHeaderPanel = $(grid.getPreHeaderPanel());
+    var $preHeaderPanel = $(grid.getPreHeaderPanelLeft());
     renderHeaderGroups($preHeaderPanel, 0, options.frozenColumn + 1);
 
     // Add column groups to right panel
-    $preHeaderPanel = $(grid.getPreHeaderPanelR());
+    $preHeaderPanel = $(grid.getPreHeaderPanelRight());
     renderHeaderGroups($preHeaderPanel, options.frozenColumn + 1, columns.length);
 
     function renderHeaderGroups(preHeaderPanel, start, end) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -174,6 +174,7 @@ if (typeof Slick === "undefined") {
     var $headerRow, $headerRowScroller, $headerRowSpacerL, $headerRowSpacerR;
     var $footerRow, $footerRowScroller, $footerRowSpacerL, $footerRowSpacerR;
     var $preHeaderPanel, $preHeaderPanelScroller, $preHeaderPanelSpacer;
+    var $preHeaderPanelR, $preHeaderPanelScrollerR, $preHeaderPanelSpacerR;
     var $topPanelScroller;
     var $topPanel;
     var $viewport;
@@ -379,8 +380,14 @@ if (typeof Slick === "undefined") {
         $preHeaderPanelSpacer = $("<div style='display:block;height:1px;position:absolute;top:0;left:0;'></div>")
             .appendTo($preHeaderPanelScroller);
 
+        $preHeaderPanelScrollerR = $("<div class='slick-preheader-panel ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($paneHeaderR);
+        $preHeaderPanelR = $("<div />").appendTo($preHeaderPanelScrollerR);
+        $preHeaderPanelSpacerR = $("<div style='display:block;height:1px;position:absolute;top:0;left:0;'></div>")
+            .appendTo($preHeaderPanelScrollerR);
+
         if (!options.showPreHeaderPanel) {
           $preHeaderPanelScroller.hide();
+          $preHeaderPanelScrollerR.hide();
         }
       }
 
@@ -1046,6 +1053,10 @@ if (typeof Slick === "undefined") {
 
     function getPreHeaderPanel() {
       return $preHeaderPanel[0];
+    }
+
+    function getPreHeaderPanelR() {
+      return $preHeaderPanelR[0];
     }
 
     function getHeaderRowColumn(columnIdOrIdx) {
@@ -4037,7 +4048,11 @@ if (typeof Slick === "undefined") {
           $footerRowScrollContainer[0].scrollLeft = scrollLeft;
         }
         if (options.createPreHeaderPanel) {
-          $preHeaderPanelScroller[0].scrollLeft = scrollLeft;
+          if (hasFrozenColumns()) {
+            $preHeaderPanelScrollerR[0].scrollLeft = scrollLeft;
+          } else {
+            $preHeaderPanelScroller[0].scrollLeft = scrollLeft;
+          }
         }
 
         if (hasFrozenColumns()) {
@@ -5827,6 +5842,7 @@ if (typeof Slick === "undefined") {
       "getTopPanel": getTopPanel,
       "setTopPanelVisibility": setTopPanelVisibility,
       "getPreHeaderPanel": getPreHeaderPanel,
+      "getPreHeaderPanelR": getPreHeaderPanelR,
       "setPreHeaderPanelVisibility": setPreHeaderPanelVisibility,
       "getHeader": getHeader,
       "getHeaderColumn": getHeaderColumn,

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1055,7 +1055,7 @@ if (typeof Slick === "undefined") {
       return $preHeaderPanel[0];
     }
 
-    function getPreHeaderPanelR() {
+    function getPreHeaderPanelRight() {
       return $preHeaderPanelR[0];
     }
 
@@ -5842,7 +5842,8 @@ if (typeof Slick === "undefined") {
       "getTopPanel": getTopPanel,
       "setTopPanelVisibility": setTopPanelVisibility,
       "getPreHeaderPanel": getPreHeaderPanel,
-      "getPreHeaderPanelR": getPreHeaderPanelR,
+      "getPreHeaderPanelLeft": getPreHeaderPanel,
+      "getPreHeaderPanelRight": getPreHeaderPanelRight,
       "setPreHeaderPanelVisibility": setPreHeaderPanelVisibility,
       "getHeader": getHeader,
       "getHeaderColumn": getHeaderColumn,


### PR DESCRIPTION
Created the preheader panel, scroller and spacer elements for the right side panel, and bound scrollLeft to the right panel when frozen columns are set.

Exposed the right preheader panel via public getter for constructing the column group headers.

Added example of usage.

Fixes #340 