### PR TITLE
fix(picker): ColumnPicker/GridMenu exclude hidden cols when forceFitCols

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -183,12 +183,12 @@
 
     function updateColumn(e) {
       if ($(e.target).data("option") == "autoresize") {
-        if (e.target.checked) {
-          _grid.setOptions({ forceFitColumns: true });
-          _grid.autosizeColumns();
-        } else {
-          _grid.setOptions({ forceFitColumns: false });
-        }
+        // when calling setOptions, it will resize with ALL Columns (even the hidden ones)
+        // we can avoid this problem by keeping a reference to the visibleColumns before setOptions and then setColumns after 
+        var previousVisibleColumns = getVisibleColumns();
+        var isChecked = e.target.checked;
+        _grid.setOptions({ forceFitColumns: isChecked });
+        _grid.setColumns(previousVisibleColumns);
         return;
       }
 
@@ -215,7 +215,7 @@
         }
 
         _grid.setColumns(visibleColumns);
-        onColumnsChanged.notify({ columns: visibleColumns, grid: _grid });
+        onColumnsChanged.notify({ allColumns: columns, columns: visibleColumns, grid: _grid });
       }
     }
 
@@ -223,11 +223,17 @@
       return columns;
     }
 
+    /** visible columns, we can simply get them directly from the grid */
+    function getVisibleColumns() {
+      return _grid.getColumns();
+    }
+
     init(_grid);
 
     return {
       "init": init,
       "getAllColumns": getAllColumns,
+      "getVisibleColumns": getVisibleColumns,
       "destroy": destroy,
       "updateAllTitles": updateAllTitles,
       "onColumnsChanged": onColumnsChanged

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -487,12 +487,12 @@
 
     function updateColumn(e) {
       if ($(e.target).data("option") == "autoresize") {
-        if (e.target.checked) {
-          _grid.setOptions({ forceFitColumns: true });
-          _grid.autosizeColumns();
-        } else {
-          _grid.setOptions({ forceFitColumns: false });
-        }
+        // when calling setOptions, it will resize with ALL Columns (even the hidden ones)
+        // we can avoid this problem by keeping a reference to the visibleColumns before setOptions and then setColumns after 
+        var previousVisibleColumns = getVisibleColumns();
+        var isChecked = e.target.checked;
+        _grid.setOptions({ forceFitColumns: isChecked });
+        _grid.setColumns(previousVisibleColumns);
         return;
       }
 


### PR DESCRIPTION
- there was an issue happening after toggling the "Force Fit Columns" flag when having hidden columns, it was not respecting the list of columns and hidden columns were coming back as visible even though they were hidden prior to the flag change. In other words, calling "Force Fit" shouldn't change any column visibilities.
- this issue was first reported in this [issue](https://github.com/ghiscoding/Angular-Slickgrid/issues/461) on the Angular-Slickgrid lib.

- [x] current Cypress E2E tests should be enough for this PR
- [x] also test manually with my local setup

The issue was mentioned as the following

> I mean when i hide some column 
![image](https://user-images.githubusercontent.com/31447178/82116443-30d7d480-976a-11ea-8c97-83eb13ead628.png)
and then i click 'Force Fit Columns' I get all columns but I expected to get columns without 'Effort Driven'
![image](https://user-images.githubusercontent.com/31447178/82116476-68df1780-976a-11ea-8795-78f8f717cec0.png)

