### PR TITLE
fix(resize): measure scrollbar from body instead of viewport, fixes #275

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -730,7 +730,7 @@ if (typeof Slick === "undefined") {
     }
 
     function measureScrollbar() {
-      var $outerdiv = $('<div class="' + $viewport.className + '" style="position:absolute; top:-10000px; left:-10000px; overflow:auto; width:100px; height:100px;"></div>').appendTo($viewport);
+      var $outerdiv = $('<div class="' + $viewport.className + '" style="position:absolute; top:-10000px; left:-10000px; overflow:auto; width:100px; height:100px;"></div>').appendTo('body');
       var $innerdiv = $('<div style="width:200px; height:200px; overflow:auto;"></div>').appendTo($outerdiv);
       var dim = {
         width: $outerdiv[0].offsetWidth - $outerdiv[0].clientWidth,


### PR DESCRIPTION
- fixes #275

As discussed in the issue, this PR does the following

currently using append to `$viewport`
```js
var $outerdiv = $('<div class="' + $viewport.className + '" ...).appendTo($viewport);

// measure... {width: 8, height: 8} 
```
the code change to fix the issue is to append to `body` 
```js
var $outerdiv = $('<div class="' + $viewport.className + '" ...).appendTo('body');

// measure... {width: 17, height: 17} <-- CORRECT
```

- [x] tested every single Examples for any new issues and they all look good to me. 

@6pac 
I tried every single Examples and I couldn't find any issues or misbehavior with this change. You can do some more tests on your side if you want, feel free to merge at any time. 

Thanks