### PR TITLE
fix(plugin): check options exist before getting prop

### DIFF
--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -34,7 +34,7 @@
     };
 
     // user could override the expandable icon logic from within the options or after instantiating the plugin
-    if (typeof options.usabilityOverride === 'function') {
+    if (options && typeof options.usabilityOverride === 'function') {
       usabilityOverride(options.usabilityOverride);
     }
 


### PR DESCRIPTION
- while browsing for some examples (Row Move Example), I caught this console error. This fixes it