### PR TITLE
fix(core): rollback PR #497 which is now causing resize issue

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -30,7 +30,7 @@ if (typeof Slick === "undefined") {
 
 (function ($) {
   "use strict";
-  
+
   // Slick.Grid
   $.extend(true, window, {
     Slick: {
@@ -584,7 +584,7 @@ if (typeof Slick === "undefined") {
           $footerRow
             .on("contextmenu", handleFooterContextMenu)
             .on("click", handleFooterClick);
-		
+
           $footerRowScroller
               .on("scroll", handleFooterRowScroll);
         }
@@ -1280,7 +1280,7 @@ if (typeof Slick === "undefined") {
             }
           }
         }
-	      
+
         if (m.sortable) {
           header.addClass("slick-header-sortable");
           header.append("<span class='slick-sort-indicator"
@@ -2095,21 +2095,21 @@ if (typeof Slick === "undefined") {
       var c = columnOrIndexOrId;
       if (typeof columnOrIndexOrId === 'number') {
         c = columns[columnOrIndexOrId];
-      } 
+      }
       else if (typeof columnOrIndexOrId === 'string') {
         for (i = 0; i < columns.length; i++) {
           if (columns[i].Id === columnOrIndexOrId) { c = columns[i]; }
         }
       }
       var $gridCanvas = $(getCanvasNode(0, 0));
-      getColAutosizeWidth(c, $gridCanvas, isInit);      
+      getColAutosizeWidth(c, $gridCanvas, isInit);
     }
-    
+
     function autosizeColumns(autosizeMode, isInit) {
       //LogColWidths();
 
       autosizeMode =  autosizeMode || options.autosizeColsMode;
-      if (autosizeMode === Slick.GridAutosizeColsMode.LegacyForceFit 
+      if (autosizeMode === Slick.GridAutosizeColsMode.LegacyForceFit
       || autosizeMode === Slick.GridAutosizeColsMode.LegacyOff) {
         legacyAutosizeColumns();
         return;
@@ -2172,7 +2172,7 @@ if (typeof Slick === "undefined") {
               colWidth = c.autoSize.widthPx;
             }
             if (c.rerenderOnResize && c.width  != colWidth) { reRender = true; }
-            c.width = colWidth; 
+            c.width = colWidth;
           }
         } else if ((options.viewportSwitchToScrollModeWidthPercent && totalWidthLessSTR + strColsMinWidth > viewportWidth * options.viewportSwitchToScrollModeWidthPercent / 100)
           || (totalMinWidth > viewportWidth)) {
@@ -2200,19 +2200,19 @@ if (typeof Slick === "undefined") {
               }
             }
             if (c.rerenderOnResize && c.width  != colWidth) { reRender = true; }
-            c.width = colWidth; 
+            c.width = colWidth;
           }
         }
       }
 
       if (autosizeMode === Slick.GridAutosizeColsMode.IgnoreViewport) {
         // just size columns as-is
-        for (i = 0; i < columns.length; i++) { 
+        for (i = 0; i < columns.length; i++) {
           colWidth = columns[i].autoSize.widthPx;
           if (columns[i].rerenderOnResize && columns[i].width != colWidth) {
             reRender = true;
           }
-          columns[i].width = colWidth; 
+          columns[i].width = colWidth;
         }
       }
 
@@ -2529,7 +2529,7 @@ if (typeof Slick === "undefined") {
         }
         columns[i].width = widths[i];
       }
-      
+
       reRenderColumns(reRender);
     }
 
@@ -2740,7 +2740,7 @@ if (typeof Slick === "undefined") {
 
         var m = columns[i] = $.extend({}, columnDefaults, columns[i]);
         m.autoSize = $.extend({}, columnAutosizeDefaults, m.autoSize);
-        
+
         columnsById[m.id] = i;
         if (m.minWidth && m.width < m.minWidth) {
           m.width = m.minWidth;
@@ -3452,7 +3452,6 @@ if (typeof Slick === "undefined") {
       paneBottomH = 0;
       viewportTopH = 0;
       viewportBottomH = 0;
-      var preHeaderHeight = options.showPreHeaderPanel ? options.preHeaderPanelHeight : 0;
 
       getViewportWidth();
       getViewportHeight();
@@ -3471,7 +3470,7 @@ if (typeof Slick === "undefined") {
       }
 
       // The top pane includes the top panel and the header row
-      paneTopH += topPanelH + preHeaderHeight + headerRowH + footerRowH;
+      paneTopH += topPanelH + headerRowH + footerRowH;
 
       if (hasFrozenColumns() && options.autoHeight) {
         paneTopH += scrollbarDimensions.height;
@@ -4622,7 +4621,7 @@ if (typeof Slick === "undefined") {
       var column = $footer && $footer.data("column");
       trigger(self.onFooterClick, {column: column}, e);
     }
-	  
+
     function handleMouseEnter(e) {
       trigger(self.onMouseEnter, {}, e);
     }


### PR DESCRIPTION
- the PR #497 was wrong and should be rolled back since the pre-header height is already calculated by getViewportHeight() which is called in the resizeCanvas() method.
- rollback #497 - ref #493