### PR TITLE
Protect against negative scrollTop/scrollLeft in _handleScroll

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -4028,6 +4028,11 @@ if (typeof Slick === "undefined") {
       var maxScrollDistanceY = $viewportScrollContainerY[0].scrollHeight - $viewportScrollContainerY[0].clientHeight;
       var maxScrollDistanceX = $viewportScrollContainerY[0].scrollWidth - $viewportScrollContainerY[0].clientWidth;
 
+      // Protect against erroneous clientHeight/Width greater than scrollHeight/Width.
+      // Sometimes seen in Chrome.
+      maxScrollDistanceY = Math.max(0, maxScrollDistanceY);
+      maxScrollDistanceX = Math.max(0, maxScrollDistanceX);
+
       // Ceiling the max scroll values
       if (scrollTop > maxScrollDistanceY) {
         scrollTop = maxScrollDistanceY;


### PR DESCRIPTION
With Chrome at certain zoom levels, the `clientHeight` of `$viewportScrollContainerY[0]` is reported as being 1 pixel larger than the `scrollHeight`.

![image](https://user-images.githubusercontent.com/2463873/77692858-61bf3880-6f75-11ea-8bf0-f392d56c93e5.png)

I think this may actually be a Chrome/Chromium bug as I don't think this should ever occur.

When this occurs and the `autoHeight` is set to true in the SlickGrid options, `th` is used in calculations even though it is `undefined`. This causes the grid to fail to render.

This pull request just protects against a negative value in `scrollTop` or `scrollLeft`.

Without changes in this PR:
![image](https://user-images.githubusercontent.com/2463873/77694515-1f4b2b00-6f78-11ea-9667-f7b78132d0af.png)

With changes:
![image](https://user-images.githubusercontent.com/2463873/77694574-3be76300-6f78-11ea-841b-0a19e58d5741.png)
