### PR TITLE
fix(plugin): check usabilityOverride before accepting new position

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Check out the **[Examples](https://github.com/6pac/SlickGrid/wiki/Examples)** fo
 Also check out the [Wiki](https://github.com/6pac/SlickGrid/wiki) for news and documentation.
 
 ### E2E Tests with Cypress
-We are now starting to add E2E (end to end) tests in the browser with [Cypress](https://www.cypress.io/). You can see [here](https://github.com/6pac/SlickGrid/tree/master/cypress/integration) the list of Examples that now have E2E tests. We also added these Cypress E2E tests to the [GitHub Actions](https://github.com/features/actions) Workflow to automate certain steps while making sure any new commits aren't breaking the build/test. It will basically run all the E2E tests every time someone pushes a commit or a PR.
+We are now starting to add E2E (end to end) tests in the browser with [Cypress](https://www.cypress.io/). You can see [here](https://github.com/6pac/SlickGrid/tree/master/cypress/integration) the list of Examples that now have E2E tests. We also added these tests to the [GitHub Actions](https://github.com/features/actions) Workflow to automate certain steps while making sure any new commits aren't breaking the build/test. It will basically run all the E2E tests every time someone pushes a Commit or a Pull Request.
 
-We also welcome any contributions (tests or fixes) and if you wish to add Cypress E2E tests, all you need to do is to clone the repo and then run the following commands
+We also welcome any new contributions (tests or fixes) and if you wish to add Cypress E2E tests, all you need to do is to clone the repo and then run the following commands
 ```bash
-npm install # install all npm packages
-npm run server # run a local http server
-npm run cypress:open # open Cypress tool
+npm install             # install all npm packages
+npm run serve           # run a local http server on port 8080
+npm run cypress:open    # open Cypress tool
 ```
-Once Cypress UI is open, you can click on "Run all Specs" to start the E2E browser tests.
+Once the Cypress UI is open, you can then click on "Run all Specs" to execute all E2E browser tests.

--- a/cypress/integration/example-row-detail-selection-and-move.spec.js
+++ b/cypress/integration/example-row-detail-selection-and-move.spec.js
@@ -39,18 +39,19 @@ describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
             .should('have.length', 0);
     });
 
-    it('should drag opened Row Detail to another position in the grid', () => {
+    it('should drag opened Row Detail to another valid position in the grid', () => {
         cy.get('[style="top:25px"] > .slick-cell.cell-reorder').as('moveIconTask1');
         cy.get('[style="top:75px"] > .slick-cell.cell-reorder').as('moveIconTask3');
-
-        cy.get('@moveIconTask3').should('have.length', 1);
+        cy.get('[style="top:100px"]').as('expandIconTask4');
 
         cy.get('@moveIconTask3')
             .trigger('mousedown', { button: 0, force: true })
             .trigger('mousemove', 'bottomRight');
 
-        cy.get('@moveIconTask1')
-            .trigger('mousemove', 'bottomRight')
+        cy.get('[style="top:100px"]')
+            .trigger('mousemove', 'bottomRight', { force: true });
+
+        cy.get('[style="top:100px"]')
             .trigger('mouseup', 'bottomRight', { force: true });
 
         cy.get('input[type="checkbox"]:checked')
@@ -63,49 +64,68 @@ describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
 
         cy.get('[style="top:0px"] > .slick-cell:nth(4)').should('contain', 'Task 0');
         cy.get('[style="top:25px"] > .slick-cell:nth(4)').should('contain', 'Task 1');
-        cy.get('[style="top:50px"] > .slick-cell:nth(4)').should('contain', 'Task 3');
-        cy.get('[style="top:75px"] > .slick-cell:nth(4)').should('contain', 'Task 2');
-        cy.get('[style="top:100px"] > .slick-cell:nth(4)').should('contain', 'Task 4');
+        cy.get('[style="top:50px"] > .slick-cell:nth(4)').should('contain', 'Task 2');
+        cy.get('[style="top:75px"] > .slick-cell:nth(4)').should('contain', 'Task 4');
+        cy.get('[style="top:100px"] > .slick-cell:nth(4)').should('contain', 'Task 3');
 
         cy.get('input[type="checkbox"]:checked')
             .should('have.length', 0);
     });
 
-    it('should select 2 rows (Task 3,4), then move row and expect the 2 rows to still be selected without any others', () => {
-        cy.get('[style="top:50px"] > .slick-cell:nth(2)').click();
-        cy.get('[style="top:100px"] > .slick-cell:nth(2)').click();
+    it('should try moving a row to an invalid target and expect nothing moved (same rows as prior test)', () => {
+        cy.get('[style="top:25px"] > .slick-cell.cell-reorder').as('moveIconTask1');
+        cy.get('[style="top:100px"]').as('expandIconTask4');
 
-        cy.get('[style="top:50px"] > .slick-cell.cell-reorder').as('moveIconTask3');
-        cy.get('[style="top:125px"] > .slick-cell.cell-reorder').as('moveIconTask5');
-
-        cy.get('@moveIconTask3').should('have.length', 1);
-
-        cy.get('@moveIconTask3')
+        cy.get('@moveIconTask1')
             .trigger('mousedown', { button: 0, force: true })
             .trigger('mousemove', 'bottomRight');
 
-        cy.get('@moveIconTask5')
-            .trigger('mousemove', 'bottomRight')
+        cy.get('[style="top:75px"]')
+            .trigger('mousemove', 'topRight', { force: true });
+
+        cy.get('[style="top:75px"]')
+            .trigger('mouseup', 'topRight', { force: true });
+
+        cy.get('input[type="checkbox"]:checked')
+            .should('have.length', 0);
+    });
+
+    it('should select 2 rows (Task 1,3), then move row and expect the 2 rows to still be selected without any other rows', () => {
+        cy.get('[style="top:25px"] > .slick-cell:nth(2)').click();
+        cy.get('[style="top:100px"] > .slick-cell:nth(2)').click();
+
+        cy.get('[style="top:25px"] > .slick-cell.cell-reorder').as('moveIconTask1');
+        cy.get('[style="top:150px"]').as('moveIconTask3');
+
+        cy.get('@moveIconTask1').should('have.length', 1);
+
+        cy.get('@moveIconTask1')
+            .trigger('mousedown', { button: 0, force: true })
+            .trigger('mousemove', 'bottomRight');
+
+        cy.get('@moveIconTask3')
+            .trigger('mousemove', 'bottomRight', { force: true })
             .trigger('mouseup', 'bottomRight', { force: true });
 
         cy.get('[style="top:0px"] > .slick-cell:nth(4)').should('contain', 'Task 0');
-        cy.get('[style="top:25px"] > .slick-cell:nth(4)').should('contain', 'Task 1');
-        cy.get('[style="top:50px"] > .slick-cell:nth(4)').should('contain', 'Task 2');
-        cy.get('[style="top:75px"] > .slick-cell:nth(4)').should('contain', 'Task 4');
+        cy.get('[style="top:25px"] > .slick-cell:nth(4)').should('contain', 'Task 2');
+        cy.get('[style="top:50px"] > .slick-cell:nth(4)').should('contain', 'Task 4');
+        cy.get('[style="top:75px"] > .slick-cell:nth(4)').should('contain', 'Task 3');
         cy.get('[style="top:100px"] > .slick-cell:nth(4)').should('contain', 'Task 5');
-        cy.get('[style="top:125px"] > .slick-cell:nth(4)').should('contain', 'Task 3');
+        cy.get('[style="top:125px"] > .slick-cell:nth(4)').should('contain', 'Task 6');
+        cy.get('[style="top:150px"] > .slick-cell:nth(4)').should('contain', 'Task 1');
 
         // Task 4 and 3 should be selected
         cy.get('input[type="checkbox"]:checked').should('have.length', 2);
         cy.get('[style="top:75px"] > .slick-cell:nth(2) input[type="checkbox"]:checked').should('have.length', 1);
-        cy.get('[style="top:125px"] > .slick-cell:nth(2) input[type="checkbox"]:checked').should('have.length', 1);
+        cy.get('[style="top:150px"] > .slick-cell:nth(2) input[type="checkbox"]:checked').should('have.length', 1);
     });
 
     it('should click on "Single Row Move OFF", then drag a row and expect both selected rows to be moved together', () => {
         cy.contains('Single Row Move OFF').click();
 
         cy.get('[style="top:175px"] > .slick-cell.cell-reorder').as('moveIconTask7');
-        cy.get('[style="top:125px"] > .slick-cell.cell-reorder').as('moveIconTask3');
+        cy.get('[style="top:75px"] > .slick-cell.cell-reorder').as('moveIconTask3');
 
         cy.get('@moveIconTask3').should('have.length', 1);
 
@@ -113,23 +133,24 @@ describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
             .trigger('mousedown', { button: 0, force: true })
             .trigger('mousemove', 'bottomRight');
 
-        cy.get('@moveIconTask7')
-            .trigger('mousemove', 'bottomRight')
+        cy.get('[style="top:200px"]')
+            .trigger('mousemove', 'bottomRight', { force: true })
             .trigger('mouseup', 'bottomRight', { force: true });
 
         cy.get('[style="top:0px"] > .slick-cell:nth(4)').should('contain', 'Task 0');
-        cy.get('[style="top:25px"] > .slick-cell:nth(4)').should('contain', 'Task 1');
-        cy.get('[style="top:50px"] > .slick-cell:nth(4)').should('contain', 'Task 2');
+        cy.get('[style="top:25px"] > .slick-cell:nth(4)').should('contain', 'Task 2');
+        cy.get('[style="top:50px"] > .slick-cell:nth(4)').should('contain', 'Task 4');
         cy.get('[style="top:75px"] > .slick-cell:nth(4)').should('contain', 'Task 5');
         cy.get('[style="top:100px"] > .slick-cell:nth(4)').should('contain', 'Task 6');
         cy.get('[style="top:125px"] > .slick-cell:nth(4)').should('contain', 'Task 7');
-        cy.get('[style="top:150px"] > .slick-cell:nth(4)').should('contain', 'Task 4');
+        cy.get('[style="top:150px"] > .slick-cell:nth(4)').should('contain', 'Task 8');
         cy.get('[style="top:175px"] > .slick-cell:nth(4)').should('contain', 'Task 3');
+        cy.get('[style="top:200px"] > .slick-cell:nth(4)').should('contain', 'Task 1');
 
-        // Task 4 and 3 should be selected
+        // // Task 1 and 3 should be selected
         cy.get('input[type="checkbox"]:checked').should('have.length', 2);
-        cy.get('[style="top:150px"] > .slick-cell:nth(2) input[type="checkbox"]:checked').should('have.length', 1);
         cy.get('[style="top:175px"] > .slick-cell:nth(2) input[type="checkbox"]:checked').should('have.length', 1);
+        cy.get('[style="top:200px"] > .slick-cell:nth(2) input[type="checkbox"]:checked').should('have.length', 1);
     });
 
     it('should open the Task 3 Row Detail and still expect same detail', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "slickgrid",
-  "version": "2.4.20",
+  "version": "2.4.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -63,6 +63,34 @@
         }
       }
     },
+    "@cypress/request": {
+      "version": "2.88.5",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.5.tgz",
+      "integrity": "sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
     "@cypress/xvfb": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
@@ -93,11 +121,82 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@types/blob-util": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/blob-util/-/blob-util-1.3.3.tgz",
+      "integrity": "sha512-4ahcL/QDnpjWA2Qs16ZMQif7HjGP2cw3AGjHabybjw7Vm1EKu+cfQN1D78BaZbS1WJNa1opSMF5HNMztx7lR0w==",
+      "dev": true
+    },
+    "@types/bluebird": {
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.29.tgz",
+      "integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw==",
+      "dev": true
+    },
+    "@types/chai": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.7.tgz",
+      "integrity": "sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==",
+      "dev": true
+    },
+    "@types/chai-jquery": {
+      "version": "1.1.40",
+      "resolved": "https://registry.npmjs.org/@types/chai-jquery/-/chai-jquery-1.1.40.tgz",
+      "integrity": "sha512-mCNEZ3GKP7T7kftKeIs7QmfZZQM7hslGSpYzKbOlR2a2HCFf9ph4nlMRA9UnuOETeOQYJVhJQK7MwGqNZVyUtQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*",
+        "@types/jquery": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "@types/jquery": {
+      "version": "3.3.31",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.31.tgz",
+      "integrity": "sha512-Lz4BAJihoFw5nRzKvg4nawXPzutkv7wmfQ5121avptaSIXlDNJCUuxZxX/G+9EVidZGuO0UBlk+YjKbwRKJigg==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.1.tgz",
+      "integrity": "sha512-EZQUP3hSZQyTQRfiLqelC9NMWd1kqLcmQE0dMiklxBkgi84T+cHOhnKpgk4NnOWpGX863yE6+IaGnOXUNFqDnQ==",
+      "dev": true
+    },
+    "@types/sinon-chai": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.3.tgz",
+      "integrity": "sha512-TOUFS6vqS0PVL1I8NGVSNcFaNJtFoyZPXZ5zur+qlhDfOmQECZZM4H4kKgca6O8L+QceX/ymODZASfUfn+y4yQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
+      }
     },
     "@types/sizzle": {
       "version": "2.3.2",
@@ -479,13 +578,24 @@
       }
     },
     "cypress": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.2.0.tgz",
-      "integrity": "sha512-8LdreL91S/QiTCLYLNbIjLL8Ht4fJmu/4HGLxUI20Tc7JSfqEfCmXELrRfuPT0kjosJwJJZacdSji9XSRkPKUw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.4.0.tgz",
+      "integrity": "sha512-ZpsV3pVemANGi4Cxu0UIqFv23uHdDJZYlKY+8P/eixujCpI1TQ5RSPBp2grfV3ZvlGYrOXPJY44j9iEh1xoQug==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
+        "@cypress/request": "2.88.5",
         "@cypress/xvfb": "1.2.4",
+        "@types/blob-util": "1.3.3",
+        "@types/bluebird": "3.5.29",
+        "@types/chai": "4.2.7",
+        "@types/chai-jquery": "1.1.40",
+        "@types/jquery": "3.3.31",
+        "@types/lodash": "4.14.149",
+        "@types/minimatch": "3.0.3",
+        "@types/mocha": "5.2.7",
+        "@types/sinon": "7.5.1",
+        "@types/sinon-chai": "3.2.3",
         "@types/sizzle": "2.3.2",
         "arch": "2.1.1",
         "bluebird": "3.7.2",
@@ -499,7 +609,7 @@
         "eventemitter2": "4.1.2",
         "execa": "1.0.0",
         "executable": "4.1.1",
-        "extract-zip": "1.6.7",
+        "extract-zip": "1.7.0",
         "fs-extra": "8.1.0",
         "getos": "3.1.4",
         "is-ci": "2.0.0",
@@ -508,18 +618,25 @@
         "listr": "0.14.3",
         "lodash": "4.17.15",
         "log-symbols": "3.0.0",
-        "minimist": "1.2.2",
+        "minimist": "1.2.5",
         "moment": "2.24.0",
         "ospath": "1.2.2",
         "pretty-bytes": "5.3.0",
         "ramda": "0.26.1",
-        "request": "github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16",
         "request-progress": "3.0.0",
         "supports-color": "7.1.0",
         "tmp": "0.1.0",
         "untildify": "4.0.0",
         "url": "0.11.0",
         "yauzl": "2.10.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "dashdash": {
@@ -835,15 +952,15 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
       },
       "dependencies": {
         "debug": {
@@ -855,20 +972,26 @@
             "ms": "2.0.0"
           }
         },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
-        },
-        "yauzl": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-          "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-          "dev": true,
-          "requires": {
-            "fd-slicer": "~1.0.1"
-          }
         }
       }
     },
@@ -897,9 +1020,9 @@
       "dev": true
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -2085,6 +2208,14 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "regexpp": {
@@ -2092,33 +2223,6 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
-    },
-    "request": {
-      "version": "github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16",
-      "from": "github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
     },
     "request-progress": {
       "version": "3.0.0",
@@ -2179,9 +2283,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
       "dev": true
     },
     "safer-buffer": {
@@ -2286,6 +2390,14 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "strip-ansi": {
@@ -2631,17 +2743,6 @@
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
-      },
-      "dependencies": {
-        "fd-slicer": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-          "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-          "dev": true,
-          "requires": {
-            "pend": "~1.2.0"
-          }
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jquery-ui": ">=1.8.0"
   },
   "devDependencies": {
-    "cypress": "^4.2.0",
+    "cypress": "^4.4.0",
     "eslint": "^6.8.0",
     "http-server": "^0.12.1"
   }

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -131,11 +131,23 @@
         };
 
         if (_self.onBeforeMoveRows.notify(eventData) === false) {
-          dd.guide.css("top", -1000);
           dd.canMove = false;
         } else {
-          dd.guide.css("top", insertBefore * _grid.getOptions().rowHeight);
           dd.canMove = true;
+        }
+
+        // if there's a UsabilityOverride defined, we also need to verify that the condition is valid
+        if (_usabilityOverride) {
+          var insertBeforeDataContext = _grid.getDataItem(insertBefore);
+          dd.canMove = checkUsabilityOverride(insertBefore, insertBeforeDataContext, _grid);
+        }
+
+        // if the new target is possible we'll display the dark blue bar (representin the acceptability) at the target position
+        // else it won't show up (it will be off the screen)
+        if (!dd.canMove) {
+          dd.guide.css("top", -1000);
+        } else {
+          dd.guide.css("top", insertBefore * _grid.getOptions().rowHeight);
         }
 
         dd.insertBefore = insertBefore;
@@ -181,7 +193,7 @@
       if (!checkUsabilityOverride(row, dataContext, grid)) {
         return null;
       } else {
-        return { addClasses: "cell-reorder dnd", text: "" };
+        return { addClasses: "cell-reorder dnd" };
       }
     }
 


### PR DESCRIPTION
- we should not allow a row to be moved where it's not possible (where the "usabilityOverride" returns false)

### TODO
- [x] check visually that it works
- [x] add Cypress E2E test for this new behavior

in the Example shown below, we should only allow to move a row on every 2nd row (before or after the row move icon is displayed). When I introduced the "usabilityOverride" in PR #474 I forgot to check that condition, this PR fixes it.

![yolKmXRyEs](https://user-images.githubusercontent.com/643976/79362608-cd614980-7f14-11ea-89d8-a1208f33fb94.gif)
