### PR TITLE
fix(grouping): collapse all then expand sub-group, fixes #512

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -654,7 +654,7 @@
       }
 
       if(groups.length) {
-        addTotals(groups);
+        addTotals(groups, level);
       }
 
       groups.sort(groupingInfos[level].comparer);


### PR DESCRIPTION
- it seems that previous PR #487 brought a new regression bug, the fix is to simply pass the level to the addTotals function

![kp6b6pFO1r](https://user-images.githubusercontent.com/643976/85969535-f0d55580-b995-11ea-9151-f4459e1dbaf3.gif)
