### PR TITLE
Fix Object.defineProperty error

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -829,12 +829,12 @@
      * @param {string} fnName 
      */
     function setFunctionName(fn, fnName) {
-      if (Object && Object.defineProperty) {
+      try {
         Object.defineProperty(fn, 'name', {
           writable: true,
           value: fnName
         });
-      } else {
+      } catch(err) {
         fn.name = fnName;
       }
     }


### PR DESCRIPTION
I'm receiving the following error message on a WebKit browser for a very popular analytics product called Tableau:

> TypeError: Attempting to change writable attribute of unconfigurable property


This fix simply catches an error, if there is one, and uses the default method of setting `fn.name`

Here's a screenshot of the error being thrown:
![image](https://user-images.githubusercontent.com/11670864/64653443-4b87cb80-d3db-11e9-9481-9734610eb4a9.png)
