### PR TITLE
Bugfix/enforce show cell selection

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -4768,12 +4768,6 @@ if (typeof Slick === "undefined") {
         activeRow = cell.row;
         activeCell = activePosX = activeCell = activePosX = getCellFromNode(activeCellNode);
 
-        $activeCellNode.addClass("active");
-        if (rowsCache[activeRow]) {
-          $(rowsCache[activeRow].rowNode).addClass('active');
-        }
-
-
         if (opt_editMode == null) {
           opt_editMode = (activeRow == getDataLength()) || options.autoEdit;
         }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -4773,8 +4773,10 @@ if (typeof Slick === "undefined") {
         }
 
         if (options.showCellSelection) {
-        $(activeCellNode).addClass("active");
-        $(rowsCache[activeRow].rowNode).addClass("active");
+          $activeCellNode.addClass("active");
+          if (rowsCache[activeRow]) {
+            $(rowsCache[activeRow].rowNode).addClass("active");
+          }
         }
 
         if (options.editable && opt_editMode && isCellPotentiallyEditable(activeRow, activeCell)) {


### PR DESCRIPTION
I noticed every once in a while I would receive `Uncaught TypeError: Cannot read property 'rowNode' of undefined` from `setActiveCellInternal`

After poking around I saw a crucial conditional is missing and also that the `active` CSS class is always applied to the active cell, regardless of the value set for `options.showCellSelection`