### PR TITLE
fix(gridMenu): Grid Menu wrong location changing from regular to frozen

### DIFF
--- a/cypress/integration/example-frozen-columns-and-column-group.spec.js
+++ b/cypress/integration/example-frozen-columns-and-column-group.spec.js
@@ -1,0 +1,121 @@
+/// <reference types="Cypress" />
+
+describe('Example - Row Grouping Titles', () => {
+    const fullPreTitles = ['', 'Common Factor', 'Period', 'Analysis'];
+    const fullTitles = ['#', 'Title', 'Duration', 'Start', 'Finish', '% Complete', 'Effort Driven'];
+
+    it('should display Example Grid Menu', () => {
+        cy.visit(`${Cypress.config('baseExampleUrl')}/example-frozen-columns-and-column-group.html`);
+        cy.get('h2').should('contain', 'Demonstrates:');
+        cy.contains('Frozen columns with extra header row grouping columns into categories');
+    });
+
+    it('should have exact Column Pre-Header & Column Header Titles in the grid', () => {
+        cy.get('#myGrid')
+            .find('.slick-header-columns:nth(0)')
+            .children()
+            .each(($child, index) => expect($child.text()).to.eq(fullPreTitles[index]));
+
+        cy.get('#myGrid')
+            .find('.slick-header-columns:nth(1)')
+            .children()
+            .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+    });
+
+    it('should have a frozen grid on page load with 3 columns on the left and 4 columns on the right', () => {
+        cy.get('[style="top:0px"]').should('have.length', 2);
+        cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 3);
+        cy.get('.grid-canvas-right > [style="top:0px"]').children().should('have.length', 4);
+
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '0');
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 0');
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '5 days');
+
+        cy.get('.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '01/01/2009');
+        cy.get('.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(1)').should('contain', '01/05/2009');
+    });
+
+    it('should have exact Column Pre-Header & Column Header Titles in the grid', () => {
+        cy.get('#myGrid')
+            .find('.slick-header-columns:nth(0)')
+            .children()
+            .each(($child, index) => expect($child.text()).to.eq(fullPreTitles[index]));
+
+        cy.get('#myGrid')
+            .find('.slick-header-columns:nth(1)')
+            .children()
+            .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+    });
+
+    it('should click on the "Remove Frozen Columns" button to switch to a regular grid without frozen columns and expect 7 columns on the left container', () => {
+        cy.contains('Remove Frozen Columns')
+            .click({ force: true });
+
+        cy.get('[style="top:0px"]').should('have.length', 1);
+        cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 7);
+
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '0');
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 0');
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '5 days');
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(3)').should('contain', '01/01/2009');
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(4)').should('contain', '01/05/2009');
+    });
+
+    it('should have exact Column Pre-Header & Column Header Titles in the grid', () => {
+        cy.get('#myGrid')
+            .find('.slick-header-columns:nth(0)')
+            .children()
+            .each(($child, index) => expect($child.text()).to.eq(fullPreTitles[index]));
+
+        cy.get('#myGrid')
+            .find('.slick-header-columns:nth(1)')
+            .children()
+            .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+    });
+
+    it('should click on the "Set 3 Frozen Columns" button to switch frozen columns grid and expect 3 frozen columns on the left and 4 columns on the right', () => {
+        cy.contains('Set 3 Frozen Columns')
+            .click({ force: true });
+
+        cy.get('[style="top:0px"]').should('have.length', 2);
+        cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 3);
+        cy.get('.grid-canvas-right > [style="top:0px"]').children().should('have.length', 4);
+
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '0');
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 0');
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '5 days');
+
+        cy.get('.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '01/01/2009');
+        cy.get('.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(1)').should('contain', '01/05/2009');
+    });
+
+    it('should have exact Column Pre-Header & Column Header Titles in the grid', () => {
+        cy.get('#myGrid')
+            .find('.slick-header-columns:nth(0)')
+            .children()
+            .each(($child, index) => expect($child.text()).to.eq(fullPreTitles[index]));
+
+        cy.get('#myGrid')
+            .find('.slick-header-columns:nth(1)')
+            .children()
+            .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+    });
+
+    it('should click on the Grid Menu command "Clear Frozen Columns" to switch to a regular grid without frozen columns and expect 7 columns on the left container', () => {
+        cy.get('#myGrid')
+            .find('button.slick-gridmenu-button')
+            .click({ force: true });
+
+        cy.contains('Clear Frozen Columns')
+            .click({ force: true });
+
+        cy.get('[style="top:0px"]').should('have.length', 1);
+        cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 7);
+
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '0');
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 0');
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '5 days');
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(3)').should('contain', '01/01/2009');
+        cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(4)').should('contain', '01/05/2009');
+    });
+});

--- a/examples/example-frozen-columns-and-column-group.html
+++ b/examples/example-frozen-columns-and-column-group.html
@@ -31,6 +31,11 @@
     <ul>
       <li>Frozen columns with extra header row grouping columns into categories</li>
     </ul>
+    <div style="margin-bottom:10px">
+      <button onclick="setFrozenColumns(-1)">Remove Frozen Columns</button>
+      <button onclick="setFrozenColumns(2)">Set 3 Frozen Columns</button>
+    </div>
+
       <h2>View Source:</h2>
       <ul>
           <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-frozen-columns-and-column-group.html" target="_sourcewindow"> View the source for this example on Github</a></li>
@@ -52,13 +57,20 @@
 
 <script>
   function CreateAddlHeaderRow() {
-    // Add column groups to left panel
-    var $preHeaderPanel = $(grid.getPreHeaderPanelLeft());
-    renderHeaderGroups($preHeaderPanel, 0, options.frozenColumn + 1);
+    // when it's a frozen grid, we need to render both side (left/right)
+    if (options.frozenColumn >=0) {
+      // Add column groups to left panel
+      var $preHeaderPanel = $(grid.getPreHeaderPanelLeft());
+      renderHeaderGroups($preHeaderPanel, 0, options.frozenColumn + 1, columns.length);
 
-    // Add column groups to right panel
-    $preHeaderPanel = $(grid.getPreHeaderPanelRight());
-    renderHeaderGroups($preHeaderPanel, options.frozenColumn + 1, columns.length);
+      // Add column groups to right panel
+      $preHeaderPanel = $(grid.getPreHeaderPanelRight());
+      renderHeaderGroups($preHeaderPanel, options.frozenColumn + 1, columns.length);
+    } else {
+      // when it's a regular grid (without frozen rows), after clearning frozen columns, we re-render everything on the left
+      var $preHeaderPanel = $(grid.getPreHeaderPanelLeft());
+      renderHeaderGroups($preHeaderPanel, 0, columns.length);
+    }
 
     function renderHeaderGroups(preHeaderPanel, start, end) {
       preHeaderPanel.empty()
@@ -85,6 +97,12 @@
         lastColumnGroup = m.columnGroup;
       }
     }
+  }
+
+  function setFrozenColumns(frozenCols) {
+    grid.setOptions({ frozenColumn: frozenCols });
+    options = grid.getOptions();
+    CreateAddlHeaderRow();
   }
 
   function pickerHeaderColumnValueExtractor(column) {
@@ -114,7 +132,19 @@
       headerColumnValueExtractor: pickerHeaderColumnValueExtractor
     },
     gridMenu: {
-      headerColumnValueExtractor: pickerHeaderColumnValueExtractor
+      headerColumnValueExtractor: pickerHeaderColumnValueExtractor,
+      customTitle: "Commands",
+      columnTitle: "Columns",
+      customItems: [
+        {
+          iconImage: "../images/delete.png",
+          title: "Clear Frozen Columns",
+          disabled: false,
+          command: "clear-frozen-columns",
+          cssClass: 'bold',     // container css class
+          textCssClass: 'red'   // just the text css class
+        }
+      ]
     },
   };
   var columns = [
@@ -160,6 +190,13 @@
 
     grid.onColumnsResized.subscribe(function (e, args) {
       CreateAddlHeaderRow();
+    });
+
+    // subscribe to Grid Menu event(s)
+    gridMenuControl.onCommand.subscribe(function(e, args) {
+      if(args.command === "clear-frozen-columns") {
+        setFrozenColumns(-1);
+      }
     });
     
     // Initialise data

--- a/package-lock.json
+++ b/package-lock.json
@@ -242,9 +242,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
       "dev": true
     },
     "balanced-match": {
@@ -513,9 +513,9 @@
       }
     },
     "cypress": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.6.0.tgz",
-      "integrity": "sha512-vIPXAceRP+Nxvnm/O9ruY9EQaRGmVVybtk9F1sfC9mH3067YbitrdBTynaaLuHFj90p9e0U2ZCV7OkX4x4V/Wg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.8.0.tgz",
+      "integrity": "sha512-Lsff8lF8pq6k/ioNua783tCsxGSLp6gqGXecdIfqCkqjYiOA53XKuEf1CaQJLUVs1dHSf49eDUp/sb620oJjVQ==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -555,14 +555,6 @@
         "untildify": "4.0.0",
         "url": "0.11.0",
         "yauzl": "2.10.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "dashdash": {
@@ -971,21 +963,6 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -1553,9 +1530,9 @@
       }
     },
     "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "dev": true
     },
     "is-stream": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jquery-ui": ">=1.8.0"
   },
   "devDependencies": {
-    "cypress": "^4.6.0",
+    "cypress": "^4.8.0",
     "eslint": "^7.0.0",
     "http-server": "^0.12.3"
   }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2814,7 +2814,10 @@ if (typeof Slick === "undefined") {
         invalidateRow(getDataLength());
       }
 
+      var originalOptions = $.extend(true, {}, options);
       options = $.extend(options, args);
+      trigger(self.onSetOptions, { "optionsBefore": originalOptions, "optionsAfter": options });
+
       validateAndEnforceOptions();
 
       $viewport.css("overflow-y", options.autoHeight ? "hidden" : "auto");
@@ -5819,6 +5822,7 @@ if (typeof Slick === "undefined") {
       "onCellCssStylesChanged": new Slick.Event(),
       "onAutosizeColumns": new Slick.Event(),
       "onRendered": new Slick.Event(),
+      "onSetOptions": new Slick.Event(),
 
       // Methods
       "registerPlugin": registerPlugin,


### PR DESCRIPTION
- add a new SlickGrid event `onSetOptions` to know when users dynamically changes the grid from regular to frozen (or vice versa)
- the issue was that when changing a grid dynamically from regular to a frozen grid, the Grid Menu is positioned at the wrong location (shows up on left container instead of right container), the reason is because a regular grid uses the Left Grid Pane, while a frozen grid uses both left/right Grid Pane and its menu should be on the right Grid Pane (instead of left for a regular grid).

#### TODO
- [x] manually tested with SlickGrid example (modified the `example-frozen-columns-and-column-group.html` to test it)
- [x] manually tested with Angular-Slickgrid examples
- [x] add some Cypress E2E tests
  - now 100 tests in total on 9 different examples, sweet :)

#### BEFORE FIX 
you can see the grid menu showing up on the left container, on its top right, but it really **shouldn't be there**

![54xlqM22Ba](https://user-images.githubusercontent.com/643976/84437265-b41e0600-ac02-11ea-9f5f-d648f944c9a3.gif)

---- 
#### AFTER FIX 
grid menu is only on top right corner of the grid, where it should always be

![sx8EQyJUMn](https://user-images.githubusercontent.com/643976/84437365-d879e280-ac02-11ea-9175-06c685a4cd0c.gif)


