### PR TITLE
fix(pickers): ColumnPicker/GridMenu with 2 independent grids

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -30,6 +30,7 @@
   function SlickColumnPicker(columns, grid, options) {
     var _grid = grid;
     var _options = options;
+    var _gridUid = (grid && grid.getUID) ? grid.getUID() : '';
     var $columnTitleElm;
     var $list;
     var $menu;
@@ -55,7 +56,7 @@
       grid.onColumnsReordered.subscribe(updateColumnOrder);
       _options = $.extend({}, defaults, options);
 
-      $menu = $("<div class='slick-columnpicker' style='display:none' />").appendTo(document.body);
+      $menu = $("<div class='slick-columnpicker " + _gridUid + "' style='display:none' />").appendTo(document.body);
       $("<button type='button' class='close' data-dismiss='slick-columnpicker' aria-label='Close'><span class='close' aria-hidden='true'>&times;</span></button>").appendTo($menu);
 
       // user could pass a title on top of the columns list
@@ -101,7 +102,7 @@
         columnId = columns[i].id;
         excludeCssClass = columns[i].excludeFromColumnPicker ? "hidden" : "";
         $li = $('<li class="' + excludeCssClass + '" />').appendTo($list);
-        $input = $("<input type='checkbox' id='colpicker-" + columnId + "' />").data("column-id", columnId).appendTo($li);
+        $input = $("<input type='checkbox' id='" + _gridUid + "colpicker-" + columnId + "' />").data("column-id", columnId).appendTo($li);
         columnCheckboxes.push($input);
 
         if (_grid.getColumnIndex(columnId) != null) {
@@ -114,7 +115,7 @@
           columnLabel = defaults.headerColumnValueExtractor(columns[i]);
         }
 
-        $("<label for='colpicker-" + columnId + "' />")
+        $("<label for='" + _gridUid + "colpicker-" + columnId + "' />")
           .html(columnLabel)
           .appendTo($li);
       }
@@ -126,8 +127,8 @@
       if (!(_options.columnPicker && _options.columnPicker.hideForceFitButton)) {
         var forceFitTitle = (_options.columnPicker && _options.columnPicker.forceFitTitle) || _options.forceFitTitle;
         $li = $("<li />").appendTo($list);
-        $input = $("<input type='checkbox' id='colpicker-forcefit' />").data("option", "autoresize").appendTo($li);
-        $("<label for='colpicker-forcefit' />").text(forceFitTitle).appendTo($li);
+        $input = $("<input type='checkbox' id='" + _gridUid + "colpicker-forcefit' />").data("option", "autoresize").appendTo($li);
+        $("<label for='" + _gridUid + "colpicker-forcefit' />").text(forceFitTitle).appendTo($li);
         if (_grid.getOptions().forceFitColumns) {
           $input.attr("checked", "checked");
         }
@@ -136,8 +137,8 @@
       if (!(_options.columnPicker && _options.columnPicker.hideSyncResizeButton)) {
         var syncResizeTitle = (_options.columnPicker && _options.columnPicker.syncResizeTitle) || _options.syncResizeTitle;
         $li = $("<li />").appendTo($list);
-        $input = $("<input type='checkbox' id='colpicker-syncresize' />").data("option", "syncresize").appendTo($li);
-        $("<label for='colpicker-syncresize' />").text(syncResizeTitle).appendTo($li);
+        $input = $("<input type='checkbox' id='" + _gridUid + "colpicker-syncresize' />").data("option", "syncresize").appendTo($li);
+        $("<label for='" + _gridUid + "colpicker-syncresize' />").text(syncResizeTitle).appendTo($li);
         if (_grid.getOptions().syncColumnCellResize) {
           $input.attr("checked", "checked");
         }

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -350,7 +350,7 @@
         excludeCssClass = columns[i].excludeFromGridMenu ? "hidden" : "";
         $li = $('<li class="' + excludeCssClass + '" />').appendTo($list);
 
-        $input = $("<input type='checkbox' id='gridmenu-colpicker-" + columnId + "' />").data("column-id", columns[i].id).appendTo($li);
+        $input = $("<input type='checkbox' id='" + _gridUid + "-gridmenu-colpicker-" + columnId + "' />").data("column-id", columns[i].id).appendTo($li);
         columnCheckboxes.push($input);
 
         if (_grid.getColumnIndex(columns[i].id) != null) {
@@ -364,7 +364,7 @@
           columnLabel = _defaults.headerColumnValueExtractor(columns[i]);
         }
 
-        $("<label for='gridmenu-colpicker-" + columnId + "' />")
+        $("<label for='" + _gridUid + "-gridmenu-colpicker-" + columnId + "' />")
           .html(columnLabel)
           .appendTo($li);
       }
@@ -376,8 +376,8 @@
       if (!(_options.gridMenu && _options.gridMenu.hideForceFitButton)) {
         var forceFitTitle = (_options.gridMenu && _options.gridMenu.forceFitTitle) || _defaults.forceFitTitle;
         $li = $("<li />").appendTo($list);
-        $input = $("<input type='checkbox' id='gridmenu-colpicker-forcefit' />").data("option", "autoresize").appendTo($li);
-        $("<label for='gridmenu-colpicker-forcefit' />").text(forceFitTitle).appendTo($li);
+        $input = $("<input type='checkbox' id='" + _gridUid + "-gridmenu-colpicker-forcefit' />").data("option", "autoresize").appendTo($li);
+        $("<label for='" + _gridUid + "-gridmenu-colpicker-forcefit' />").text(forceFitTitle).appendTo($li);
 
         if (_grid.getOptions().forceFitColumns) {
           $input.attr("checked", "checked");
@@ -387,8 +387,8 @@
       if (!(_options.gridMenu && _options.gridMenu.hideSyncResizeButton)) {
         var syncResizeTitle = (_options.gridMenu && _options.gridMenu.syncResizeTitle) || _defaults.syncResizeTitle;
         $li = $("<li />").appendTo($list);
-        $input = $("<input type='checkbox' id='gridmenu-colpicker-syncresize' />").data("option", "syncresize").appendTo($li);
-        $("<label for='gridmenu-colpicker-syncresize' />").text(syncResizeTitle).appendTo($li);
+        $input = $("<input type='checkbox' id='" + _gridUid + "-gridmenu-colpicker-syncresize' />").data("option", "syncresize").appendTo($li);
+        $("<label for='" + _gridUid + "-gridmenu-colpicker-syncresize' />").text(syncResizeTitle).appendTo($li);
 
         if (_grid.getOptions().syncColumnCellResize) {
           $input.attr("checked", "checked");

--- a/cypress/integration/example-multi-grid-basic.spec.js
+++ b/cypress/integration/example-multi-grid-basic.spec.js
@@ -1,0 +1,280 @@
+/// <reference types="Cypress" />
+
+describe('Example - Grid Menu', () => {
+  const fullTitles = ['Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
+
+  beforeEach(() => {
+    // create a console.log spy for later use
+    cy.window().then((win) => {
+      cy.spy(win.console, "log");
+    });
+  });
+
+  it('should display Example Multi-grid Basic', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example-multi-grid-basic.html`);
+    cy.get('h2').should('contain', 'Demonstrates:');
+    cy.contains('Two basic Grids with minimal configuration');
+  });
+
+  it('should have exact same Column Titles in both grids', () => {
+    cy.get('#myGrid01')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+
+    cy.get('#myGrid02')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+  });
+
+  it('should open the Grid Menu on 1st Grid and expect all Columns to be checked', () => {
+    let gridUid = '';
+    cy.get('#myGrid01')
+      .find('button.slick-gridmenu-button')
+      .click({ force: true });
+
+    cy.get('#myGrid01')
+      .should(($grid) => {
+        const classes = $grid.prop('className').split(' ');
+        gridUid = classes.find(className => /slickgrid_.*/.test(className));
+        expect(gridUid).to.not.be.null;
+      })
+      .then(() => {
+        cy.get(`.slick-gridmenu.${gridUid}`)
+          .find('.slick-gridmenu-list')
+          .children('li')
+          .each(($child, index) => {
+            if (index <= 5) {
+              const $input = $child.children('input');
+              const $label = $child.children('label');
+              expect($input.attr('checked')).to.eq('checked');
+              expect($label.text()).to.eq(fullTitles[index]);
+            }
+          });
+      });
+  });
+
+  it('should then hide "Title" column from same 1st Grid and expect the column to be removed from 1st Grid', () => {
+    const newColumnList = ['Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
+    cy.get('#myGrid01')
+      .get('.slick-gridmenu:visible')
+      .find('.slick-gridmenu-list')
+      .children('li:visible:nth(0)')
+      .children('label')
+      .should('contain', 'Title')
+      .click({ force: true });
+
+    cy.get('#myGrid01')
+      .get('.slick-gridmenu:visible')
+      .find('span.close')
+      .click({ force: true });
+
+    cy.get('#myGrid01')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(newColumnList[index]));
+  });
+
+  it('should open the Grid Menu off 2nd Grid and expect all Columns to still be all checked', () => {
+    let gridUid = '';
+    cy.get('#myGrid02')
+      .find('button.slick-gridmenu-button')
+      .click({ force: true });
+
+    cy.get('#myGrid02')
+      .should(($grid) => {
+        const classes = $grid.prop('className').split(' ');
+        gridUid = classes.find(className => /slickgrid_.*/.test(className));
+        expect(gridUid).to.not.be.null;
+      })
+      .then(() => {
+        cy.get(`.slick-gridmenu.${gridUid}`)
+          .find('.slick-gridmenu-list')
+          .children('li')
+          .each(($child, index) => {
+            if (index <= 5) {
+              const $input = $child.children('input');
+              const $label = $child.children('label');
+              expect($input.attr('checked')).to.eq('checked');
+              expect($label.text()).to.eq(fullTitles[index]);
+            }
+          });
+      });
+  });
+
+  it('should then hide "% Complete" column from this same 2nd Grid and expect the column to be removed from 2nd Grid', () => {
+    const newColumnList = ['Title', 'Duration', 'Start', 'Finish', 'Effort Driven'];
+    cy.get('#myGrid02')
+      .get('.slick-gridmenu:visible')
+      .find('.slick-gridmenu-list')
+      .children('li:visible:nth(2)')
+      .children('label')
+      .should('contain', '% Complete')
+      .click({ force: true });
+
+    cy.get('#myGrid02')
+      .get('.slick-gridmenu:visible')
+      .find('span.close')
+      .click({ force: true });
+
+    cy.get('#myGrid02')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(newColumnList[index]));
+  });
+
+  it('should go back to 1st Grid and open its Grid Menu and we expect this grid to stil have the "Title" column be hidden (unchecked)', () => {
+    cy.get('#myGrid01')
+      .find('button.slick-gridmenu-button')
+      .click({ force: true });
+
+    cy.get('.slick-gridmenu-list')
+      .children('li')
+      .each(($child, index) => {
+        if (index <= 5) {
+          const $input = $child.children('input');
+          const $label = $child.children('label');
+          if ($label.text() === 'Title') {
+            expect($input.attr('checked')).to.eq(undefined);
+          } else {
+            expect($input.attr('checked')).to.eq('checked');
+          }
+          expect($label.text()).to.eq(fullTitles[index]);
+        }
+      });
+  });
+
+  it('should hide "Start" column from 1st Grid and expect to have 2 hidden columns (Title, Start)', () => {
+    const newColumnList = ['Duration', '% Complete', 'Finish', 'Effort Driven'];
+    cy.get('#myGrid01')
+      .get('.slick-gridmenu:visible')
+      .find('.slick-gridmenu-list')
+      .children('li:visible:nth(3)')
+      .children('label')
+      .should('contain', 'Start')
+      .click({ force: true });
+
+    cy.get('#myGrid01')
+      .get('.slick-gridmenu:visible')
+      .find('span.close')
+      .click({ force: true });
+
+    cy.get('#myGrid01')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(newColumnList[index]));
+  });
+
+  it('should open Column Picker of 2nd Grid and show the "% Complete" column back to visible', () => {
+    cy.get('#myGrid02')
+      .find('.slick-header-column')
+      .first()
+      .trigger('mouseover')
+      .trigger('contextmenu')
+      .invoke('show');
+
+    cy.get('.slick-columnpicker')
+      .find('.slick-columnpicker-list')
+      .children()
+      .each(($child, index) => {
+        if (index <= 5) {
+          expect($child.text()).to.eq(fullTitles[index]);
+        }
+      });
+
+    cy.get('.slick-columnpicker')
+      .find('.slick-columnpicker-list')
+      .children('li:nth-child(3)')
+      .children('label')
+      .should('contain', '% Complete')
+      .click();
+
+    cy.get('#myGrid02')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => {
+        if (index <= 5) {
+          expect($child.text()).to.eq(fullTitles[index]);
+        }
+      });
+
+    cy.get('#myGrid02')
+      .get('.slick-columnpicker:visible')
+      .find('span.close')
+      .trigger('click')
+      .click();
+  });
+
+  it('should open the Grid Menu on 2nd Grid and expect all Columns to be checked', () => {
+    let gridUid = '';
+    cy.get('#myGrid02')
+      .find('button.slick-gridmenu-button')
+      .click({ force: true });
+
+    cy.get('#myGrid02')
+      .should(($grid) => {
+        const classes = $grid.prop('className').split(' ');
+        gridUid = classes.find(className => /slickgrid_.*/.test(className));
+        expect(gridUid).to.not.be.null;
+      })
+      .then(() => {
+        cy.get(`.slick-gridmenu.${gridUid}`)
+          .find('.slick-gridmenu-list')
+          .children('li')
+          .each(($child, index) => {
+            if (index <= 5) {
+              const $input = $child.children('input');
+              const $label = $child.children('label');
+              expect($input.attr('checked')).to.eq('checked');
+              expect($label.text()).to.eq(fullTitles[index]);
+            }
+          });
+      });
+  });
+
+  it('should still expect 1st Grid to be unchanged from previous state and still have only 4 columns shown', () => {
+    const newColumnList = ['Duration', '% Complete', 'Finish', 'Effort Driven'];
+
+    cy.get('#myGrid01')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(newColumnList[index]));
+  });
+
+  it('should open the Grid Menu on 1st Grid and also expect to only have 4 columns checked (visible)', () => {
+    let gridUid = '';
+    cy.get('#myGrid01')
+      .find('button.slick-gridmenu-button')
+      .click({ force: true });
+
+    cy.get('#myGrid01')
+      .should(($grid) => {
+        const classes = $grid.prop('className').split(' ');
+        gridUid = classes.find(className => /slickgrid_.*/.test(className));
+        expect(gridUid).to.not.be.null;
+      })
+      .then(() => {
+        cy.get(`.slick-gridmenu.${gridUid}`)
+          .find('.slick-gridmenu-list')
+          .children('li')
+          .each(($child, index) => {
+            if (index <= 5) {
+              const $input = $child.children('input');
+              const $label = $child.children('label');
+              if ($label.text() === 'Title' || $label.text() === 'Start') {
+                expect($input.attr('checked')).to.eq(undefined);
+              } else {
+                expect($input.attr('checked')).to.eq('checked');
+              }
+              expect($label.text()).to.eq(fullTitles[index]);
+            }
+          });
+      });
+
+    cy.get('#myGrid01')
+      .get('.slick-gridmenu:visible')
+      .find('span.close')
+      .click({ force: true });
+  });
+});

--- a/examples/example-multi-grid-basic.html
+++ b/examples/example-multi-grid-basic.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="../controls/slick.gridmenu.css" type="text/css"/>
+  <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
   <style>
   #myGrid01, #myGrid02 {
 	background: white;
@@ -26,7 +28,8 @@
     <td valign="top">
       <h2>Demonstrates:</h2>
       <ul>
-        <li>two basic grids with minimal configuration</li>
+        <li>Two basic Grids with minimal configuration</li>
+        <li>Each Grids has separate Column Picker & Grid Menu</li>
       </ul>
         <h2>View Source:</h2>
         <ul>
@@ -41,6 +44,8 @@
 
 <script src="../slick.core.js"></script>
 <script src="../slick.grid.js"></script>
+<script src="../controls/slick.columnpicker.js"></script>
+<script src="../controls/slick.gridmenu.js"></script>
 
 <script>
   var grid01, grid02;
@@ -74,11 +79,19 @@
   }
   
   $(function () {
+    // Create 1st Grid with its own ColumnPicker/GridMenu
     var data01 = CreateData();
     grid01 = new Slick.Grid("#myGrid01", data01, columns, options);
-
+    new Slick.Controls.ColumnPicker(columns, grid01, options);
+    new Slick.Controls.GridMenu(columns, grid01, options);
+    
+    // Create 2nd Grid with its own ColumnPicker/GridMenu
     var data02 = CreateData();
-    grid02 = new Slick.Grid("#myGrid02", data02, columns.slice(0), jQuery.extend({}, options));
+    var columns02 = columns.slice(0);
+    var options02 = jQuery.extend({}, options);
+    grid02 = new Slick.Grid("#myGrid02", data02, columns02, options02);
+    new Slick.Controls.ColumnPicker(columns02, grid02, options02);
+    new Slick.Controls.GridMenu(columns02, grid02, options02);
   })
 </script>
 </body>


### PR DESCRIPTION
- ColumnPicker & GridMenu Picker should work independently
- There was an issue with the independence of each picker because the checkbox labels were sharing the exact same label text (because both grids had exact same column headers) and that caused side effect that clicking on bottom grid checkbox picker would actually change the 1st grid instead of 2nd grid and vice versa... that was caused by checkbox label not being unique
- add uniqueness by adding the grid UID to each checkbox labels
- this bug impacted both the ColumnPicker & the GridMenu and was only happening when having tow or more grids in the same page with same column headers

#### TODO
- [x] modified Example with 2 Grids to test it all out
- [x] add Cypress E2E tests to cover all possibilities
- [x] tested in my libs as well

This bug was hard to find, I thought I had a Singleton issue but it turns out to simply be that each Checkbox Label **must** be unique in their names. Since both grids had the exact same header titles, the checkbox labels (not the checkbox itself, just its associated label) were being shared in both pickers and was causing the issue which can be seen in the animated gif (you can see the checkbox themselves are ok, but their associated labels were problematic).

This last fix is looking good on my side, I did not find any other issues in my libs.

The BUG (before the fix) can be seen below

![3t1SQQgDDm](https://user-images.githubusercontent.com/643976/82253447-febba380-991e-11ea-8c15-cd6861919c45.gif)
