### PR TITLE
fix(plugin): Row Move Formatter should have empty text value

### DIFF
--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -181,7 +181,7 @@
       if (!checkUsabilityOverride(row, dataContext, grid)) {
         return null;
       } else {
-        return { addClasses: "cell-reorder dnd" };
+        return { addClasses: "cell-reorder dnd", text: "" };
       }
     }
 


### PR DESCRIPTION
- without the `text: ""`, it was showing `undefined` beside the icon in some occasion when the grid gets re-render.
- also note that the built-in formatter was added fairly recently in this previous PR #474 

Reference, you can see the 3 dots and `undefined` in html code

![image](https://user-images.githubusercontent.com/643976/79266562-c0d1e800-7e65-11ea-89b1-192c525c3bcc.png)
