### PR TITLE
feat(menus): add "onAfterMenuShow" event to all possible menu plugins

### DIFF
--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -388,8 +388,10 @@
       $list.appendTo($menu);
       _isMenuOpen = true;
 
-      if (_self.onAfterMenuShow.notify(callbackArgs, e, _self) == false) {
-        return;
+      if (typeof e.isPropagationStopped === "function") {
+        if (_self.onAfterMenuShow.notify(callbackArgs, e, _self) == false) {
+          return;
+        }
       }
     }
 

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -64,6 +64,14 @@
  *
  *
  * The plugin exposes the following events:
+ *
+ *    onAfterMenuShow:   Fired after the menu is shown.  You can customize the menu or dismiss it by returning false.
+ *      * ONLY works with a jQuery event (as per slick.core code), so we cannot notify when it's a button event (when grid menu is attached to an external button, not the hamburger menu)
+ *        Event args:
+ *            grid:     Reference to the grid.
+ *            column:   Column definition.
+ *            menu:     Menu options.  Note that you can change the menu items here.
+ * 
  *    onBeforeMenuShow:   Fired before the menu is shown.  You can customize the menu or dismiss it by returning false.
  *      * ONLY works with a jQuery event (as per slick.core code), so we cannot notify when it's a button event (when grid menu is attached to an external button, not the hamburger menu)
  *        Event args:
@@ -189,6 +197,7 @@
     }
 
     function destroy() {
+      _self.onAfterMenuShow.unsubscribe();
       _self.onBeforeMenuShow.unsubscribe();
       _self.onMenuClose.unsubscribe();
       _self.onCommand.unsubscribe();
@@ -321,7 +330,6 @@
       // notify of the onBeforeMenuShow only works when it's a jQuery event (as per slick.core code)
       // this mean that we cannot notify when the grid menu is attach to a button event
       if (typeof e.isPropagationStopped === "function") {
-
         if (_self.onBeforeMenuShow.notify(callbackArgs, e, _self) == false) {
           return;
         }
@@ -379,6 +387,10 @@
 
       $list.appendTo($menu);
       _isMenuOpen = true;
+
+      if (_self.onAfterMenuShow.notify(callbackArgs, e, _self) == false) {
+        return;
+      }
     }
 
     function handleBodyMouseDown(e) {
@@ -547,6 +559,7 @@
       "setOptions": setOptions,
       "updateAllTitles": updateAllTitles,
 
+      "onAfterMenuShow": new Slick.Event(),
       "onBeforeMenuShow": new Slick.Event(),
       "onMenuClose": new Slick.Event(),
       "onCommand": new Slick.Event(),

--- a/cypress/integration/example-grid-menu.spec.js
+++ b/cypress/integration/example-grid-menu.spec.js
@@ -3,6 +3,13 @@
 describe('Example - Grid Menu', () => {
   const fullTitles = ['#', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];
 
+  beforeEach(() => {
+    // create a console.log spy for later use
+    cy.window().then((win) => {
+      cy.spy(win.console, "log");
+    });
+  });
+
   it('should display Example Grid Menu', () => {
     cy.visit(`${Cypress.config('baseExampleUrl')}/example-grid-menu.html`);
     cy.get('h2').should('contain', 'Demonstrates:');
@@ -16,12 +23,19 @@ describe('Example - Grid Menu', () => {
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
-  it('should open the Grid Menu and expect a title for "Custom Menus" and for "Columns"', () => {
+  it('should open the Grid Menu and expect onBeforeMenuShow then onAfterMenuShow to show in the console log', () => {
     cy.get('#myGrid')
       .find('button.slick-gridmenu-button')
-      .trigger('click')
       .click({ force: true });
 
+    cy.window().then((win) => {
+      expect(win.console.log).to.have.callCount(2);
+      expect(win.console.log).to.be.calledWith('Before the Grid Menu is shown');
+      expect(win.console.log).to.be.calledWith('After the Grid Menu is shown');
+    });
+  });
+
+  it('should have the Grid Menu already opened and expect a title for "Custom Menus" and for "Columns"', () => {
     cy.get('.slick-gridmenu-custom')
       .find('.title')
       .contains('Custom Menus');
@@ -33,7 +47,6 @@ describe('Example - Grid Menu', () => {
     cy.get('#myGrid')
       .get('.slick-gridmenu:visible')
       .find('span.close')
-      .trigger('click')
       .click({ force: true });
   });
 
@@ -42,7 +55,6 @@ describe('Example - Grid Menu', () => {
 
     cy.get('#myGrid')
       .find('button.slick-gridmenu-button')
-      .trigger('click')
       .click({ force: true });
 
     cy.get('#myGrid')
@@ -56,7 +68,6 @@ describe('Example - Grid Menu', () => {
     cy.get('#myGrid')
       .get('.slick-gridmenu:visible')
       .find('span.close')
-      .trigger('click')
       .click({ force: true });
 
     cy.get('#myGrid')
@@ -68,7 +79,6 @@ describe('Example - Grid Menu', () => {
   it('should click on the External Grid Menu to show the column "A" as 1st column again', () => {
     cy.get('button')
       .contains('Grid Menu')
-      .trigger('click')
       .click({ force: true });
 
     cy.get('#myGrid')
@@ -161,7 +171,6 @@ describe('Example - Grid Menu', () => {
   it('should open the Grid Menu and click on Clear Filter and expect multiple rows now showing in the grid', () => {
     cy.get('#myGrid')
       .find('button.slick-gridmenu-button')
-      .trigger('click')
       .click({ force: true });
 
     cy.get('.slick-gridmenu-item')
@@ -195,7 +204,6 @@ describe('Example - Grid Menu', () => {
 
     cy.get('button')
       .contains('Grid Menu')
-      .trigger('click')
       .click({ force: true });
 
     cy.get('#myGrid')
@@ -207,7 +215,6 @@ describe('Example - Grid Menu', () => {
     cy.get('#myGrid')
       .get('.slick-gridmenu:visible')
       .find('span.close')
-      .trigger('click')
       .click();
   });
 
@@ -221,7 +228,6 @@ describe('Example - Grid Menu', () => {
 
     cy.get('#myGrid')
       .find('button.slick-gridmenu-button')
-      .trigger('click')
       .click({ force: true });
 
     cy.get('.slick-gridmenu-item.slick-gridmenu-item-disabled')
@@ -236,7 +242,6 @@ describe('Example - Grid Menu', () => {
     cy.get('#myGrid')
       .get('.slick-gridmenu:visible')
       .find('span.close')
-      .trigger('click')
       .click({ force: true });
   });
 

--- a/cypress/integration/example-plugin-contextmenu.spec.js
+++ b/cypress/integration/example-plugin-contextmenu.spec.js
@@ -3,6 +3,13 @@
 describe('Example - Context Menu & Cell Menu', () => {
   const fullTitles = ['#', 'Title', '% Complete', 'Start', 'Finish', 'Priority', 'Effort Driven', 'Action'];
 
+  beforeEach(() => {
+    // create a console.log spy for later use
+    cy.window().then((win) => {
+      cy.spy(win.console, "log");
+    });
+  });
+
   it('should display Example Context Menu & Cell Menu', () => {
     cy.visit(`${Cypress.config('baseExampleUrl')}/example-plugin-contextmenu.html`);
     cy.get('h2').should('contain', 'Demonstrates:');
@@ -38,6 +45,41 @@ describe('Example - Context Menu & Cell Menu', () => {
 
     cy.get('.slick-cell-menu')
       .should('not.exist')
+  });
+
+  it('should open the Context Menu and expect onBeforeMenuShow then onAfterMenuShow to show in the console log', () => {
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(1)')
+      .contains('Task 0');
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(1)')
+      .rightclick();
+
+    cy.window().then((win) => {
+      expect(win.console.log).to.have.callCount(2);
+      expect(win.console.log).to.be.calledWith('Before the global Context Menu is shown');
+      expect(win.console.log).to.be.calledWith('After the Context Menu is shown');
+    });
+  });
+
+  it('should expect the Context Menu to not have the "Help" menu when there is Effort Driven set to True', () => {
+    const commands = ['Copy Cell Value', 'Delete Row', '', 'Command (always disabled)'];
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(1)')
+      .contains('Task 0');
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(1)')
+      .rightclick();
+
+    cy.get('.slick-context-menu.dropright .slick-context-menu-command-list')
+      .find('.slick-context-menu-item')
+      .each(($command, index) => {
+        expect($command.text()).to.eq(commands[index]);
+        expect($command.text()).not.include('Help');
+      });
   });
 
   it('should expect the Context Menu to not have the "Help" menu when there is Effort Driven set to True', () => {
@@ -140,12 +182,23 @@ describe('Example - Context Menu & Cell Menu', () => {
       .click();
   });
 
-  it('should be able to click on the Action Cell Menu (x) close button, on top right corner, to close the menu', () => {
+  it('should open the Cell Menu and expect onBeforeMenuShow then onAfterMenuShow to show in the console log', () => {
     cy.get('#myGrid')
       .find('.slick-row .slick-cell:nth(7)')
       .contains('Action')
       .click({ force: true });
 
+    cy.get('.slick-cell-menu.dropleft')
+      .should('exist');
+
+    cy.window().then((win) => {
+      expect(win.console.log).to.have.callCount(2);
+      expect(win.console.log).to.be.calledWith('Before the Cell Menu is shown');
+      expect(win.console.log).to.be.calledWith('After the Cell Menu is shown');
+    });
+  });
+
+  it('should be able to click on the Action Cell Menu (x) close button, on top right corner, to close the menu', () => {
     cy.get('.slick-cell-menu.dropleft')
       .should('exist');
 

--- a/cypress/integration/example-plugin-headermenu.spec.js
+++ b/cypress/integration/example-plugin-headermenu.spec.js
@@ -22,7 +22,7 @@ describe('Example - Header Menu', () => {
       .each(($child, index) => expect($child.text()).to.eq(titles[index]));
   });
 
-  it('should hover over the "Title" column and expect Sort & Hide commands to be disabled', () => {
+  it('should open the Header Menu on the "Title" column and expect onBeforeMenuShow then onAfterMenuShow to show in the console log', () => {
     cy.get('#myGrid')
       .find('.slick-header-column')
       .first()
@@ -32,6 +32,14 @@ describe('Example - Header Menu', () => {
       .invoke('show')
       .click();
 
+    cy.window().then((win) => {
+      expect(win.console.log).to.have.callCount(2);
+      expect(win.console.log).to.be.calledWith('Before the Header Menu is shown');
+      expect(win.console.log).to.be.calledWith('After the Header Menu is shown');
+    });
+  });
+
+  it('should open the Header Menu on the "Title" column and expect Sort & Hide commands to be disabled', () => {
     cy.get('.slick-header-menuitem.slick-header-menuitem-disabled')
       .contains('Sort Ascending')
       .should('exist');

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -337,6 +337,15 @@
       }
     });
 
+    // subscribe to some events
+    
+    gridMenuControl.onBeforeMenuShow.subscribe(function(e, args) {
+      console.log('Before the Grid Menu is shown');
+    });
+    gridMenuControl.onAfterMenuShow.subscribe(function(e, args) {
+      console.log('After the Grid Menu is shown');
+    });
+
     // subscribe to event when column visibility is changed via the menu
     gridMenuControl.onColumnsChanged.subscribe(function(e, args) {
       console.log('Columns changed via the menu');

--- a/examples/example-plugin-contextmenu.html
+++ b/examples/example-plugin-contextmenu.html
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
-  <title>SlickGrid example 7: Events</title>
+  <title>SlickGrid example: Cell Menu & Context Menu</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css" />
   <link rel="stylesheet" href="../plugins/slick.cellmenu.css" type="text/css" />
   <link rel="stylesheet" href="../plugins/slick.contextmenu.css" type="text/css" />
@@ -135,7 +135,7 @@
           </li>
           <li>
             There are also a few SlickGrid Events you can subscribe
-            onBeforeMenuShow, onBeforeMenuClose, onCommand, onOptionSelected
+            onBeforeMenuShow, onBeforeMenuClose, onAfterMenuShow, onCommand, onOptionSelected
           </li>
           <li>
             There 2 ways to execute a Command/Option
@@ -472,6 +472,13 @@
         console.log("Global Context Menu is closing", args);
       });
 
+      contextMenuPlugin.onAfterMenuShow.subscribe(function (e, args) {
+        // for example, you could select the row it was clicked with
+        // grid.setSelectedRows([args.row]); // select the entire row
+        grid.setActiveCell(args.row, args.cell, false); // select the cell that the click originated
+        console.log("After the Context Menu is shown", args);
+      });
+
       // subscribe to Context Menu onCommand event (or use the action callback on each command)
       contextMenuPlugin.onCommand.subscribe(function (e, args) {
         executeCommand(e, args);
@@ -500,6 +507,13 @@
       });
       cellMenuPlugin.onBeforeMenuClose.subscribe(function (e, args) {
         console.log("Cell Menu is closing", args);
+      });
+
+      cellMenuPlugin.onAfterMenuShow.subscribe(function (e, args) {
+        // for example, you could select the row it was clicked with
+        // grid.setSelectedRows([args.row]); // select the entire row
+        grid.setActiveCell(args.row, args.cell, false); // select the cell that the click originated
+        console.log("After the Cell Menu is shown", args);
       });
 
       // subscribe to Cell Menu onCommand event (or use the action callback on each command)

--- a/examples/example-plugin-headermenu.html
+++ b/examples/example-plugin-headermenu.html
@@ -252,6 +252,13 @@
         executeSort(args.sortCols);
       });
 
+      headerMenuPlugin.onBeforeMenuShow.subscribe(function(e, args) {
+        console.log('Before the Header Menu is shown');
+      });
+      headerMenuPlugin.onAfterMenuShow.subscribe(function(e, args) {
+        console.log('After the Header Menu is shown');
+      });
+
       headerMenuPlugin.onCommand.subscribe(function (e, args) {
         if (args.command === "hide") {
           // hide column

--- a/plugins/slick.cellmenu.js
+++ b/plugins/slick.cellmenu.js
@@ -84,6 +84,12 @@
    *
    * The plugin exposes the following events:
    *
+   *    onAfterMenuShow: Fired after the menu is shown.  You can customize the menu or dismiss it by returning false.
+   *        Event args:
+   *            cell:         Cell or column index
+   *            row:          Row index
+   *            grid:         Reference to the grid.
+   * 
    *    onBeforeMenuShow: Fired before the menu is shown.  You can customize the menu or dismiss it by returning false.
    *        Event args:
    *            cell:         Cell or column index
@@ -161,6 +167,7 @@
     }
 
     function destroy() {
+      _self.onAfterMenuShow.unsubscribe();
       _self.onBeforeMenuShow.unsubscribe();
       _self.onBeforeMenuClose.unsubscribe();
       _self.onCommand.unsubscribe();
@@ -244,6 +251,14 @@
       menu.show();
       menu.appendTo("body");
 
+      if (_self.onAfterMenuShow.notify({
+        "cell": _currentCell,
+        "row": _currentRow,
+        "grid": _grid
+      }, e, _self) == false) {
+        return;
+      }
+
       return menu;
     }
 
@@ -266,10 +281,20 @@
       return 0;
     }
 
-    function destroyMenu() {
+    function destroyMenu(e, args) {
       $menu = $menu || $(".slick-cell-menu." + _gridUid);
 
       if ($menu && $menu.remove) {
+        if ($menu.length > 0) {
+          if (_self.onBeforeMenuClose.notify({
+            "cell": args && args.cell,
+            "row": args && args.row,
+            "grid": _grid,
+            "menu": $menu
+          }, e, _self) == false) {
+            return;
+          }
+        }
         $menu.remove();
         $menu = null;
       }
@@ -635,6 +660,7 @@
       "pluginName": "CellMenu",
       "setOptions": setOptions,
 
+      "onAfterMenuShow": new Slick.Event(),
       "onBeforeMenuShow": new Slick.Event(),
       "onBeforeMenuClose": new Slick.Event(),
       "onCommand": new Slick.Event(),

--- a/plugins/slick.contextmenu.js
+++ b/plugins/slick.contextmenu.js
@@ -90,6 +90,12 @@
    *
    * The plugin exposes the following events:
    *
+   *    onAfterMenuShow: Fired after the menu is shown.  You can customize the menu or dismiss it by returning false.
+   *        Event args:
+   *            cell:         Cell or column index
+   *            row:          Row index
+   *            grid:         Reference to the grid.
+   *
    *    onBeforeMenuShow: Fired before the menu is shown.  You can customize the menu or dismiss it by returning false.
    *        Event args:
    *            cell:         Cell or column index
@@ -178,6 +184,7 @@
     }
 
     function destroy() {
+      _self.onAfterMenuShow.unsubscribe();
       _self.onBeforeMenuShow.unsubscribe();
       _self.onBeforeMenuClose.unsubscribe();
       _self.onCommand.unsubscribe();
@@ -262,6 +269,14 @@
 
       menu.show();
       menu.appendTo("body");
+
+      if (_self.onAfterMenuShow.notify({
+        "cell": _currentCell,
+        "row": _currentRow,
+        "grid": _grid
+      }, e, _self) == false) {
+        return;
+      }
 
       return menu;
     }
@@ -657,6 +672,7 @@
       "pluginName": "ContextMenu",
       "setOptions": setOptions,
 
+      "onAfterMenuShow": new Slick.Event(),
       "onBeforeMenuShow": new Slick.Event(),
       "onBeforeMenuClose": new Slick.Event(),
       "onCommand": new Slick.Event(),

--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -64,6 +64,13 @@
    *
    *
    * The plugin exposes the following events:
+
+   *    onAfterMenuShow:   Fired after the menu is shown.  You can customize the menu or dismiss it by returning false.
+   *        Event args:
+   *            grid:     Reference to the grid.
+   *            column:   Column definition.
+   *            menu:     Menu options.  Note that you can change the menu items here.
+   * 
    *    onBeforeMenuShow:   Fired before the menu is shown.  You can customize the menu or dismiss it by returning false.
    *        Event args:
    *            grid:     Reference to the grid.
@@ -294,6 +301,10 @@
       $activeHeaderColumn
         .addClass("slick-header-column-active");
 
+      if (_self.onAfterMenuShow.notify(callbackArgs, e, _self) == false) {
+        return;
+      }
+
       // Stop propagation so that it doesn't register as a header click event.
       e.preventDefault();
       e.stopPropagation();
@@ -350,6 +361,7 @@
       "pluginName": "HeaderMenu",
       "setOptions": setOptions,
 
+      "onAfterMenuShow": new Slick.Event(),
       "onBeforeMenuShow": new Slick.Event(),
       "onCommand": new Slick.Event()
     });


### PR DESCRIPTION
#### List of TODOs
- [x] update all Menu Plugins (`CellMenu`, `ContextMenu`, `HeaderMenu` and `GridMenu`)
- [x] update all Menu Examples and subscribe to the new `onAfterMenuShow` with `console.log` samples
- [x] add Cypress E2E tests