### PR TITLE
fix(plugins): Row Move icon formatter should have text property

### DIFF
--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -1,5 +1,5 @@
 /**
- * Row Move Manager options: 
+ * Row Move Manager options:
  *    cssClass:             A CSS class to be added to the menu item container.
  *    columnId:             Column definition id (defaults to "_move")
  *    cancelEditOnDrag:     Do we want to cancel any Editing while dragging a row (defaults to false)
@@ -193,7 +193,7 @@
       if (!checkUsabilityOverride(row, dataContext, grid)) {
         return null;
       } else {
-        return { addClasses: "cell-reorder dnd" };
+        return { addClasses: "cell-reorder dnd", text: "" };
       }
     }
 


### PR DESCRIPTION
- in some cases the formatter was showing "..." because of the text being shown as undefined