### PR TITLE
feat(core): add a supressColumnSet on setOptions method

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2799,7 +2799,7 @@ if (typeof Slick === "undefined") {
       return options;
     }
 
-    function setOptions(args, suppressRender) {
+    function setOptions(args, suppressRender, suppressColumnSet) {
       if (!getEditorLock().commitCurrentEdit()) {
         return;
       }
@@ -2821,13 +2821,17 @@ if (typeof Slick === "undefined") {
       validateAndEnforceOptions();
 
       $viewport.css("overflow-y", options.autoHeight ? "hidden" : "auto");
-      if (!suppressRender) { render(); }
+      if (!suppressRender) {
+        render();
+      }
 
       setFrozenOptions();
       setScroller();
       zombieRowNodeFromLastMouseWheelEvent = null;
 
-      setColumns(treeColumns.extractColumns());
+      if (!suppressColumnSet) {
+        setColumns(treeColumns.extractColumns());
+      }
     }
 
     function validateAndEnforceOptions() {


### PR DESCRIPTION
- this is to avoid having the grid reset the columns when for example we just want to change simple flags that don't have any impact on the grid or its rendering