### PR TITLE
feat(plugins): add "hidden" property to all plugins with menu items

### DIFF
--- a/controls/slick.gridmenu.css
+++ b/controls/slick.gridmenu.css
@@ -81,6 +81,7 @@
   padding: 2px 4px;
   border: 1px solid transparent;
   border-radius: 3px;
+  display: block;
 }
 .slick-gridmenu-item:hover {
   border-color: silver;
@@ -109,6 +110,11 @@
 /* Disabled */
 .slick-gridmenu-item-disabled {
   color: silver;
+}
+
+/* Hidden */
+.slick-gridmenu-item-hidden {
+  display: none;
 }
 
 /* Excluded item from Grid Menu will be hidden */

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -59,7 +59,8 @@
  *    action:                     Optionally define a callback function that gets executed when item is chosen (and/or use the onCommand event)
  *    title:                      Menu item text.
  *    divider:                    Whether the current item is a divider, not an actual command.
- *    disabled:                   Whether the item is disabled.
+ *    disabled:                   Whether the item/command is disabled.
+ *    hidden:                     Whether the item/command is hidden.
  *    tooltip:                    Item tooltip.
  *    command:                    A command identifier to be passed to the onCommand event handlers.
  *    cssClass:                   A CSS class to be added to the menu item container.
@@ -154,7 +155,7 @@
 
     // when a grid changes from a regular grid to a frozen grid, we need to destroy & recreate the grid menu
     // we do this change because the Grid Menu is on the left container on a regular grid but is on the right container on a frozen grid
-    grid.onSetOptions.subscribe(function(e, args) {
+    grid.onSetOptions.subscribe(function (e, args) {
       if (args && args.optionsBefore && args.optionsAfter) {
         var switchedFromRegularToFrozen = args.optionsBefore.frozenColumn >= 0 && args.optionsAfter.frozenColumn === -1;
         var switchedFromFrozenToRegular = args.optionsBefore.frozenColumn === -1 && args.optionsAfter.frozenColumn >= 0;
@@ -293,6 +294,10 @@
         }
         if (item.disabled) {
           $li.addClass("slick-gridmenu-item-disabled");
+        }
+
+        if (item.hidden) {
+          $li.addClass("slick-header-menuitem-hidden");
         }
 
         if (item.cssClass) {

--- a/examples/example-plugin-headermenu.html
+++ b/examples/example-plugin-headermenu.html
@@ -37,8 +37,7 @@
       border: 1px solid #718BB7;
       background: #f0f0f0;
       padding: 2px;
-      -moz-box-shadow: 2px 2px 2px silver;
-      -webkit-box-shadow: 2px 2px 2px silver;
+      box-shadow: 2px 2px 2px silver;
       z-index: 20;
     }
 
@@ -47,6 +46,7 @@
       padding: 2px 4px;
       border: 1px solid transparent;
       border-radius: 3px;
+      display: block;
     }
 
     .slick-header-menuitem:hover {
@@ -57,6 +57,9 @@
     .slick-header-menuitem-disabled {
       border-color: transparent !important;
       background: inherit !important;
+    }
+    .slick-header-menuitem-hidden {
+      display: none;
     }
 
     .icon-help {
@@ -127,12 +130,14 @@
               iconImage: "../images/sort-asc.gif",
               title: "Sort Ascending",
               disabled: !columns[i].sortable,
+              // hidden: !columns[i].sortable, // you could disable or hide the command completely
               command: "sort-asc"
             },
             {
               iconImage: "../images/sort-desc.gif",
               title: "Sort Descending",
               disabled: !columns[i].sortable,
+              // hidden: !columns[i].sortable, // you could disable or hide the command completely
               cssClass: !columns[i].sortable ? 'italic' : '',
               command: "sort-desc"
             },

--- a/plugins/slick.cellmenu.css
+++ b/plugins/slick.cellmenu.css
@@ -79,6 +79,7 @@
   padding: 2px 4px;
   border: 1px solid transparent;
   border-radius: 3px;
+  display: block;
 }
 .slick-cell-menu-item:hover {
   border-color: silver;
@@ -108,6 +109,11 @@
 /* Disabled */
 .slick-cell-menu-item-disabled {
   color: silver;
+}
+
+/* Hidden */
+.slick-cell-menu-item-hidden {
+  display: none;
 }
 
 /* Excluded item from Grid Menu will be hidden */

--- a/plugins/slick.cellmenu.js
+++ b/plugins/slick.cellmenu.js
@@ -543,6 +543,11 @@
           $li.addClass("slick-cell-menu-item-disabled");
         }
 
+        // if the item is hidden then add the hidden css class
+        if (item.hidden) {
+          $li.addClass("slick-cell-menu-item-hidden");
+        }
+
         if (item.cssClass) {
           $li.addClass(item.cssClass);
         }

--- a/plugins/slick.cellmenu.js
+++ b/plugins/slick.cellmenu.js
@@ -72,7 +72,8 @@
    *    option:                     An option to be passed to the onOptionSelected event handlers (when using "optionItems").
    *    title:                      Menu item text label.
    *    divider:                    Boolean which tells if the current item is a divider, not an actual command. You could also pass "divider" instead of an object
-   *    disabled:                   Whether the item is disabled.
+   *    disabled:                   Whether the item/command is disabled.
+   *    hidden:                     Whether the item/command is hidden.
    *    tooltip:                    Item tooltip.
    *    cssClass:                   A CSS class to be added to the menu item container.
    *    iconCssClass:               A CSS class to be added to the menu item icon.
@@ -89,7 +90,7 @@
    *            cell:         Cell or column index
    *            row:          Row index
    *            grid:         Reference to the grid.
-   * 
+   *
    *    onBeforeMenuShow: Fired before the menu is shown.  You can customize the menu or dismiss it by returning false.
    *        Event args:
    *            cell:         Cell or column index
@@ -460,6 +461,11 @@
         // if the item is disabled then add the disabled css class
         if (item.disabled || !isItemUsable) {
           $li.addClass("slick-cell-menu-item-disabled");
+        }
+
+        // if the item is hidden then add the hidden css class
+        if (item.hidden) {
+          $li.addClass("slick-cell-menu-item-hidden");
         }
 
         if (item.cssClass) {

--- a/plugins/slick.contextmenu.css
+++ b/plugins/slick.contextmenu.css
@@ -116,6 +116,11 @@
   color: silver;
 }
 
+/* Hidden */
+.slick-context-menu-item-hidden {
+  display: none;
+}
+
 /* Excluded item from Grid Menu will be hidden */
 .slick-context-menu-list li.hidden {
   display: none;

--- a/plugins/slick.contextmenu.js
+++ b/plugins/slick.contextmenu.js
@@ -79,7 +79,8 @@
    *    option:                     An option to be passed to the onOptionSelected event handlers (when using "optionItems").
    *    title:                      Menu item text.
    *    divider:                    Boolean which tell if the current item is a divider, not an actual command. You could also pass "divider" instead of an object
-   *    disabled:                   Whether the item is disabled.
+   *    disabled:                   Whether the item/command is disabled.
+   *    hidden:                     Whether the item/command is hidden.
    *    tooltip:                    Item tooltip.
    *    cssClass:                   A CSS class to be added to the menu item container.
    *    iconCssClass:               A CSS class to be added to the menu item icon.
@@ -416,6 +417,11 @@
         // if the item is disabled then add the disabled css class
         if (item.disabled || !isItemUsable) {
           $li.addClass("slick-context-menu-item-disabled");
+        }
+
+        // if the item is hidden then add the hidden css class
+        if (item.hidden) {
+          $li.addClass("slick-context-menu-item-hidden");
         }
 
         if (item.cssClass) {

--- a/plugins/slick.contextmenu.js
+++ b/plugins/slick.contextmenu.js
@@ -499,6 +499,11 @@
           $li.addClass("slick-context-menu-item-disabled");
         }
 
+        // if the item is hidden then add the hidden css class
+        if (item.hidden) {
+          $li.addClass("slick-context-menu-item-hidden");
+        }
+
         if (item.cssClass) {
           $li.addClass(item.cssClass);
         }

--- a/plugins/slick.headerbuttons.js
+++ b/plugins/slick.headerbuttons.js
@@ -40,8 +40,7 @@
    * Available button options:
    *    cssClass:     CSS class to add to the button.
    *    image:        Relative button image path.
-   *    disabled:     Whether the item/command is disabled.
-   *    hidden:       Whether the item/command is hidden.
+   *    disabled:     Whether the item is disabled.
    *    tooltip:      Button tooltip.
    *    showOnHover:  Only show the button on hover.
    *    handler:      Button click handler.
@@ -132,10 +131,6 @@
 
           if (button.disabled) {
             btn.addClass("slick-header-button-disabled");
-          }
-
-          if (button.hidden) {
-            btn.addClass("slick-header-button-hidden");
           }
 
           if (button.showOnHover) {

--- a/plugins/slick.headerbuttons.js
+++ b/plugins/slick.headerbuttons.js
@@ -40,7 +40,8 @@
    * Available button options:
    *    cssClass:     CSS class to add to the button.
    *    image:        Relative button image path.
-   *    disabled:     Whether the item is disabled.
+   *    disabled:     Whether the item/command is disabled.
+   *    hidden:       Whether the item/command is hidden.
    *    tooltip:      Button tooltip.
    *    showOnHover:  Only show the button on hover.
    *    handler:      Button click handler.
@@ -131,6 +132,10 @@
 
           if (button.disabled) {
             btn.addClass("slick-header-button-disabled");
+          }
+
+          if (button.hidden) {
+            btn.addClass("slick-header-button-hidden");
           }
 
           if (button.showOnHover) {

--- a/plugins/slick.headermenu.css
+++ b/plugins/slick.headermenu.css
@@ -35,6 +35,7 @@
   margin: 0;
   padding: 0;
   cursor: pointer;
+  display: block;
 }
 
 .slick-header-menuicon {
@@ -56,6 +57,11 @@
 /* Disabled */
 .slick-header-menuitem-disabled {
   color: silver;
+}
+
+/* Hidden */
+.slick-header-menuitem-hidden {
+  display: none;
 }
 
 /* Divider */

--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -52,7 +52,8 @@
    *    action:                   Optionally define a callback function that gets executed when item is chosen (and/or use the onCommand event)
    *    title:                    Menu item text.
    *    divider:                  Whether the current item is a divider, not an actual command.
-   *    disabled:                 Whether the item is disabled.
+   *    disabled:                 Whether the item/command is disabled.
+   *    hidden:                   Whether the item/command is hidden.
    *    tooltip:                  Item tooltip.
    *    command:                  A command identifier to be passed to the onCommand event handlers.
    *    cssClass:                 A CSS class to be added to the menu item container.
@@ -70,7 +71,7 @@
    *            grid:     Reference to the grid.
    *            column:   Column definition.
    *            menu:     Menu options.  Note that you can change the menu items here.
-   * 
+   *
    *    onBeforeMenuShow:   Fired before the menu is shown.  You can customize the menu or dismiss it by returning false.
    *        Event args:
    *            grid:     Reference to the grid.
@@ -250,6 +251,10 @@
 
         if (item.disabled) {
           $li.addClass("slick-header-menuitem-disabled");
+        }
+
+        if (item.hidden) {
+          $li.addClass("slick-header-menuitem-hidden");
         }
 
         if (item.cssClass) {


### PR DESCRIPTION
- in some cases we might want to use "disabled" but in other cases we might want to use "hidden" to still have the command but just keep it invisible, this PR adds this new "hidden" property to all possible controls/plugins with menu items/commands (HeaderMenu, GridMenu, CellMenu, ContextMenu).