### PR TITLE
fix(gridMenu): add missing "headerColumnValueExtractor" to Grid Menu & fix #490

### DIFF
--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -135,7 +135,10 @@
       forceFitTitle: "Force fit columns",
       menuWidth: 18,
       resizeOnShowHeaderRow: false,
-      syncResizeTitle: "Synchronous resize"
+      syncResizeTitle: "Synchronous resize",
+      headerColumnValueExtractor: function (columnDef) {
+        return columnDef.name;
+      }
     };
 
     function init(grid) {
@@ -323,7 +326,7 @@
       };
 
       // run the override function (when defined), if the result is false it won't go further
-      if (!runOverrideFunctionWhenExists(_options.gridMenu.menuUsabilityOverride, callbackArgs)) {
+      if (_options && _options.gridMenu && !runOverrideFunctionWhenExists(_options.gridMenu.menuUsabilityOverride, callbackArgs)) {
         return;
       }
 
@@ -335,7 +338,7 @@
         }
       }
 
-      var $li, $input, columnId, excludeCssClass;
+      var $li, $input, columnId, columnLabel, excludeCssClass;
       for (var i = 0; i < columns.length; i++) {
         columnId = columns[i].id;
         excludeCssClass = columns[i].excludeFromGridMenu ? "hidden" : "";
@@ -348,8 +351,15 @@
           $input.attr("checked", "checked");
         }
 
+        // get the column label from the picker value extractor (user can optionally provide a custom extractor)
+        if (_options && _options.gridMenu && _options.gridMenu.headerColumnValueExtractor) {
+          columnLabel = _options.gridMenu.headerColumnValueExtractor(columns[i]);
+        } else {
+          columnLabel = _defaults.headerColumnValueExtractor(columns[i]);
+        }
+
         $("<label for='gridmenu-colpicker-" + columnId + "' />")
-          .html(columns[i].name)
+          .html(columnLabel)
           .appendTo($li);
       }
 

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -18,7 +18,8 @@
  *      iconImage: "../images/drag-handle.png",     // this is the Grid Menu icon (hamburger icon)
  *      iconCssClass: "fa fa-bars",                 // you can provide iconImage OR iconCssClass
  *      leaveOpen: false,                           // do we want to leave the Grid Menu open after a command execution? (false by default)
- *      menuWidth: 18,                              // width that will be use to resize the column header container (18 by default)
+ *      menuWidth: 18,                              // width (icon) that will be use to resize the column header container (18 by default)
+ *      contentMinWidth: 0,							            // defaults to 0 (auto), minimum width of grid menu content (command, column list) 
  *      resizeOnShowHeaderRow: false,               // false by default
  *
  *      // the last 2 checkboxes titles
@@ -134,6 +135,7 @@
       hideSyncResizeButton: false,
       forceFitTitle: "Force fit columns",
       menuWidth: 18,
+      contentMinWidth: 0,
       resizeOnShowHeaderRow: false,
       syncResizeTitle: "Synchronous resize",
       headerColumnValueExtractor: function (columnDef) {
@@ -389,10 +391,16 @@
         }
       }
 
+      var menuWidth = $menu.width();
+      var gridMenuIconWidth = (_options.gridMenu && _options.gridMenu.menuWidth) || _defaults.menuWidth;
+      var contentMinWidth = (_options.gridMenu && _options.gridMenu.contentMinWidth) ? _options.gridMenu.contentMinWidth : _defaults.contentMinWidth;
+      var currentMenuWidth = (contentMinWidth > menuWidth) ? contentMinWidth : (menuWidth + gridMenuIconWidth);
+
       $menu
         .css("top", e.pageY + 10)
-        .css("left", e.pageX - $menu.width())
+        .css("left", e.pageX - currentMenuWidth)
         .css("max-height", $(window).height() - e.pageY - 10)
+        .css("min-width", contentMinWidth)
         .show();
 
       $list.appendTo($menu);

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -391,18 +391,27 @@
         }
       }
 
+      var menuIconOffset = $(e.target).prop('nodeName') == "button" ? $(e.target).offset() : $(e.target).parent("button").offset(); // get button offset position
+      if (!menuIconOffset) {
+        menuIconOffset = $(e.target).offset(); // external grid menu might fall in this last case
+      }
       var menuWidth = $menu.width();
       var gridMenuIconWidth = (_options.gridMenu && _options.gridMenu.menuWidth) || _defaults.menuWidth;
       var contentMinWidth = (_options.gridMenu && _options.gridMenu.contentMinWidth) ? _options.gridMenu.contentMinWidth : _defaults.contentMinWidth;
       var currentMenuWidth = (contentMinWidth > menuWidth) ? contentMinWidth : (menuWidth + gridMenuIconWidth);
+      var nextPositionTop = e.pageY > 0 ? e.pageY : menuIconOffset.top + 10;
+      var nextPositionLeft = e.pageX > 0 ? e.pageX : menuIconOffset.left + 10;
 
       $menu
-        .css("top", e.pageY + 10)
-        .css("left", e.pageX - currentMenuWidth)
-        .css("max-height", $(window).height() - e.pageY - 10)
-        .css("min-width", contentMinWidth)
-        .show();
+        .css("top", nextPositionTop + 10)
+        .css("left", nextPositionLeft - currentMenuWidth + 10)
+        .css("max-height", $(window).height() - e.pageY - 10);
 
+      if (contentMinWidth > 0) {
+        $menu.css("min-width", contentMinWidth);
+      }
+
+      $menu.show();
       $list.appendTo($menu);
       _isMenuOpen = true;
 

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -21,6 +21,7 @@
  *      menuWidth: 18,                              // width (icon) that will be use to resize the column header container (18 by default)
  *      contentMinWidth: 0,							            // defaults to 0 (auto), minimum width of grid menu content (command, column list) 
  *      resizeOnShowHeaderRow: false,               // false by default
+ *      useClickToRepositionMenu: true,             // true by default
  *
  *      // the last 2 checkboxes titles
  *      hideForceFitButton: false,                  // show/hide checkbox near the end "Force Fit Columns"
@@ -44,9 +45,11 @@
  *     hideForceFitButton:        Hide the "Force fit columns" button (defaults to false)
  *     hideSyncResizeButton:      Hide the "Synchronous resize" button (defaults to false)
  *     forceFitTitle:             Text of the title "Force fit columns"
+ *     contentMinWidth:						minimum width of grid menu content (command, column list), defaults to 0 (auto)
  *     menuWidth:                 Grid menu button width (defaults to 18)
  *     resizeOnShowHeaderRow:     Do we want to resize on the show header row event
  *     syncResizeTitle:           Text of the title "Synchronous resize"
+ *     useClickToRepositionMenu:  Use the Click offset to reposition the Grid Menu (defaults to true), when set to False it will use the icon offset to reposition the grid menu
  *     menuUsabilityOverride:     Callback method that user can override the default behavior of enabling/disabling the menu from being usable (must be combined with a custom formatter)
  *
  * Available custom menu item options:
@@ -138,6 +141,7 @@
       contentMinWidth: 0,
       resizeOnShowHeaderRow: false,
       syncResizeTitle: "Synchronous resize",
+      useClickToRepositionMenu: true,
       headerColumnValueExtractor: function (columnDef) {
         return columnDef.name;
       }
@@ -396,11 +400,12 @@
         menuIconOffset = $(e.target).offset(); // external grid menu might fall in this last case
       }
       var menuWidth = $menu.width();
+      var useClickToRepositionMenu = (_options.gridMenu && _options.gridMenu.useClickToRepositionMenu !== undefined) ? _options.gridMenu.useClickToRepositionMenu : _defaults.useClickToRepositionMenu;
       var gridMenuIconWidth = (_options.gridMenu && _options.gridMenu.menuWidth) || _defaults.menuWidth;
       var contentMinWidth = (_options.gridMenu && _options.gridMenu.contentMinWidth) ? _options.gridMenu.contentMinWidth : _defaults.contentMinWidth;
       var currentMenuWidth = (contentMinWidth > menuWidth) ? contentMinWidth : (menuWidth + gridMenuIconWidth);
-      var nextPositionTop = e.pageY > 0 ? e.pageY : menuIconOffset.top + 10;
-      var nextPositionLeft = e.pageX > 0 ? e.pageX : menuIconOffset.left + 10;
+      var nextPositionTop = (useClickToRepositionMenu && e.pageY > 0) ? e.pageY : menuIconOffset.top + 10;
+      var nextPositionLeft = (useClickToRepositionMenu && e.pageX > 0) ? e.pageX : menuIconOffset.left + 10;
 
       $menu
         .css("top", nextPositionTop + 10)

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -410,7 +410,7 @@
       $menu
         .css("top", nextPositionTop + 10)
         .css("left", nextPositionLeft - currentMenuWidth + 10)
-        .css("max-height", $(window).height() - e.pageY - 10);
+        .css("max-height", $(window).height() - e.pageY - 15);
 
       if (contentMinWidth > 0) {
         $menu.css("min-width", contentMinWidth);

--- a/examples/example-frozen-columns-and-column-group.html
+++ b/examples/example-frozen-columns-and-column-group.html
@@ -6,6 +6,8 @@
   <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
+  <link rel="stylesheet" href="../controls/slick.gridmenu.css" type="text/css"/>
   <style>
     .slick-preheader-panel.ui-state-default  {
       width: 100%;
@@ -45,6 +47,8 @@
 <script src="../slick.core.js"></script>
 <script src="../slick.dataview.js"></script>
 <script src="../slick.grid.js"></script>
+<script src="../controls/slick.columnpicker.js"></script>
+<script src="../controls/slick.gridmenu.js"></script>
 
 <script>
   function CreateAddlHeaderRow() {
@@ -83,9 +87,19 @@
     }
   }
 
+  function pickerHeaderColumnValueExtractor(column) {
+    var headerGroup = column.columnGroup || '';
+    if (headerGroup) {
+      return headerGroup + ' - ' + column.name;
+    }
+    return column.name;
+  }
+
   var dataView;
   var grid;
   var data = [];
+  var columnpicker;
+  var gridMenuControl;
   var options = {
     enableCellNavigation: true,
     enableColumnReorder: false,
@@ -93,7 +107,15 @@
     showPreHeaderPanel: true,
     preHeaderPanelHeight: 23,
     explicitInitialization: true,
-    frozenColumn: 2
+    frozenColumn: 2,
+
+    // if you wish to include the columnGroup as part of the pickers, you can do so with following code 
+    columnPicker: {
+      headerColumnValueExtractor: pickerHeaderColumnValueExtractor
+    },
+    gridMenu: {
+      headerColumnValueExtractor: pickerHeaderColumnValueExtractor
+    },
   };
   var columns = [
     {id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 40, resizable: false, selectable: false },
@@ -121,6 +143,8 @@
 
     dataView = new Slick.Data.DataView();
     grid = new Slick.Grid("#myGrid", dataView, columns, options);
+    columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
+    gridMenuControl = new Slick.Controls.GridMenu(columns, grid, options);
 
     dataView.onRowCountChanged.subscribe(function (e, args) {
       grid.updateRowCount();

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -170,6 +170,7 @@
     // gridMenu Object is optional
     // when not passed, it will act as a regular Column Picker (with default Grid Menu image of drag-handle.png)
     gridMenu: {
+      useClickToRepositionMenu: false, // defaults to true (false would use the icon offset to reposition the grid menu)
       menuUsabilityOverride: function (args) {
         // we could disable the menu entirely by returning false
         return true;


### PR DESCRIPTION
- The `headerColumnValueExtractor` is especially useful when having Header Title Column Grouping if we want to include the title as part of the column picker list within the Grid Menu
- add a new `contentMinWidth` grid menu option
- add a new `useClickToRepositionMenu` grid menu option, which use the click offset or the icon offset (when false) to reposition the grid menu
- lastly, I also fixed issue #490 by making the grid menu also work with keyboard event (ENTER)

When I created the Grid Menu control, I forgot to include the `headerColumnValueExtractor` function that the Column Picker already has, this is really helpful when having a grid with Column Header Title Grouping as can be seen below

@6pac in case you're wondering, @ghiscoding-SE is my work GitHub account, I work for Schneider Electric, hence the SE ;)

- [x] current Cypress E2E tests should be enough to cover this PR
- [x] also tested manually with my local setup

BEFORE 

![image](https://user-images.githubusercontent.com/643976/81958465-0eb04c00-95dc-11ea-9021-1991acedc32d.png)

AFTER 

![image](https://user-images.githubusercontent.com/643976/81958576-2ee00b00-95dc-11ea-828f-306567d9327b.png)
