### PR TITLE
fix(gridMenu): Menu should work with Frozen Col 0, fixes #436

### DIFF
--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -120,7 +120,7 @@
       _gridOptions = grid.getOptions();
       var gridMenuWidth = (_options.gridMenu && _options.gridMenu.menuWidth) || _defaults.menuWidth;
       var $header;
-      if (_gridOptions && _gridOptions.frozenColumn && _gridOptions.frozenColumn >= 0) {
+      if (_gridOptions && _gridOptions.hasOwnProperty('frozenColumn') && _gridOptions.frozenColumn >= 0) {
         $header = $('.' + _gridUid + ' .slick-header-right');
       } else {
         $header = $('.' + _gridUid + ' .slick-header-left');


### PR DESCRIPTION
- fixes the previous commit to fix the same issue, we should allow frozenColumns to be 0 or more and we should check that the `frozenColumn` property exist
- fixes #436