### PR TITLE
`title` only added if no `title` is already defined

### DIFF
--- a/plugins/slick.autotooltips.js
+++ b/plugins/slick.autotooltips.js
@@ -49,15 +49,18 @@
       if (cell) {
         var $node = $(_grid.getCellNode(cell.row, cell.cell));
         var text;
-        if ($node.innerWidth() < $node[0].scrollWidth) {
-          text = $.trim($node.text());
-          if (options.maxToolTipLength && text.length > options.maxToolTipLength) {
-            text = text.substr(0, options.maxToolTipLength - 3) + "...";
+        if (!$node.attr("title"))
+        {
+          if ($node.innerWidth() < $node[0].scrollWidth) {
+            text = $.trim($node.text());
+            if (options.maxToolTipLength && text.length > options.maxToolTipLength) {
+              text = text.substr(0, options.maxToolTipLength - 3) + "...";
+            }
+          } else {
+            text = "";
           }
-        } else {
-          text = "";
+          $node.attr("title", text);
         }
-        $node.attr("title", text);
       }
     }
     


### PR DESCRIPTION
`handleMouseEnter` now checks for `$node.attur("title")` first. if `title` already exists, it doesn't update/create `title` value.