### PR TITLE
fix(drag): make sure drag event are only for slickgrid, fixes #239

### DIFF
--- a/lib/jquery.event.drag-2.3.0.js
+++ b/lib/jquery.event.drag-2.3.0.js
@@ -112,9 +112,12 @@
                 // check the which directive
                 if ( event.which != 0 && dd.which > 0 && event.which != dd.which )
                     return;
-                // check for suppressed selector
-                if ( $( event.target ).is( dd.not ) )
+                // check for suppressed selector and/or
+                // make sure the target css class starts with "slick" so that we know we are in a Slick Grid
+                var targetClass = $( event.target ).attr('class') || "";                
+                if ( $( event.target ).is( dd.not ) || (!targetClass || targetClass.toString().indexOf('slick') === -1))
                     return;
+                
                 // check for handle selector
                 if ( dd.handle && !$( event.target ).closest( dd.handle, event.currentTarget ).length )
                     return;


### PR DESCRIPTION
- closes #239 
- tweak `jquery.event.drag` so that it only drag DOM elements that are own by a SlickGrid. The fix is to only allow a drag if the target element css class name starts with "slick" so that we know that we are inside a grid, else disregard the drag. That fixes all external lib issues.

The fix was tested with a grid and Froala Editor (an older version of the lib, `2.3.5` that was reported as having issues). Before the fix, the Froala Editor is not usable, though after the fix it's all good and usable. I also tested a few SlickGrid Examples to make sure that nothing was broken (column resize, column drag, draggable grouping, cell selection with external cell copy) and everything is also fine with SlickGrid.

Demo 

without (trying to click the editor doesn't work), then with the fix I'm able to use Frola and all is good

![GLTPmQ8Evk](https://user-images.githubusercontent.com/643976/72124639-82430380-3333-11ea-9a15-98d23528e743.gif)
