### PR TITLE
calculate hearderRowH also when having frozen columms

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3424,6 +3424,11 @@ if (typeof Slick === "undefined") {
     }
 
     function getViewportHeight() {
+      if (!options.autoHeight || options.frozenColumn != -1) {
+        topPanelH = ( options.showTopPanel ) ? options.topPanelHeight + getVBoxDelta($topPanelScroller) : 0;
+        headerRowH = ( options.showHeaderRow ) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
+        footerRowH = ( options.showFooterRow ) ? options.footerRowHeight + getVBoxDelta($footerRowScroller) : 0;
+      }
       if (options.autoHeight) {
         var fullHeight = $paneHeaderL.outerHeight();
         fullHeight += ( options.showHeaderRow ) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
@@ -3436,9 +3441,6 @@ if (typeof Slick === "undefined") {
       } else {
         var columnNamesH = ( options.showColumnHeader ) ? parseFloat($.css($headerScroller[0], "height"))
           + getVBoxDelta($headerScroller) : 0;
-        topPanelH = ( options.showTopPanel ) ? options.topPanelHeight + getVBoxDelta($topPanelScroller) : 0;
-        headerRowH = ( options.showHeaderRow ) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
-        footerRowH = ( options.showFooterRow ) ? options.footerRowHeight + getVBoxDelta($footerRowScroller) : 0;
         var preHeaderH = (options.createPreHeaderPanel && options.showPreHeaderPanel) ? options.preHeaderPanelHeight + getVBoxDelta($preHeaderPanelScroller) : 0;
 
         viewportH = parseFloat($.css($container[0], "height", true))


### PR DESCRIPTION
When frozen columns is enabled the height of the header row is missing in the height calculations.
With this change the values are also calculated in this specific case so they are available later.

This fixes #521 for me.