### PR TITLE
fix(cellMenu): stop event bubbling only on valid cell menu column

### DIFF
--- a/plugins/slick.cellmenu.js
+++ b/plugins/slick.cellmenu.js
@@ -354,11 +354,14 @@
     }
 
     function handleCellClick(e, args) {
-      e.preventDefault();
-
       var cell = _grid.getCellFromEvent(e);
       var dataContext = _grid.getDataItem(cell.row);
       var columnDef = _grid.getColumns()[cell.cell];
+
+      // prevent event from bubbling but only on column that has a cell menu defined
+      if (columnDef && columnDef.cellMenu) {
+        e.preventDefault();
+      }
 
       // merge the cellMenu of the column definition with the default properties
       _cellMenuProperties = $.extend({}, _cellMenuProperties, columnDef.cellMenu);


### PR DESCRIPTION
- this fixes an issue found with Row Selection which also uses the onClick event and because the cellMenu was preventing bubbling, it was breaking multiple row selection. That is why we should prevent bubbling only on column that do have a cell menu, else just keep going with regular bubbling