### PR TITLE
Fix menu max-height.

### DIFF
--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -410,7 +410,7 @@
       $menu
         .css("top", nextPositionTop + 10)
         .css("left", nextPositionLeft - currentMenuWidth + 10)
-        .css("max-height", $(window).height() - e.pageY - 15);
+        .css("max-height", $(window).height() - e.clientY - 15);
 
       if (contentMinWidth > 0) {
         $menu.css("min-width", contentMinWidth);


### PR DESCRIPTION
When determining the max-height of the context menu, we should be basing the Y coord on the size of the viewport and the position from the top of the viewport.  Using pageY is measuring the mouse position from the top of the page, not the viewport.  This request changes the pageY to clientY in order to correctly calculate the position of the mouse from the top of the viewport and ensure the menu doesn't extend below the viewport, and is also big enough to use.  For very large pages, when the grid is towards the bottom, the size of the menu was being set to an unusably small value.