### PR TITLE
Fix error for $footerRowTarget undefined

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1096,7 +1096,7 @@ if (typeof Slick === "undefined") {
         $footerRowTarget = $footerRowL;
       }
 
-      var $footer = $footerRowTarget.children().eq(idx);
+      var $footer = $footerRowTarget && $footerRowTarget.children().eq(idx);
       return $footer && $footer[0];
     }
 


### PR DESCRIPTION
If there is no footer row on the grid, and you call `grid.getFooterRowColumn(colId)`, then you'll get an error. I realize that you shouldn't be calling this function if you don't have a footer, but I did accidentally and this simple fix will help in case others do the same.