### PR TITLE
fix(core): `resizeCanvas` should include preheader height, fixes #493

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3478,7 +3478,7 @@ if (typeof Slick === "undefined") {
       }
 
       // The top viewport does not contain the top panel or header row
-      viewportTopH = paneTopH - topPanelH - preHeaderHeight - headerRowH - footerRowH;
+      viewportTopH = paneTopH - topPanelH - headerRowH - footerRowH;
 
       if (options.autoHeight) {
         if (hasFrozenColumns()) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3452,6 +3452,7 @@ if (typeof Slick === "undefined") {
       paneBottomH = 0;
       viewportTopH = 0;
       viewportBottomH = 0;
+      var preHeaderHeight = options.showPreHeaderPanel ? options.preHeaderPanelHeight : 0;
 
       getViewportWidth();
       getViewportHeight();
@@ -3470,14 +3471,14 @@ if (typeof Slick === "undefined") {
       }
 
       // The top pane includes the top panel and the header row
-      paneTopH += topPanelH + headerRowH + footerRowH;
+      paneTopH += topPanelH + preHeaderHeight + headerRowH + footerRowH;
 
       if (hasFrozenColumns() && options.autoHeight) {
         paneTopH += scrollbarDimensions.height;
       }
 
       // The top viewport does not contain the top panel or header row
-      viewportTopH = paneTopH - topPanelH - headerRowH - footerRowH;
+      viewportTopH = paneTopH - topPanelH - preHeaderHeight - headerRowH - footerRowH;
 
       if (options.autoHeight) {
         if (hasFrozenColumns()) {


### PR DESCRIPTION
- ref #493

- [x] Tested locally with the Auto-Resize Example, also confirmed with the user that it works on his side and was discussed in issue #493. 