### PR TITLE
fix(rowDetail): use column id instead of item id

### DIFF
--- a/plugins/slick.rowdetailview.js
+++ b/plugins/slick.rowdetailview.js
@@ -232,7 +232,7 @@
       }
 
       // clicking on a row select checkbox
-      if (_options.useRowClick || _grid.getColumns()[args.cell][_dataViewIdProperty] === _options.columnId && $(e.target).hasClass(_options.cssClass)) {
+      if (_options.useRowClick || _grid.getColumns()[args.cell]['id'] === _options.columnId && $(e.target).hasClass(_options.cssClass)) {
         // if editing, try to commit
         if (_grid.getEditorLock().isActive() && !_grid.getEditorLock().commitCurrentEdit()) {
           e.preventDefault();


### PR DESCRIPTION
- this issue is only noticeable when using "useRowClick: false" and a different dataViewIdProperty
- ref Angular-Slickgrid [issue](https://github.com/ghiscoding/Angular-Slickgrid/issues/440)