### PR TITLE
Bugfix/autotooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
-## This is a fork from https://github.com/6pac/SlickGrid
+## This is the 6pac SlickGrid repo
 
-Created to extend 6pac/SlickGrid.
+Check out the NEW SlickGrid Website! http://slickgrid.net/
+
+This is the acknowledged most active non-customised fork of SlickGrid.
+
+It aims to be a viable alternative master repo, building on the legacy of the mleibman/SlickGrid master branch, keeping libraries up to date and applying small, safe core patches and enhancements without turning into a personalised build.
+
+Check out the **[Examples](https://github.com/6pac/SlickGrid/wiki/Examples)** for examples demonstrating new features and use cases, such as dynamic grid creation and editors with third party controls.
+
+Also check out the [Wiki](https://github.com/6pac/SlickGrid/wiki) for news and documentation.
+
+### E2E Tests with Cypress
+We are now starting to add E2E (end to end) tests in the browser with [Cypress](https://www.cypress.io/). You can see [here](https://github.com/6pac/SlickGrid/tree/master/cypress/integration) the list of Examples that now have Cypress tests. We also added these Cypress tests to the [GitHub Actions](https://github.com/features/actions) Workflow to automate certain steps, it will basically run all the E2E tests every time someone pushes a commit or a PR.
+
+We also welcome any contributions (tests or fixes) and if you wish to add Cypress tests, all you need to do is to clone the repo and then run the following commands
+```bash
+npm install # install all npm packages
+npm run server # run a local http server
+npm run cypress:open # open Cypress tool
+```
+Once Cypress tool is open, you can click on "Run all Specs" to start the E2E browser tests.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,3 @@
-## This is the 6pac SlickGrid repo
+## This is a fork from https://github.com/6pac/SlickGrid
 
-Check out the NEW SlickGrid Website! http://slickgrid.net/
-
-This is the acknowledged most active non-customised fork of SlickGrid.
-
-It aims to be a viable alternative master repo, building on the legacy of the mleibman/SlickGrid master branch, keeping libraries up to date and applying small, safe core patches and enhancements without turning into a personalised build.
-
-Check out the **[Examples](https://github.com/6pac/SlickGrid/wiki/Examples)** for examples demonstrating new features and use cases, such as dynamic grid creation and editors with third party controls.
-
-Also check out the [Wiki](https://github.com/6pac/SlickGrid/wiki) for news and documentation.
-
-### E2E Tests with Cypress
-We are now starting to add E2E (end to end) tests in the browser with [Cypress](https://www.cypress.io/). You can see [here](https://github.com/6pac/SlickGrid/tree/master/cypress/integration) the list of Examples that now have Cypress tests. We also added these Cypress tests to the [GitHub Actions](https://github.com/features/actions) Workflow to automate certain steps, it will basically run all the E2E tests every time someone pushes a commit or a PR.
-
-We also welcome any contributions (tests or fixes) and if you wish to add Cypress tests, all you need to do is to clone the repo and then run the following commands
-```bash
-npm install # install all npm packages
-npm run server # run a local http server
-npm run cypress:open # open Cypress tool
-```
-Once Cypress tool is open, you can click on "Run all Specs" to start the E2E browser tests.
+Created to extend 6pac/SlickGrid.

--- a/plugins/slick.autotooltips.js
+++ b/plugins/slick.autotooltips.js
@@ -49,18 +49,15 @@
       if (cell) {
         var $node = $(_grid.getCellNode(cell.row, cell.cell));
         var text;
-        if (!$node.attr("title"))
-        {
-          if ($node.innerWidth() < $node[0].scrollWidth) {
-            text = $.trim($node.text());
-            if (options.maxToolTipLength && text.length > options.maxToolTipLength) {
-              text = text.substr(0, options.maxToolTipLength - 3) + "...";
-            }
-          } else {
-            text = "";
+        if ($node.innerWidth() < $node[0].scrollWidth) {
+          text = $.trim($node.text());
+          if (options.maxToolTipLength && text.length > options.maxToolTipLength) {
+            text = text.substr(0, options.maxToolTipLength - 3) + "...";
           }
-          $node.attr("title", text);
+        } else {
+          text = "";
         }
+        $node.attr("title", text);
       }
     }
     

--- a/plugins/slick.autotooltips.js
+++ b/plugins/slick.autotooltips.js
@@ -49,15 +49,18 @@
       if (cell) {
         var $node = $(_grid.getCellNode(cell.row, cell.cell));
         var text;
-        if ($node.innerWidth() < $node[0].scrollWidth) {
-          text = $.trim($node.text());
-          if (options.maxToolTipLength && text.length > options.maxToolTipLength) {
-            text = text.substr(0, options.maxToolTipLength - 3) + "...";
+        if (!$node.attr("title"))
+        {
+          if ($node.innerWidth() < $node[0].scrollWidth) {
+            text = $.trim($node.text());
+            if (options.maxToolTipLength && text.length > options.maxToolTipLength) {
+              text = text.substr(0, options.maxToolTipLength - 3) + "...";
+            }
+          } else {
+            text = "";
           }
-        } else {
-          text = "";
+          $node.attr("title", text);
         }
-        $node.attr("title", text);
       }
     }
     

--- a/slick.groupitemmetadataprovider.js
+++ b/slick.groupitemmetadataprovider.js
@@ -20,9 +20,9 @@
    * @module Data
    * @namespace Slick.Data
    * @constructor
-   * @param _options
+   * @param inputOptions
    */
-  function GroupItemMetadataProvider(_options) {
+  function GroupItemMetadataProvider(inputOptions) {
     var _grid;
     var _defaults = {
       checkboxSelect: false,
@@ -44,17 +44,15 @@
 
     var options = {};
 
-    setOptions(_options);
+    setOptions(inputOptions);
 
     function getOptions(){
       return options;
     }
 
-    function setOptions(_options)
+    function setOptions(inputOptions)
     {
-      options = $.extend(true, {}, _defaults, options, _options);
-
-      return this;
+      options = $.extend(true, {}, _defaults, options, inputOptions);
     }
 
     function defaultGroupCellFormatter(row, cell, value, columnDef, item, grid) {

--- a/slick.groupitemmetadataprovider.js
+++ b/slick.groupitemmetadataprovider.js
@@ -20,9 +20,9 @@
    * @module Data
    * @namespace Slick.Data
    * @constructor
-   * @param options
+   * @param _options
    */
-  function GroupItemMetadataProvider(options) {
+  function GroupItemMetadataProvider(_options) {
     var _grid;
     var _defaults = {
       checkboxSelect: false,
@@ -42,8 +42,20 @@
       includeHeaderTotals: false
     };
 
-    options = $.extend(true, {}, _defaults, options);
+    var options = {};
 
+    setOptions(_options);
+
+    function getOptions(){
+      return options;
+    }
+
+    function setOptions(_options)
+    {
+      options = $.extend(true, {}, _defaults, options, _options);
+
+      return this;
+    }
 
     function defaultGroupCellFormatter(row, cell, value, columnDef, item, grid) {
       if (!options.enableExpandCollapse) {
@@ -170,7 +182,9 @@
       "init": init,
       "destroy": destroy,
       "getGroupRowMetadata": getGroupRowMetadata,
-      "getTotalsRowMetadata": getTotalsRowMetadata
+      "getTotalsRowMetadata": getTotalsRowMetadata,
+      "getOptions": getOptions,
+      "setOptions": setOptions
     };
   }
 })(jQuery);


### PR DESCRIPTION
`handleMouseEnter` function now checks if `$node` already has `attr("title")`. only if no `title` is set, the automatic value will be set.