### PR TITLE
fix(core): queuePostProcessedRowForCleanup is missing

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3307,12 +3307,16 @@ if (typeof Slick === "undefined") {
         cacheEntry.rowNode.hide();
 
         zombieRowNodeFromLastMouseWheelEvent = cacheEntry.rowNode;
+        zombieRowCacheFromLastMouseWheelEvent = cacheEntry;
+        zombieRowPostProcessedFromLastMouseWheelEvent = postProcessedRows[row];
       } else {
-
-        cacheEntry.rowNode.each(function() {
-          this.parentElement.removeChild(this);
-        });
-
+        if (options.enableAsyncPostRenderCleanup && postProcessedRows[row]) {
+          queuePostProcessedRowForCleanup(cacheEntry, postProcessedRows[row], row);
+        } else {
+          cacheEntry.rowNode.each(function() {
+            this.parentElement.removeChild(this);
+          });
+        }
       }
 
       delete rowsCache[row];
@@ -4381,9 +4385,15 @@ if (typeof Slick === "undefined") {
 
         if (zombieRowNodeFromLastMouseWheelEvent && zombieRowNodeFromLastMouseWheelEvent[left? 0:1] != rowNode) {
           var zombieRow = zombieRowNodeFromLastMouseWheelEvent[left || zombieRowNodeFromLastMouseWheelEvent.length == 1? 0:1];
-          zombieRow.parentElement.removeChild(zombieRow);
-
+          if (options.enableAsyncPostRenderCleanup && zombieRowPostProcessedFromLastMouseWheelEvent) {
+            queuePostProcessedRowForCleanup(zombieRowCacheFromLastMouseWheelEvent,
+              zombieRowPostProcessedFromLastMouseWheelEvent);
+          } else {
+            zombieRow.parentElement.removeChild(zombieRow);
+          }
           zombieRowNodeFromLastMouseWheelEvent = null;
+          zombieRowCacheFromLastMouseWheelEvent = null
+          zombieRowPostProcessedFromLastMouseWheelEvent = null;
         }
 
         rowNodeFromLastMouseWheelEvent = rowNode;


### PR DESCRIPTION
- when merging X-Slickgrid for the Frozen stuff, the `queuePostProcessedRowForCleanup` was forgotten as part of the merge.
- ref issue #483 

## Ready for Testing

I don't know how to test it, so please don't merge until someone knows how to test it and possibly change the code if need be. I copied over the missing piece of code, but that might not work since some of the X-Slickgrid uses jQuery DOM references while in this fork, there are portions which use native DOM references. So unless someone knows how to test it, this PR might not be merged. 

I tried the `example10a-async-post-render-cleanup.html` and I don't see any error. I see a bunch of console log showing cleaned/rendered. So I assume everything is good, is there anything else that can be tested for this `queuePostProcessedRowForCleanup` method? If that is the only example to test with, it looks fine to me.

Some references 

> Looking at previous version tag `2.3.23`, it seems to be called at 2 different places [here](https://github.com/6pac/SlickGrid/blob/2.3.23/slick.grid.js#L1842) and [here](https://github.com/6pac/SlickGrid/blob/2.3.23/slick.grid.js#L2637)

There's also [unpkg - SlickGrid@2.3.23](https://unpkg.com/browse/slickgrid@2.3.23/) which you can see any version code. 

![image](https://user-images.githubusercontent.com/643976/82134972-acb63900-97cb-11ea-8132-f1f5de73e87c.png)
