### PR TITLE
feat(plugins): add ways to use all 3 plugins together, closes #347

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Check out the **[Examples](https://github.com/6pac/SlickGrid/wiki/Examples)** fo
 Also check out the [Wiki](https://github.com/6pac/SlickGrid/wiki) for news and documentation.
 
 ### E2E Tests with Cypress
-We are now starting to add E2E (end to end) tests in the browser with [Cypress](https://www.cypress.io/). You can see [here](https://github.com/6pac/SlickGrid/tree/master/cypress/integration) the list of Examples that now have Cypress tests. We also added these Cypress tests to the [GitHub Actions](https://github.com/features/actions) Workflow to automate certain steps, it will basically run all the E2E tests every time someone pushes a commit or a PR.
+We are now starting to add E2E (end to end) tests in the browser with [Cypress](https://www.cypress.io/). You can see [here](https://github.com/6pac/SlickGrid/tree/master/cypress/integration) the list of Examples that now have E2E tests. We also added these Cypress E2E tests to the [GitHub Actions](https://github.com/features/actions) Workflow to automate certain steps while making sure any new commits aren't breaking the build/test. It will basically run all the E2E tests every time someone pushes a commit or a PR.
 
-We also welcome any contributions (tests or fixes) and if you wish to add Cypress tests, all you need to do is to clone the repo and then run the following commands
+We also welcome any contributions (tests or fixes) and if you wish to add Cypress E2E tests, all you need to do is to clone the repo and then run the following commands
 ```bash
 npm install # install all npm packages
 npm run server # run a local http server
 npm run cypress:open # open Cypress tool
 ```
-Once Cypress tool is open, you can click on "Run all Specs" to start the E2E browser tests.
+Once Cypress UI is open, you can click on "Run all Specs" to start the E2E browser tests.

--- a/cypress/integration/example-row-detail-selection-and-move.spec.js
+++ b/cypress/integration/example-row-detail-selection-and-move.spec.js
@@ -1,0 +1,73 @@
+/// <reference types="Cypress" />
+
+describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
+    const fullTitles = ['', '', '', '#', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
+
+    beforeEach(() => {
+        // create a console.log spy for later use
+        cy.window().then((win) => {
+            cy.spy(win.console, "log");
+        });
+    });
+
+    it('should display Example Row Detail/Row Move/Checkbox Selector Plugins', () => {
+        cy.visit(`${Cypress.config('baseExampleUrl')}/example-row-detail-selection-and-move.html`);
+        cy.get('h2').should('contain', 'Demonstrates:');
+        cy.get('h3').should('contain', 'The following three Plugins used together');
+    });
+
+    it('should have exact Column Titles in the grid', () => {
+        cy.get('#myGrid')
+            .find('.slick-header-columns')
+            .children()
+            .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+    });
+
+    it('should open the Row Detail of the 2nd row and expect to find some details', () => {
+        cy.get('.slick-cell.detailView-toggle:nth(3)')
+            .click()
+            .wait(250);
+
+        cy.get('.innerDetailView_3')
+            .find('h2')
+            .should('contain', 'Task 3');
+
+        cy.get('input[id="assignee_3"]')
+            .should('exist');
+
+        cy.get('input[type="checkbox"]:checked')
+            .should('have.length', 0);
+    });
+
+    it('should drag opened Row Detail to another position in the grid', () => {
+        cy.get('[style="top:25px"] > .slick-cell.cell-reorder').as('moveIcon1');
+        cy.get('[style="top:75px"] > .slick-cell.cell-reorder').as('moveIcon3');
+
+        cy.get('@moveIcon3').should('have.length', 1);
+
+        cy.get('@moveIcon3')
+            .trigger('mousedown', { button: 0, force: true })
+            .trigger('mousemove', 'bottomRight');
+
+        cy.get('@moveIcon1')
+            .trigger('mousemove', 'bottomRight')
+            .trigger('mouseup', 'bottomRight', { force: true });
+
+        cy.get('input[type="checkbox"]:checked')
+            .should('have.length', 0);
+    });
+
+    it('should expect row got moved to another row index', () => {
+        cy.get('.slick-viewport-top.slick-viewport-left')
+            .scrollTo('top');
+
+        cy.get('[style="top:0px"] > .slick-cell:nth(4)').should('contain', 'Task 0');
+        cy.get('[style="top:25px"] > .slick-cell:nth(4)').should('contain', 'Task 1');
+        cy.get('[style="top:50px"] > .slick-cell:nth(4)').should('contain', 'Task 3');
+        cy.get('[style="top:75px"] > .slick-cell:nth(4)').should('contain', 'Task 2');
+        cy.get('[style="top:100px"] > .slick-cell:nth(4)').should('contain', 'Task 4');
+
+        cy.get('input[type="checkbox"]:checked')
+            .should('have.length', 0);
+    });
+});

--- a/cypress/integration/example-row-detail-selection-and-move.spec.js
+++ b/cypress/integration/example-row-detail-selection-and-move.spec.js
@@ -40,16 +40,16 @@ describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
     });
 
     it('should drag opened Row Detail to another position in the grid', () => {
-        cy.get('[style="top:25px"] > .slick-cell.cell-reorder').as('moveIcon1');
-        cy.get('[style="top:75px"] > .slick-cell.cell-reorder').as('moveIcon3');
+        cy.get('[style="top:25px"] > .slick-cell.cell-reorder').as('moveIconTask1');
+        cy.get('[style="top:75px"] > .slick-cell.cell-reorder').as('moveIconTask3');
 
-        cy.get('@moveIcon3').should('have.length', 1);
+        cy.get('@moveIconTask3').should('have.length', 1);
 
-        cy.get('@moveIcon3')
+        cy.get('@moveIconTask3')
             .trigger('mousedown', { button: 0, force: true })
             .trigger('mousemove', 'bottomRight');
 
-        cy.get('@moveIcon1')
+        cy.get('@moveIconTask1')
             .trigger('mousemove', 'bottomRight')
             .trigger('mouseup', 'bottomRight', { force: true });
 
@@ -57,7 +57,7 @@ describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
             .should('have.length', 0);
     });
 
-    it('should expect row got moved to another row index', () => {
+    it('should expect row to be moved to another row index', () => {
         cy.get('.slick-viewport-top.slick-viewport-left')
             .scrollTo('top');
 
@@ -69,5 +69,81 @@ describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
 
         cy.get('input[type="checkbox"]:checked')
             .should('have.length', 0);
+    });
+
+    it('should select 2 rows (Task 3,4), then move row and expect the 2 rows to still be selected without any others', () => {
+        cy.get('[style="top:50px"] > .slick-cell:nth(2)').click();
+        cy.get('[style="top:100px"] > .slick-cell:nth(2)').click();
+
+        cy.get('[style="top:50px"] > .slick-cell.cell-reorder').as('moveIconTask3');
+        cy.get('[style="top:125px"] > .slick-cell.cell-reorder').as('moveIconTask5');
+
+        cy.get('@moveIconTask3').should('have.length', 1);
+
+        cy.get('@moveIconTask3')
+            .trigger('mousedown', { button: 0, force: true })
+            .trigger('mousemove', 'bottomRight');
+
+        cy.get('@moveIconTask5')
+            .trigger('mousemove', 'bottomRight')
+            .trigger('mouseup', 'bottomRight', { force: true });
+
+        cy.get('[style="top:0px"] > .slick-cell:nth(4)').should('contain', 'Task 0');
+        cy.get('[style="top:25px"] > .slick-cell:nth(4)').should('contain', 'Task 1');
+        cy.get('[style="top:50px"] > .slick-cell:nth(4)').should('contain', 'Task 2');
+        cy.get('[style="top:75px"] > .slick-cell:nth(4)').should('contain', 'Task 4');
+        cy.get('[style="top:100px"] > .slick-cell:nth(4)').should('contain', 'Task 5');
+        cy.get('[style="top:125px"] > .slick-cell:nth(4)').should('contain', 'Task 3');
+
+        // Task 4 and 3 should be selected
+        cy.get('input[type="checkbox"]:checked').should('have.length', 2);
+        cy.get('[style="top:75px"] > .slick-cell:nth(2) input[type="checkbox"]:checked').should('have.length', 1);
+        cy.get('[style="top:125px"] > .slick-cell:nth(2) input[type="checkbox"]:checked').should('have.length', 1);
+    });
+
+    it('should click on "Single Row Move OFF", then drag a row and expect both selected rows to be moved together', () => {
+        cy.contains('Single Row Move OFF').click();
+
+        cy.get('[style="top:175px"] > .slick-cell.cell-reorder').as('moveIconTask7');
+        cy.get('[style="top:125px"] > .slick-cell.cell-reorder').as('moveIconTask3');
+
+        cy.get('@moveIconTask3').should('have.length', 1);
+
+        cy.get('@moveIconTask3')
+            .trigger('mousedown', { button: 0, force: true })
+            .trigger('mousemove', 'bottomRight');
+
+        cy.get('@moveIconTask7')
+            .trigger('mousemove', 'bottomRight')
+            .trigger('mouseup', 'bottomRight', { force: true });
+
+        cy.get('[style="top:0px"] > .slick-cell:nth(4)').should('contain', 'Task 0');
+        cy.get('[style="top:25px"] > .slick-cell:nth(4)').should('contain', 'Task 1');
+        cy.get('[style="top:50px"] > .slick-cell:nth(4)').should('contain', 'Task 2');
+        cy.get('[style="top:75px"] > .slick-cell:nth(4)').should('contain', 'Task 5');
+        cy.get('[style="top:100px"] > .slick-cell:nth(4)').should('contain', 'Task 6');
+        cy.get('[style="top:125px"] > .slick-cell:nth(4)').should('contain', 'Task 7');
+        cy.get('[style="top:150px"] > .slick-cell:nth(4)').should('contain', 'Task 4');
+        cy.get('[style="top:175px"] > .slick-cell:nth(4)').should('contain', 'Task 3');
+
+        // Task 4 and 3 should be selected
+        cy.get('input[type="checkbox"]:checked').should('have.length', 2);
+        cy.get('[style="top:150px"] > .slick-cell:nth(2) input[type="checkbox"]:checked').should('have.length', 1);
+        cy.get('[style="top:175px"] > .slick-cell:nth(2) input[type="checkbox"]:checked').should('have.length', 1);
+    });
+
+    it('should open the Task 3 Row Detail and still expect same detail', () => {
+        cy.get('[style="top:175px"] > .slick-cell:nth(4)').should('contain', 'Task 3');
+
+        cy.get('[style="top:175px"] > .slick-cell:nth(0)')
+            .click()
+            .wait(250);
+
+        cy.get('.innerDetailView_3')
+            .find('h2')
+            .should('contain', 'Task 3');
+
+        cy.get('input[id="assignee_3"]')
+            .should('exist');
     });
 });

--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -72,10 +72,11 @@
 
     <div class="options-panel">
       <h2>Demonstrates:</h2>
+      <h3>The following three Plugins used together</h3>
       <ul>
         <li>1. Checkbox Row Selection</li>
         <li>2. Row Detail</li>
-        <li>3. Row Move</li>
+        <li>3. Row Move Manager</li>
       </ul>
 
       <h2>Options:</h2>
@@ -181,7 +182,7 @@
     function loadView(itemDetail) {
       return [
         '<div>',
-        '<h4>' + itemDetail.title + '</h4>',
+        '<h2>' + itemDetail.title + '</h2>',
         '<div class="detail">',
         '<label>Assignee:</label> <input id="assignee_' + itemDetail.id + '" type="text" value="' + itemDetail.assignee + '"/>',
         '</div>',
@@ -204,7 +205,7 @@
         itemDetail.assignee = fakeNames[randomNumber(0, 9)];
         itemDetail.reporter = fakeNames[randomNumber(0, 9)];
         notifyTemplate(itemDetail)
-      }, 1000);
+      }, 250);
     }
 
     // notify the onAsyncResponse with the "args.item" (required property)
@@ -238,7 +239,7 @@
         postTemplate: loadView,
         process: simulateServerCall,
         useRowClick: false,
-        panelRows: 6,
+        panelRows: 7,
         singleRowExpand: true
       });
 

--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -1,0 +1,358 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
+  <link rel="stylesheet" href="../slick.grid.css" type="text/css" />
+  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css" />
+  <link rel="stylesheet" href="examples.css" type="text/css" />
+  <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css" />
+  <link rel="stylesheet" href="../plugins/slick.rowdetailview.css" type="text/css" />
+  <style>
+    .cell-reorder {
+      cursor: move;
+      background: url("../images/drag-handle.png") no-repeat center center;
+    }
+
+    .cell-selection {
+      border-right-color: silver;
+      border-right-style: solid;
+      background: #f5f5f5;
+      color: gray;
+      text-align: right;
+      font-size: 10px;
+    }
+
+    .slick-row.selected .cell-selection {
+      background-color: transparent;
+      /* show default selected row background */
+    }
+
+    .slick-cell-checkboxsel {
+      background: #f0f0f0;
+      border-right-color: silver;
+      border-right-style: solid;
+    }
+
+    .slick-group-title[level='0'] {
+      font-weight: bold;
+    }
+
+    .slick-group-title[level='1'] {
+      text-decoration: underline;
+    }
+
+    .slick-group-title[level='2'] {
+      font-style: italic;
+    }
+
+    .detail {
+      padding: 5px
+    }
+
+    .preload {
+      font-size: 18px;
+    }
+
+    .dynamic-cell-detail> :first-child {
+      vertical-align: middle;
+      line-height: 13px;
+      padding: 10px;
+      margin-left: 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <div style="position:relative">
+    <div style="width:600px;">
+      <div id="myGrid" style="width:100%;height:500px;"></div>
+    </div>
+
+    <div class="options-panel">
+      <h2>Demonstrates:</h2>
+      <ul>
+        <li>1. Checkbox Row Selection</li>
+        <li>2. Row Detail</li>
+        <li>3. Row Move</li>
+      </ul>
+
+      <h2>Options:</h2>
+      <p>
+        <p>If you wish to use all 3 plugins at the same time, you might encounter some issues with row selections.
+          Since the Row Manager Plugin also uses the selected rows array to move multiple row at once,
+          you could if you to simply make the Row Move plugin to only allow 1 row be moved at a time,
+          doing this will make the 2 plugins work nicely together without any clashing.
+          The options you will want to use for that would these 2 options to predefine while instantiating the Row Move
+          Manager Plugin ({ singleRowMove: true, disableRowSelection: true })
+        </p>
+        <p></p>
+        <button onclick="rowMovePlugin.setOptions({ singleRowMove: true, disableRowSelection: true })">
+          Single Row Move ON
+        </button>
+        &nbsp;
+        <button onclick="rowMovePlugin.setOptions({ singleRowMove: false, disableRowSelection: false })">
+          Single Row Move OFF
+        </button>
+      </p>
+
+      <h2>View Source:</h2>
+      <ul>
+        <li>
+          <a href="https://github.com/6pac/SlickGrid/blob/master/examples/example-checkbox-selection-row-detail.html"
+            target="_sourcewindow">
+            View the source for this example on Github
+          </a>
+        </li>
+        <h3>Selected Titles:</h3>
+        <div id="selectedTitles" style="overflow-x: auto; white-space: nowrap; text-overflow: ellipsis;"></div>
+      </ul>
+    </div>
+  </div>
+
+  <script src="../lib/firebugx.js"></script>
+
+  <script src="../lib/jquery-1.12.4.min.js"></script>
+  <script src="../lib/jquery-ui.min.js"></script>
+  <script src="../lib/jquery.event.drag-2.3.0.js"></script>
+
+  <script src="../slick.core.js"></script>
+  <script src="../slick.formatters.js"></script>
+  <script src="../plugins/slick.cellrangeselector.js"></script>
+  <script src="../plugins/slick.checkboxselectcolumn.js"></script>
+  <script src="../plugins/slick.rowdetailview.js"></script>
+  <script src="../plugins/slick.rowmovemanager.js"></script>
+  <script src="../plugins/slick.rowselectionmodel.js"></script>
+  <script src="../controls/slick.columnpicker.js"></script>
+  <script src="../slick.grid.js"></script>
+  <script src="../slick.dataview.js"></script>
+
+  <script>
+    var grid;
+    var dataView;
+    var data = [];
+    var detailViewPlugin;
+    var checkboxSelectorPlugin;
+    var rowMovePlugin;
+    var sortcol = "title";
+    var sortdir = 1;
+
+    var fakeNames = ['John Doe', 'Jane Doe', 'Chuck Norris', 'Bumblebee', 'Jackie Chan', 'Elvis Presley', 'Bob Marley', 'Mohammed Ali', 'Bruce Lee', 'Rocky Balboa'];
+
+    var columns = [
+      { id: "move", name: "", field: "move", width: 40, behavior: "selectAndMove", selectable: false, resizable: false, cssClass: "cell-reorder dnd" },
+      { id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 40, resizable: false, selectable: false },
+      { id: "title", name: "Title", field: "title", width: 110, minWidth: 110, cssClass: "cell-title", sortable: true },
+      { id: "duration", name: "Duration", field: "duration", sortable: true },
+      { id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, sortable: true },
+      { id: "start", name: "Start", field: "start", minWidth: 60 },
+      { id: "finish", name: "Finish", field: "finish", minWidth: 60 },
+      { id: "effort-driven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark }
+    ];
+    var options = {
+      editable: false,
+      enableAddRow: false,
+      enableCellNavigation: true,
+      enableColumnReorder: true,
+      explicitInitialization: true,
+    };
+
+    function DataItem(i) {
+      this.id = i;
+      this.num = i;
+      this.percentComplete = Math.round(Math.random() * 100);
+      this.effortDriven = (i % 5 == 0);
+      this.start = "01/01/2009";
+      this.finish = "01/05/2009";
+      this.title = "Task " + i;
+      this.duration = "5 days";
+    }
+
+    function loadingTemplate() {
+      return '<div class="preload">Loading...</div>';
+    }
+
+    function loadView(itemDetail) {
+      return [
+        '<div>',
+        '<h4>' + itemDetail.title + '</h4>',
+        '<div class="detail">',
+        '<label>Assignee:</label> <input id="assignee_' + itemDetail.id + '" type="text" value="' + itemDetail.assignee + '"/>',
+        '</div>',
+        '<div class="detail"><label>Reporter:</label> <span>' + itemDetail.reporter + '</span></div>',
+        '<div class="detail"><label>Duration:</label> <span>' + itemDetail.duration + '</span></div>',
+        '<div class="detail"><label>% Complete:</label> <span>' + itemDetail.percentComplete + '</span></div>',
+        '<div class="detail"><label>Start:</label> <span>' + itemDetail.start + '</span></div>',
+        '<div class="detail"><label>Finish:</label> <span>' + itemDetail.finish + '</span></div>',
+        '<div class="detail"><label>Effort Driven:</label> <span>' + itemDetail.effortDriven + '</span></div>',
+        '<div class="detail"><label>Effort Driven:</label> <span>' + itemDetail.effortDriven + '</span></div>',
+        '</div>'
+      ].join('');
+    }
+
+    // fill the template with a delay to simulate a server call
+    function simulateServerCall(item) {
+      setTimeout(function () {
+        // let's add some property to our item for a better simulation
+        var itemDetail = item;
+        itemDetail.assignee = fakeNames[randomNumber(0, 9)];
+        itemDetail.reporter = fakeNames[randomNumber(0, 9)];
+        notifyTemplate(itemDetail)
+      }, 1000);
+    }
+
+    // notify the onAsyncResponse with the "args.item" (required property)
+    // the plugin will then use itemDetail to populate the detail panel with "postTemplate"
+    function notifyTemplate(itemDetail) {
+      detailViewPlugin.onAsyncResponse.notify({
+        "item": itemDetail
+      }, undefined, this);
+    }
+
+    function randomNumber(min, max) {
+      return Math.floor(Math.random() * (max - min + 1) + min);
+    }
+
+    function comparer(a, b) {
+      var x = a[sortcol], y = b[sortcol];
+      return (x == y ? 0 : (x > y ? 1 : -1));
+    }
+
+    $(function () {
+      // prepare the data
+      for (var i = 0; i < 1000; i++) {
+        data[i] = new DataItem(i);
+      }
+      dataView = new Slick.Data.DataView();
+
+      // create the row detail plugin
+      detailViewPlugin = new Slick.Plugins.RowDetailView({
+        cssClass: "detailView-toggle",
+        preTemplate: loadingTemplate,
+        postTemplate: loadView,
+        process: simulateServerCall,
+        useRowClick: false,
+        panelRows: 6,
+        singleRowExpand: true
+      });
+
+      // push the plugin as the first column
+      columns.unshift(detailViewPlugin.getColumnDefinition());
+
+      // create the Checkbox Selector and push it on first index 
+      var columnIndex = 2; // which column index position do we want to add the checkbox selector?
+      checkboxSelectorPlugin = new Slick.CheckboxSelectColumn({ cssClass: "slick-cell-checkboxsel" });
+      columns.splice(columnIndex, 0, checkboxSelectorPlugin.getColumnDefinition());
+
+      grid = new Slick.Grid("#myGrid", dataView, columns, options);
+
+      // register the Selection Model that will be used for all Plugins 
+      grid.setSelectionModel(new Slick.RowSelectionModel({ selectActiveRow: false }));
+
+      // register all Plugins (Row Selection / Row Detail)
+      grid.registerPlugin(checkboxSelectorPlugin);
+      grid.registerPlugin(detailViewPlugin);
+
+      rowMovePlugin = new Slick.RowMoveManager({ cancelEditOnDrag: true, singleRowMove: true, disableRowSelection: true });
+      grid.registerPlugin(rowMovePlugin);
+
+      rowMovePlugin.onBeforeMoveRows.subscribe(function (e, data) {
+        // collapse any Row Details to avoid any rendering issues
+        detailViewPlugin.collapseAll();
+
+        for (var i = 0; i < data.rows.length; i++) {
+          if (data.rows[i] == data.insertBefore || data.rows[i] == data.insertBefore - 1) {
+            e.stopPropagation();
+            return false;
+          }
+        }
+        return true;
+      });
+
+      rowMovePlugin.onMoveRows.subscribe(function (e, args) {
+        var extractedRows = [], left, right;
+        var rows = args.rows;
+        var insertBefore = args.insertBefore;
+        left = data.slice(0, insertBefore);
+        right = data.slice(insertBefore, data.length);
+
+        rows.sort(function (a, b) { return a - b; });
+
+        for (var i = 0; i < rows.length; i++) {
+          extractedRows.push(data[rows[i]]);
+        }
+
+        rows.reverse();
+
+        for (var i = 0; i < rows.length; i++) {
+          var row = rows[i];
+          if (row < insertBefore) {
+            left.splice(row, 1);
+          } else {
+            right.splice(row - insertBefore, 1);
+          }
+        }
+
+        data = left.concat(extractedRows.concat(right));
+
+        var selectedRows = [];
+        for (var i = 0; i < rows.length; i++)
+          selectedRows.push(left.length + i);
+
+        // grid.resetActiveCell();
+        dataView.beginUpdate();
+        dataView.setItems(data);
+        dataView.endUpdate();
+        grid.render();
+      });
+
+      var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
+
+      detailViewPlugin.onBeforeRowDetailToggle.subscribe(function (e, args) {
+        console.log('before toggling row detail', args.item);
+      });
+
+      detailViewPlugin.onAfterRowDetailToggle.subscribe(function (e, args) {
+        console.log('after toggling row detail', args.item);
+      });
+
+      detailViewPlugin.onAsyncEndUpdate.subscribe(function (e, args) {
+        console.log('finished updating the post async template', args);
+      });
+
+      grid.onSelectedRowsChanged.subscribe(function (e, args) {
+        var grid = args && args.grid;
+        var selectedTitles = '';
+        var sortedSelectedRows = args.rows.sort(function (a, b) { return a - b });
+
+        // get titles for all selected rows
+        if (Array.isArray(sortedSelectedRows)) {
+          selectedTitles = args.rows.map(function (idx) {
+            var item = grid.getDataItem(idx);
+            return item && item.title || '';
+          });
+        }
+        $('#selectedTitles').text(selectedTitles.toString());
+      });
+
+      grid.onSort.subscribe(function (e, args) {
+        sortdir = args.sortAsc ? 1 : -1;
+        sortcol = args.sortCol.field;
+
+        // using native sort with comparer
+        // preferred method but can be very slow in IE with huge datasets
+        dataView.sort(comparer, args.sortAsc);
+      });
+
+      // initialize the model after all the events have been hooked up
+      grid.init();
+      dataView.beginUpdate();
+      dataView.setItems(data);
+      dataView.endUpdate();
+      dataView.syncGridSelection(grid, true);
+    });
+  </script>
+</body>
+
+</html>

--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -97,10 +97,10 @@
         </button>
       </p>
       <p>
-        The RowMoveManager Plugin is can be configured with an "usabilityOverride" which will make the row moveable
-        or not depending on a custom override callback that can be provided by the user.
-        Also don't forget to also configure a custom formatter that will follow the same logic of when to show the icon.
-        For example this demo makes the row moveable only on every second row.
+        The RowMoveManager Plugin can be configured with an "usabilityOverride" which will make the row moveable
+        or not depending on a custom override callback that can be provided by the user (all 3 plugins have such
+        override). Also don't forget to also configure a custom formatter that will follow the same logic of when to
+        show the icon. For example this demo makes the row moveable only on every second row.
       </p>
 
       <h2>View Source:</h2>
@@ -146,16 +146,7 @@
 
     var fakeNames = ['John Doe', 'Jane Doe', 'Chuck Norris', 'Bumblebee', 'Jackie Chan', 'Elvis Presley', 'Bob Marley', 'Mohammed Ali', 'Bruce Lee', 'Rocky Balboa'];
 
-    // This Formatter is used in combo with the "usabilityOverride" defined in the RowMoveManager creation
-    var moveIconFormatter = function (row, cell, value, columnDef, dataContext) {
-      if (dataContext.id % 2 === 1) {
-        return { addClasses: "cell-reorder dnd" };
-      }
-      return "";
-    }
-
     var columns = [
-      { id: "move", name: "", field: "move", width: 40, behavior: "selectAndMove", selectable: false, resizable: false, formatter: moveIconFormatter },
       { id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 40, resizable: false, selectable: false },
       { id: "title", name: "Title", field: "title", width: 110, minWidth: 110, cssClass: "cell-title", sortable: true },
       { id: "duration", name: "Duration", field: "duration", sortable: true },
@@ -255,7 +246,7 @@
       columns.unshift(detailViewPlugin.getColumnDefinition());
 
       // create the Checkbox Selector and push it on first index 
-      var columnIndex = 2; // which column index position do we want to add the checkbox selector?
+      var columnIndex = 1; // which column index position do we want to add the checkbox selector?
       checkboxSelectorPlugin = new Slick.CheckboxSelectColumn({ cssClass: "slick-cell-checkboxsel" });
       columns.splice(columnIndex, 0, checkboxSelectorPlugin.getColumnDefinition());
 
@@ -280,6 +271,9 @@
         }
       });
       grid.registerPlugin(rowMovePlugin);
+
+      // use unshift to make it the 1st column OR splice to position it where you wish
+      columns.splice(1, 0, rowMovePlugin.getColumnDefinition());
 
       rowMovePlugin.onBeforeMoveRows.subscribe(function (e, data) {
         // collapse any Row Details to avoid any rendering issues

--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -276,12 +276,12 @@
       // use unshift to make it the 1st column OR splice to position it where you wish
       columns.splice(1, 0, rowMovePlugin.getColumnDefinition());
 
-      rowMovePlugin.onBeforeMoveRows.subscribe(function (e, data) {
+      rowMovePlugin.onBeforeMoveRows.subscribe(function (e, args) {
         // collapse any Row Details to avoid any rendering issues
         detailViewPlugin.collapseAll();
 
-        for (var i = 0; i < data.rows.length; i++) {
-          if (data.rows[i] == data.insertBefore || data.rows[i] == data.insertBefore - 1) {
+        for (var i = 0; i < args.rows.length; i++) {
+          if (args.rows[i] == args.insertBefore || args.rows[i] == args.insertBefore - 1) {
             e.stopPropagation();
             return false;
           }

--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -96,6 +96,12 @@
           Single Row Move OFF
         </button>
       </p>
+      <p>
+        The RowMoveManager Plugin is can be configured with an "usabilityOverride" which will make the row moveable
+        or not depending on a custom override callback that can be provided by the user.
+        Also don't forget to also configure a custom formatter that will follow the same logic of when to show the icon.
+        For example this demo makes the row moveable only on every second row.
+      </p>
 
       <h2>View Source:</h2>
       <ul>
@@ -140,8 +146,16 @@
 
     var fakeNames = ['John Doe', 'Jane Doe', 'Chuck Norris', 'Bumblebee', 'Jackie Chan', 'Elvis Presley', 'Bob Marley', 'Mohammed Ali', 'Bruce Lee', 'Rocky Balboa'];
 
+    // This Formatter is used in combo with the "usabilityOverride" defined in the RowMoveManager creation
+    var moveIconFormatter = function (row, cell, value, columnDef, dataContext) {
+      if (dataContext.id % 2 === 1) {
+        return { addClasses: "cell-reorder dnd" };
+      }
+      return "";
+    }
+
     var columns = [
-      { id: "move", name: "", field: "move", width: 40, behavior: "selectAndMove", selectable: false, resizable: false, cssClass: "cell-reorder dnd" },
+      { id: "move", name: "", field: "move", width: 40, behavior: "selectAndMove", selectable: false, resizable: false, formatter: moveIconFormatter },
       { id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 40, resizable: false, selectable: false },
       { id: "title", name: "Title", field: "title", width: 110, minWidth: 110, cssClass: "cell-title", sortable: true },
       { id: "duration", name: "Duration", field: "duration", sortable: true },
@@ -254,7 +268,17 @@
       grid.registerPlugin(checkboxSelectorPlugin);
       grid.registerPlugin(detailViewPlugin);
 
-      rowMovePlugin = new Slick.RowMoveManager({ cancelEditOnDrag: true, singleRowMove: true, disableRowSelection: true });
+      rowMovePlugin = new Slick.RowMoveManager({
+        cancelEditOnDrag: true,
+        singleRowMove: true,
+        disableRowSelection: true,
+
+        // make only every 2nd row an a moveable row,
+        // you can override it here in the options or externally by calling the method on the plugin instance
+        usabilityOverride: function (row, dataContext, grid) {
+          return (dataContext.id % 2 === 1);
+        }
+      });
       grid.registerPlugin(rowMovePlugin);
 
       rowMovePlugin.onBeforeMoveRows.subscribe(function (e, data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,14 +13,20 @@
         "@babel/highlight": "^7.8.3"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
+      "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
+      "dev": true
+    },
     "@babel/highlight": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
       "dev": true,
       "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
     },
@@ -514,35 +520,6 @@
         "untildify": "4.0.0",
         "url": "0.11.0",
         "yauzl": "2.10.0"
-      },
-      "dependencies": {
-        "request": {
-          "version": "github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16",
-          "from": "github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.5.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          }
-        }
       }
     },
     "dashdash": {
@@ -750,12 +727,20 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
-      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.2.0.tgz",
+      "integrity": "sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.0.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.0.0.tgz",
+          "integrity": "sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
@@ -1069,9 +1054,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -2048,9 +2033,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
     "pump": {
@@ -2107,6 +2092,33 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
+    },
+    "request": {
+      "version": "github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16",
+      "from": "github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
     },
     "request-progress": {
       "version": "3.0.0",

--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -125,7 +125,7 @@
     var _options = $.extend(true, {}, _defaults, options);
 
     // user could override the expandable icon logic from within the options or after instantiating the plugin
-    if(typeof _options.expandableOverride === 'function') {
+    if (typeof _options.expandableOverride === 'function') {
       expandableOverride(_options.expandableOverride);
     }
 
@@ -240,20 +240,18 @@
           return;
         }
 
-        var item = _dataView.getItem(args.row);
-
         // trigger an event before toggling
         _self.onBeforeRowDetailToggle.notify({
           'grid': _grid,
-          'item': item
+          'item': dataContext
         }, e, _self);
 
-        toggleRowSelection(args.row, item);
+        toggleRowSelection(args.row, dataContext);
 
         // trigger an event after toggling
         _self.onAfterRowDetailToggle.notify({
           'grid': _grid,
-          'item': item,
+          'item': dataContext,
           'expandedRows': _expandedRows,
         }, e, _self);
 

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -57,7 +57,7 @@
       options = $.extend({}, options, newOptions);
     }
 
-    function handleDragInit(e, dd) {
+    function handleDragInit(e) {
       // prevent the grid from cancelling drag'n'drop by default
       e.stopImmediatePropagation();
     }
@@ -125,6 +125,7 @@
       var insertBefore = Math.max(0, Math.min(Math.round(top / _grid.getOptions().rowHeight), _grid.getDataLength()));
       if (insertBefore !== dd.insertBefore) {
         var eventData = {
+          "grid": _grid,
           "rows": dd.selectedRows,
           "insertBefore": insertBefore
         };
@@ -153,6 +154,7 @@
 
       if (dd.canMove) {
         var eventData = {
+          "grid": _grid,
           "rows": dd.selectedRows,
           "insertBefore": dd.insertBefore
         };

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -13,7 +13,9 @@
     var _self = this;
     var _handler = new Slick.EventHandler();
     var _defaults = {
-      cancelEditOnDrag: false
+      cancelEditOnDrag: false,
+      singleRowMove: false,
+      disableRowSelection: false,
     };
 
     function init(grid) {
@@ -29,6 +31,10 @@
 
     function destroy() {
       _handler.unsubscribeAll();
+    }
+
+    function setOptions(newOptions) {
+      options = $.extend({}, options, newOptions);
     }
 
     function handleDragInit(e, dd) {
@@ -50,11 +56,13 @@
       _dragging = true;
       e.stopImmediatePropagation();
 
-      var selectedRows = _grid.getSelectedRows();
+      var selectedRows = options.singleRowMove ? [cell.row] : _grid.getSelectedRows();
 
       if (selectedRows.length === 0 || $.inArray(cell.row, selectedRows) == -1) {
         selectedRows = [cell.row];
-        _grid.setSelectedRows(selectedRows);
+        if (!options.disableRowSelection) {
+          _grid.setSelectedRows(selectedRows);
+        }
       }
 
       var rowHeight = _grid.getOptions().rowHeight;
@@ -62,18 +70,18 @@
       dd.selectedRows = selectedRows;
 
       dd.selectionProxy = $("<div class='slick-reorder-proxy'/>")
-          .css("position", "absolute")
-          .css("zIndex", "99999")
-          .css("width", $(_canvas).innerWidth())
-          .css("height", rowHeight * selectedRows.length)
-          .appendTo(_canvas);
+        .css("position", "absolute")
+        .css("zIndex", "99999")
+        .css("width", $(_canvas).innerWidth())
+        .css("height", rowHeight * selectedRows.length)
+        .appendTo(_canvas);
 
       dd.guide = $("<div class='slick-reorder-guide'/>")
-          .css("position", "absolute")
-          .css("zIndex", "99998")
-          .css("width", $(_canvas).innerWidth())
-          .css("top", -1000)
-          .appendTo(_canvas);
+        .css("position", "absolute")
+        .css("zIndex", "99998")
+        .css("width", $(_canvas).innerWidth())
+        .css("top", -1000)
+        .appendTo(_canvas);
 
       dd.insertBefore = -1;
     }
@@ -133,6 +141,7 @@
 
       "init": init,
       "destroy": destroy,
+      "setOptions": setOptions,
       "pluginName": "RowMoveManager"
     });
   }

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -1,3 +1,14 @@
+/**
+ * Row Move Manager options: 
+ *    cssClass:             A CSS class to be added to the menu item container.
+ *    columnId:             Column definition id (defaults to "_move")
+ *    cancelEditOnDrag:     Do we want to cancel any Editing while dragging a row (defaults to false)
+ *    disableRowSelection:  Do we want to disable the row selection? (defaults to false)
+ *    singleRowMove:        Do we want a single row move? Setting this to false means that it's a multple row move (defaults to false)
+ *    width:                Width of the column
+ *    usabilityOverride:    Callback method that user can override the default behavior of the row being moveable or not
+ *
+ */
 (function ($) {
   // register namespace
   $.extend(true, window, {
@@ -14,9 +25,12 @@
     var _usabilityOverride = null;
     var _handler = new Slick.EventHandler();
     var _defaults = {
+      columnId: "_move",
+      cssClass: null,
       cancelEditOnDrag: false,
-      singleRowMove: false,
       disableRowSelection: false,
+      singleRowMove: false,
+      width: 40,
     };
 
     // user could override the expandable icon logic from within the options or after instantiating the plugin
@@ -147,6 +161,28 @@
       }
     }
 
+    function getColumnDefinition() {
+      return {
+        id: options.columnId || "_move",
+        name: "",
+        field: "move",
+        width: options.width || 40,
+        behavior: "selectAndMove",
+        selectable: false,
+        resizable: false,
+        cssClass: options.cssClass,
+        formatter: moveIconFormatter
+      };
+    }
+
+    function moveIconFormatter(row, cell, value, columnDef, dataContext, grid) {
+      if (!checkUsabilityOverride(row, dataContext, grid)) {
+        return null;
+      } else {
+        return { addClasses: "cell-reorder dnd" };
+      }
+    }
+
     function checkUsabilityOverride(row, dataContext, grid) {
       if (typeof _usabilityOverride === 'function') {
         return _usabilityOverride(row, dataContext, grid);
@@ -169,6 +205,7 @@
 
       "init": init,
       "destroy": destroy,
+      "getColumnDefinition": getColumnDefinition,
       "setOptions": setOptions,
       "usabilityOverride": usabilityOverride,
       "pluginName": "RowMoveManager"


### PR DESCRIPTION
DO NOT MERGE YET - I still want to add Cypress E2E tests before merging

- closes #347
- this PR allows to use 3 plugins (RowDetail, RowMoveManager & CheckboxSelector) all at the same time. Our new project requires at least 2 of the 3 to be used together. 
- in order to achieve that, I added 2 new options to the Row Move Manager Plugin, the new options are (singleRowMove & disableRowSelection) and their default are set to false so it doesn't break anyone's code
- the main changes are done in the RowMoveManager plugin, while a couple of changes were also made in the RowDetail Plugin so that all 3 plugins all work nicely together. A new Example was added as well to demo all 3 plugins in 1 grid, Cypress E2E were also added

- [x] add a way to use all 3 plugins at the same time
- [x] add `usabilityOverride` to skip move icon displayed on each row for the RowMoveManager Plugin (same override as all other plugins)
- [x] add `getColumnDefinition()` method in the RowMoveManager Plugin with a custom formatter that is connected to the new `usabilityOverride` 
  - [x] should still work when user provide their own column definition (current behavior)
- [x] add `grid` object to the `args` parameter of `onMoveRows` and `onBeforeMoveRows`
- [x] add Cypress E2E tests

See animated gif below for a demo

![iAwSJhB685](https://user-images.githubusercontent.com/643976/77238721-3b7e4f00-6ba9-11ea-87d4-f066edf3382d.gif)

demo with `usabilityOverride` (RowMoveManager Plugin) to make only second rows moveable

![image](https://user-images.githubusercontent.com/643976/77387210-264d2000-6d63-11ea-97fe-a99ed2238424.png)
