### PR TITLE
Fix 'Cannot read property of undefined' error

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2344,10 +2344,10 @@ if (typeof Slick === "undefined") {
 
       if (autoSize.valueFilterMode === Slick.ValueFilterMode.GetLongestTextAndSub) {
         // get greatest abs value in data
-        var tempVal, maxLen = 0, maxIndex;
+        var tempVal, maxLen = 0;
         for (i = 0, ii = rows.length; i < ii; i++) {
           tempVal = rows[i][columnDef.field];
-          if ((tempVal || '').length > maxLen) { maxLen = tempVal.length; maxIndex = i; }
+          if ((tempVal || '').length > maxLen) { maxLen = tempVal.length; }
         }
         // now substitute a 'c' for all characters
         tempVal = Array(maxLen + 1).join("m");
@@ -2358,7 +2358,7 @@ if (typeof Slick === "undefined") {
 
       if (autoSize.valueFilterMode === Slick.ValueFilterMode.GetLongestText) {
         // get greatest abs value in data
-        var tempVal, maxLen = 0, maxIndex;
+        var tempVal, maxLen = 0, maxIndex = 0;
         for (i = 0, ii = rows.length; i < ii; i++) {
           tempVal = rows[i][columnDef.field];
           if ((tempVal || '').length > maxLen) { maxLen = tempVal.length; maxIndex = i; }


### PR DESCRIPTION
If a column has all empty values, `maxIndex` will be undefined in [this](https://github.com/6pac/SlickGrid/blob/master/slick.grid.js#L2359-L2369) code block, so this error will be thrown:
```
Uncaught TypeError: Cannot read property 'DIM_DOCUMENT.SUPPLIER' of undefined
    at getColContentSize (slick.grid.js:2367)
    at getColAutosizeWidth (slick.grid.js:2276)
    at SlickGrid.autosizeColumns (slick.grid.js:2132)
    at child.refresh (grid.js:570)
    at grid.js:579
```

Also, I removed `maxIndex` from [this](https://github.com/6pac/SlickGrid/blob/master/slick.grid.js#L2345-L2357) code block because it is unused.