### PR TITLE
fix(picker): incorrect output for visibleColumns & fadeSpeed option

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -79,17 +79,17 @@
       _grid.onHeaderContextMenu.unsubscribe(handleHeaderContextMenu);
       _grid.onColumnsReordered.unsubscribe(updateColumnOrder);
       $(document.body).off("mousedown", handleBodyMouseDown);
-      $("div.slick-columnpicker").hide(_options.fadeSpeed);
+      $("div.slick-columnpicker").hide(_options && _options.columnPicker && _options.columnPicker.fadeSpeed);
       $menu.remove();
     }
 
     function handleBodyMouseDown(e) {
       if (($menu && $menu[0] != e.target && !$.contains($menu[0], e.target)) || e.target.className == "close") {
-        $menu.hide(_options.fadeSpeed);
+        $menu.hide(_options && _options.columnPicker && _options.columnPicker.fadeSpeed);
       }
     }
 
-    function handleHeaderContextMenu(e, args) {
+    function handleHeaderContextMenu(e) {
       e.preventDefault();
       $list.empty();
       updateColumnOrder();
@@ -147,7 +147,7 @@
         .css("top", e.pageY - 10)
         .css("left", e.pageX - 10)
         .css("max-height", $(window).height() - e.pageY - 10)
-        .fadeIn(_options.fadeSpeed);
+        .fadeIn(_options && _options.columnPicker && _options.columnPicker.fadeSpeed);
 
       $list.appendTo($menu);
     }

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -114,7 +114,6 @@
     var _isMenuOpen = false;
     var _options = options;
     var _self = this;
-    var _visibleColumns = columns;
     var $customTitleElm;
     var $columnTitleElm;
     var $customMenu;
@@ -220,7 +219,7 @@
           "grid": _grid,
           "menu": $menu,
           "columns": columns,
-          "visibleColumns": _visibleColumns
+          "visibleColumns": getVisibleColumns()
         };
 
         // run each override functions to know if the item is visible and usable
@@ -311,7 +310,7 @@
         "grid": _grid,
         "menu": $menu,
         "allColumns": columns,
-        "visibleColumns": _visibleColumns
+        "visibleColumns": getVisibleColumns()
       };
 
       // run the override function (when defined), if the result is false it won't go further
@@ -408,7 +407,7 @@
           "command": command,
           "item": item,
           "allColumns": columns,
-          "visibleColumns": _visibleColumns
+          "visibleColumns": getVisibleColumns()
         };
         _self.onCommand.notify(callbackArgs, e, _self);
 
@@ -432,7 +431,7 @@
           "grid": _grid,
           "menu": $menu,
           "allColumns": columns,
-          "visibleColumns": _visibleColumns
+          "visibleColumns": getVisibleColumns()
         };
         if (_self.onMenuClose.notify(callbackArgs, e, _self) == false) {
           return;
@@ -510,7 +509,6 @@
           "allColumns": columns,
           "columns": visibleColumns
         };
-        _visibleColumns = visibleColumns;
         _grid.setColumns(visibleColumns);
         _self.onColumnsChanged.notify(callbackArgs, e, _self);
       }
@@ -522,8 +520,9 @@
       return columns;
     }
 
+    /** visible columns, we can simply get them directly from the grid */
     function getVisibleColumns() {
-      return _visibleColumns;
+      return _grid.getColumns();
     }
 
     /**

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.gridmenu.css" type="text/css"/>
+  <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" crossorigin="anonymous">
   <style>
     .blue {
@@ -44,21 +45,26 @@
     }
 
     /** you could optionally style the grid menu column picker list with font-awesome checkboxes */
-    .slick-gridmenu-list li {
+    .slick-gridmenu-list li,
+    .slick-columnpicker-list li {
+      cursor: pointer;
       margin: 4px;
     }
-    .slick-gridmenu-list label {
+    .slick-gridmenu-list label,
+    .slick-columnpicker-list label {
       padding: 1px;
       display: block;
       cursor: pointer;
     }
     
     #myGrid input[type=checkbox], 
-    .slick-gridmenu-list input[type=checkbox] { 
+    .slick-gridmenu-list input[type=checkbox],
+    .slick-columnpicker-list input[type=checkbox] { 
       display:none; /* to hide the checkbox itself */
     } 
     #myGrid input[type=checkbox] + label:before,
-    .slick-gridmenu-list input[type=checkbox] + label:before {
+    .slick-gridmenu-list input[type=checkbox] + label:before,
+    .slick-columnpicker-list input[type=checkbox] + label:before {
       cursor: pointer;
       font-family: FontAwesome;
       color: #013668;
@@ -69,11 +75,13 @@
       margin-right: 4px;
     }
     #myGrid input[type=checkbox] + label:before,
-    .slick-gridmenu-list input[type=checkbox] + label:before { 
+    .slick-gridmenu-list input[type=checkbox] + label:before,
+    .slick-columnpicker-list input[type=checkbox] + label:before { 
       opacity: 0.2; /* unchecked icon */
     } 
     #myGrid input[type=checkbox]:checked + label:before,
-    .slick-gridmenu-list input[type=checkbox]:checked + label:before { 
+    .slick-gridmenu-list input[type=checkbox]:checked + label:before,
+    .slick-columnpicker-list input[type=checkbox]:checked + label:before { 
       opacity: 1; /* checked icon */
     } 
   </style>
@@ -123,6 +131,7 @@
 <script src="../slick.core.js"></script>
 <script src="../slick.dataview.js"></script>
 <script src="../slick.grid.js"></script>
+<script src="../controls/slick.columnpicker.js"></script>
 <script src="../controls/slick.gridmenu.js"></script>
 
 <script>
@@ -130,6 +139,8 @@
   var grid;
   var gridMenu;
   var data = [];
+  var columnpicker;
+  var gridMenuControl;
 
   function isObjectEmpty(obj) {
     for(var key in obj) {
@@ -147,6 +158,14 @@
     explicitInitialization: true,
     forceFitColumns: false,
     alwaysShowVerticalScroll: true, // this is necessary when using Grid Menu with a small dataset
+    columnPicker: {
+      fadeSpeed: 100,
+      columnTitle: "Columns",
+      hideForceFitButton: false,
+      hideSyncResizeButton: false,
+      forceFitTitle: "Force fit columns",
+      syncResizeTitle: "Synchronous resize",
+    },
 
     // gridMenu Object is optional
     // when not passed, it will act as a regular Column Picker (with default Grid Menu image of drag-handle.png)
@@ -261,8 +280,8 @@
   $(function () {
     dataView = new Slick.Data.DataView();
     grid = new Slick.Grid("#myGrid", dataView, columns, options);
+    columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
     gridMenuControl = new Slick.Controls.GridMenu(columns, grid, options);
-
 
     dataView.onRowCountChanged.subscribe(function (e, args) {
       grid.updateRowCount();


### PR DESCRIPTION
- prior to this fix, the "visibleColumns" was not taking into consideration columns that could be hidden from the column picker in addition to the picker in the grid menu
- prior to this fix, the "fadeSpeed" was pulled from the grid options which was the wrong place to get the option

@6pac 
You can merge whenever you want and there's no need for a new release, that can certainly wait