### PR TITLE
Fix issue with vertical scrollbar not going all the way down

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -188,7 +188,7 @@ if (typeof Slick === "undefined") {
     var headersWidth, headersWidthL, headersWidthR;
     var viewportHasHScroll, viewportHasVScroll;
     var headerColumnWidthDiff = 0, headerColumnHeightDiff = 0, // border+padding
-      cellWidthDiff = 0, cellHeightDiff = 0, jQueryNewWidthBehaviour = false;
+        cellWidthDiff = 0, cellHeightDiff = 0, jQueryNewWidthBehaviour = false;
     var absoluteColumnMinWidth;
     var hasFrozenRows = false;
     var frozenRowsHeight = 0;
@@ -353,11 +353,11 @@ if (typeof Slick === "undefined") {
       };
 
       $container
-        .empty()
-        .css("overflow", "hidden")
-        .css("outline", 0)
-        .addClass(uid)
-        .addClass("ui-widget");
+          .empty()
+          .css("overflow", "hidden")
+          .css("outline", 0)
+          .addClass(uid)
+          .addClass("ui-widget");
 
       // set up a positioning container if needed
       if (!(/relative|absolute|fixed/).test($container.css("position"))) {
@@ -378,12 +378,12 @@ if (typeof Slick === "undefined") {
         $preHeaderPanelScroller = $("<div class='slick-preheader-panel ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($paneHeaderL);
         $preHeaderPanel = $("<div />").appendTo($preHeaderPanelScroller);
         $preHeaderPanelSpacer = $("<div style='display:block;height:1px;position:absolute;top:0;left:0;'></div>")
-          .appendTo($preHeaderPanelScroller);
+            .appendTo($preHeaderPanelScroller);
 
         $preHeaderPanelScrollerR = $("<div class='slick-preheader-panel ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($paneHeaderR);
         $preHeaderPanelR = $("<div />").appendTo($preHeaderPanelScrollerR);
         $preHeaderPanelSpacerR = $("<div style='display:block;height:1px;position:absolute;top:0;left:0;'></div>")
-          .appendTo($preHeaderPanelScrollerR);
+            .appendTo($preHeaderPanelScrollerR);
 
         if (!options.showPreHeaderPanel) {
           $preHeaderPanelScroller.hide();
@@ -563,22 +563,22 @@ if (typeof Slick === "undefined") {
         bindAncestorScrollEvents();
 
         $container
-          .on("resize.slickgrid", resizeCanvas);
+            .on("resize.slickgrid", resizeCanvas);
         $viewport
-          .on("scroll", handleScroll);
+            .on("scroll", handleScroll);
 
         if (jQuery.fn.mousewheel) {
           $viewport.on("mousewheel", handleMouseWheel);
         }
 
         $headerScroller
-          //.on("scroll", handleHeaderScroll)
-          .on("contextmenu", handleHeaderContextMenu)
-          .on("click", handleHeaderClick)
-          .on("mouseenter", ".slick-header-column", handleHeaderMouseEnter)
-          .on("mouseleave", ".slick-header-column", handleHeaderMouseLeave);
+            //.on("scroll", handleHeaderScroll)
+            .on("contextmenu", handleHeaderContextMenu)
+            .on("click", handleHeaderClick)
+            .on("mouseenter", ".slick-header-column", handleHeaderMouseEnter)
+            .on("mouseleave", ".slick-header-column", handleHeaderMouseLeave);
         $headerRowScroller
-          .on("scroll", handleHeaderRowScroll);
+            .on("scroll", handleHeaderRowScroll);
 
         if (options.createFooterRow) {
           $footerRow
@@ -586,27 +586,27 @@ if (typeof Slick === "undefined") {
             .on("click", handleFooterClick);
 
           $footerRowScroller
-            .on("scroll", handleFooterRowScroll);
+              .on("scroll", handleFooterRowScroll);
         }
 
         if (options.createPreHeaderPanel) {
           $preHeaderPanelScroller
-            .on("scroll", handlePreHeaderPanelScroll);
+              .on("scroll", handlePreHeaderPanelScroll);
         }
 
         $focusSink.add($focusSink2)
-          .on("keydown", handleKeyDown);
+            .on("keydown", handleKeyDown);
         $canvas
-          .on("keydown", handleKeyDown)
-          .on("click", handleClick)
-          .on("dblclick", handleDblClick)
-          .on("contextmenu", handleContextMenu)
-          .on("draginit", handleDragInit)
-          .on("dragstart", { distance: 3 }, handleDragStart)
-          .on("drag", handleDrag)
-          .on("dragend", handleDragEnd)
-          .on("mouseenter", ".slick-cell", handleMouseEnter)
-          .on("mouseleave", ".slick-cell", handleMouseLeave);
+            .on("keydown", handleKeyDown)
+            .on("click", handleClick)
+            .on("dblclick", handleDblClick)
+            .on("contextmenu", handleContextMenu)
+            .on("draginit", handleDragInit)
+            .on("dragstart", {distance: 3}, handleDragStart)
+            .on("drag", handleDrag)
+            .on("dragend", handleDragEnd)
+            .on("mouseenter", ".slick-cell", handleMouseEnter)
+            .on("mouseleave", ".slick-cell", handleMouseLeave);
 
         restoreCssFromHiddenInit();
       }
@@ -615,11 +615,11 @@ if (typeof Slick === "undefined") {
     function cacheCssForHiddenInit() {
       // handle display:none on container or container parents
       $hiddenParents = $container.parents().addBack().not(':visible');
-      $hiddenParents.each(function () {
+      $hiddenParents.each(function() {
         var old = {};
-        for (var name in cssShow) {
-          old[name] = this.style[name];
-          this.style[name] = cssShow[name];
+        for ( var name in cssShow ) {
+          old[ name ] = this.style[ name ];
+          this.style[ name ] = cssShow[ name ];
         }
         oldProps.push(old);
       });
@@ -628,10 +628,10 @@ if (typeof Slick === "undefined") {
     function restoreCssFromHiddenInit() {
       // finish handle display:none on container or container parents
       // - put values back the way they were
-      $hiddenParents.each(function (i) {
+      $hiddenParents.each(function(i) {
         var old = oldProps[i];
-        for (var name in cssShow) {
-          this.style[name] = old[name];
+        for ( var name in cssShow ) {
+          this.style[ name ] = old[ name ];
         }
       });
     }
@@ -658,7 +658,7 @@ if (typeof Slick === "undefined") {
     }
 
     function getPluginByName(name) {
-      for (var i = plugins.length - 1; i >= 0; i--) {
+      for (var i = plugins.length-1; i >= 0; i--) {
         if (plugins[i].pluginName === name) {
           return plugins[i];
         }
@@ -691,10 +691,10 @@ if (typeof Slick === "undefined") {
 
       var idx = (typeof columnIdOrIdx === "number" ? columnIdOrIdx : getColumnIndex(columnIdOrIdx));
 
-      return (hasFrozenRows && rowIndex >= actualFrozenRow + (options.frozenBottom ? 0 : 1))
-        ? ((hasFrozenColumns() && idx > options.frozenColumn) ? $canvasBottomR[0] : $canvasBottomL[0])
-        : ((hasFrozenColumns() && idx > options.frozenColumn) ? $canvasTopR[0] : $canvasTopL[0])
-        ;
+      return (hasFrozenRows && rowIndex >= actualFrozenRow + (options.frozenBottom ? 0 : 1) )
+          ?  ((hasFrozenColumns() && idx > options.frozenColumn) ? $canvasBottomR[0] : $canvasBottomL[0])
+          :  ((hasFrozenColumns() && idx > options.frozenColumn) ? $canvasTopR[0] : $canvasTopL[0])
+          ;
     }
 
     function getActiveCanvasNode(element) {
@@ -746,9 +746,9 @@ if (typeof Slick === "undefined") {
       var includeScrollbar = !options.autoHeight;
 
       for (var i = 0, ii = columns.length; i < ii; i++) {
-        var width = columns[i].width;
+        var width = columns[ i ].width;
 
-        if ((options.frozenColumn) > -1 && (i > options.frozenColumn)) {
+        if (( options.frozenColumn ) > -1 && ( i > options.frozenColumn )) {
           headersWidthR += width;
         } else {
           headersWidthL += width;
@@ -756,7 +756,7 @@ if (typeof Slick === "undefined") {
       }
 
       if (includeScrollbar) {
-        if ((options.frozenColumn) > -1 && (i > options.frozenColumn)) {
+        if (( options.frozenColumn ) > -1 && ( i > options.frozenColumn )) {
           headersWidthR += scrollbarDimensions.width;
         } else {
           headersWidthL += scrollbarDimensions.width;
@@ -778,10 +778,10 @@ if (typeof Slick === "undefined") {
     }
 
     function getHeadersWidthL() {
-      headersWidthL = 0;
+      headersWidthL =0;
 
-      columns.forEach(function (column, i) {
-        if (!((options.frozenColumn) > -1 && (i > options.frozenColumn)))
+      columns.forEach(function(column, i) {
+        if (!(( options.frozenColumn ) > -1 && ( i > options.frozenColumn )))
           headersWidthL += column.width;
       });
 
@@ -796,10 +796,10 @@ if (typeof Slick === "undefined") {
     }
 
     function getHeadersWidthR() {
-      headersWidthR = 0;
+      headersWidthR =0;
 
-      columns.forEach(function (column, i) {
-        if ((options.frozenColumn) > -1 && (i > options.frozenColumn))
+      columns.forEach(function(column, i) {
+        if (( options.frozenColumn ) > -1 && ( i > options.frozenColumn ))
           headersWidthR += column.width;
       });
 
@@ -927,11 +927,11 @@ if (typeof Slick === "undefined") {
     function disableSelection($target) {
       if ($target && $target.jquery) {
         $target
-          .attr("unselectable", "on")
-          .css("MozUserSelect", "none")
-          .on("selectstart.ui", function () {
-            return false;
-          }); // from jquery:ui.core.js 1.7.2
+            .attr("unselectable", "on")
+            .css("MozUserSelect", "none")
+            .on("selectstart.ui", function () {
+              return false;
+            }); // from jquery:ui.core.js 1.7.2
       }
     }
 
@@ -1016,8 +1016,8 @@ if (typeof Slick === "undefined") {
         });
 
         $header
-          .attr("title", toolTip || "")
-          .children().eq(0).html(title);
+            .attr("title", toolTip || "")
+            .children().eq(0).html(title);
 
         trigger(self.onHeaderCellRendered, {
           "node": $header[0],
@@ -1122,8 +1122,8 @@ if (typeof Slick === "undefined") {
 
           var footerRowCell = $("<div class='ui-state-default slick-footerrow-column l" + i + " r" + i + "'></div>")
             .data("column", m)
-            .addClass(hasFrozenColumns() && i <= options.frozenColumn ? 'frozen' : '')
-            .appendTo(hasFrozenColumns() && (i > options.frozenColumn) ? $footerRowR : $footerRowL);
+            .addClass(hasFrozenColumns() && i <= options.frozenColumn? 'frozen': '')
+            .appendTo(hasFrozenColumns() && (i > options.frozenColumn)? $footerRowR: $footerRowL);
 
           trigger(self.onFooterRowCellRendered, {
             "node": footerRowCell[0],
@@ -1153,7 +1153,7 @@ if (typeof Slick === "undefined") {
 
           columnsLength += m.extractColumns().length;
 
-          if (hasFrozenColumns() && index === 0 && (columnsLength - 1) === options.frozenColumn)
+          if (hasFrozenColumns() && index === 0 && (columnsLength-1) === options.frozenColumn)
             frozenColumnsValid = true;
 
           $("<div class='ui-state-default slick-group-header-column' />")
@@ -1162,8 +1162,8 @@ if (typeof Slick === "undefined") {
             .attr("title", m.toolTip || "")
             .data("column", m)
             .addClass(m.headerCssClass || "")
-            .addClass(hasFrozenColumns() && (columnsLength - 1) > options.frozenColumn ? 'frozen' : '')
-            .appendTo(hasFrozenColumns() && (columnsLength - 1) > options.frozenColumn ? $groupHeadersR[index] : $groupHeadersL[index]);
+            .addClass(hasFrozenColumns() && (columnsLength - 1) > options.frozenColumn? 'frozen': '')
+            .appendTo(hasFrozenColumns() && (columnsLength - 1) > options.frozenColumn? $groupHeadersR[index]: $groupHeadersL[index]);
         }
 
         if (hasFrozenColumns() && index === 0 && !frozenColumnsValid) {
@@ -1187,7 +1187,7 @@ if (typeof Slick === "undefined") {
       }
 
       $headers.find(".slick-header-column")
-        .each(function () {
+        .each(function() {
           var columnDef = $(this).data("column");
           if (columnDef) {
             trigger(self.onBeforeHeaderCellDestroy, {
@@ -1207,7 +1207,7 @@ if (typeof Slick === "undefined") {
       $headerR.width(headersWidthR);
 
       $headerRow.find(".slick-headerrow-column")
-        .each(function () {
+        .each(function() {
           var columnDef = $(this).data("column");
           if (columnDef) {
             trigger(self.onBeforeHeaderRowCellDestroy, {
@@ -1223,7 +1223,7 @@ if (typeof Slick === "undefined") {
 
       if (options.createFooterRow) {
         $footerRowL.find(".slick-footerrow-column")
-          .each(function () {
+          .each(function() {
             var columnDef = $(this).data("column");
             if (columnDef) {
               trigger(self.onBeforeFooterRowCellDestroy, {
@@ -1237,7 +1237,7 @@ if (typeof Slick === "undefined") {
 
         if (hasFrozenColumns()) {
           $footerRowR.find(".slick-footerrow-column")
-            .each(function () {
+            .each(function() {
               var columnDef = $(this).data("column");
               if (columnDef) {
                 trigger(self.onBeforeFooterRowCellDestroy, {
@@ -1258,14 +1258,14 @@ if (typeof Slick === "undefined") {
         var $headerRowTarget = hasFrozenColumns() ? ((i <= options.frozenColumn) ? $headerRowL : $headerRowR) : $headerRowL;
 
         var header = $("<div class='ui-state-default slick-header-column' />")
-          .html("<span class='slick-column-name'>" + m.name + "</span>")
-          .width(m.width - headerColumnWidthDiff)
-          .attr("id", "" + uid + m.id)
-          .attr("title", m.toolTip || "")
-          .data("column", m)
-          .addClass(m.headerCssClass || "")
-          .addClass(hasFrozenColumns() && i <= options.frozenColumn ? 'frozen' : '')
-          .appendTo($headerTarget);
+            .html("<span class='slick-column-name'>" + m.name + "</span>")
+            .width(m.width - headerColumnWidthDiff)
+            .attr("id", "" + uid + m.id)
+            .attr("title", m.toolTip || "")
+            .data("column", m)
+            .addClass(m.headerCssClass || "")
+            .addClass(hasFrozenColumns() && i <= options.frozenColumn? 'frozen': '')
+            .appendTo($headerTarget);
 
         if (options.enableColumnReorder || m.sortable) {
           header
@@ -1273,7 +1273,7 @@ if (typeof Slick === "undefined") {
             .on('mouseleave', onMouseLeave);
         }
 
-        if (m.hasOwnProperty('headerCellAttrs') && m.headerCellAttrs instanceof Object) {
+        if(m.hasOwnProperty('headerCellAttrs') && m.headerCellAttrs instanceof Object) {
           for (var key in m.headerCellAttrs) {
             if (m.headerCellAttrs.hasOwnProperty(key)) {
               header.attr(key, m.headerCellAttrs[key]);
@@ -1284,7 +1284,7 @@ if (typeof Slick === "undefined") {
         if (m.sortable) {
           header.addClass("slick-header-sortable");
           header.append("<span class='slick-sort-indicator"
-            + (options.numberedMultiColumnSort && !options.sortColNumberInSeparateSpan ? " slick-sort-indicator-numbered" : "") + "' />");
+            + (options.numberedMultiColumnSort && !options.sortColNumberInSeparateSpan ? " slick-sort-indicator-numbered" : "" ) + "' />");
           if (options.numberedMultiColumnSort && options.sortColNumberInSeparateSpan) { header.append("<span class='slick-sort-indicator-numbered' />"); }
         }
 
@@ -1296,9 +1296,9 @@ if (typeof Slick === "undefined") {
 
         if (options.showHeaderRow) {
           var headerRowCell = $("<div class='ui-state-default slick-headerrow-column l" + i + " r" + i + "'></div>")
-            .data("column", m)
-            .addClass(hasFrozenColumns() && i <= options.frozenColumn ? 'frozen' : '')
-            .appendTo($headerRowTarget);
+              .data("column", m)
+              .addClass(hasFrozenColumns() && i <= options.frozenColumn? 'frozen': '')
+              .appendTo($headerRowTarget);
 
           trigger(self.onHeaderRowCellRendered, {
             "node": headerRowCell[0],
@@ -1307,9 +1307,9 @@ if (typeof Slick === "undefined") {
           });
         }
         if (options.createFooterRow && options.showFooterRow) {
-          var footerRowCell = $("<div class='ui-state-default slick-footerrow-column l" + i + " r" + i + "'></div>")
-            .data("column", m)
-            .appendTo($footerRow);
+          var footerRowCell = $("<div class='ui-state-default slick-footerrow-column l" + i   + " r" + i + "'></div>")
+              .data("column", m)
+              .appendTo($footerRow);
 
           trigger(self.onFooterRowCellRendered, {
             "node": footerRowCell[0],
@@ -1323,9 +1323,9 @@ if (typeof Slick === "undefined") {
       setupColumnResize();
       if (options.enableColumnReorder) {
         if (typeof options.enableColumnReorder == 'function') {
-          options.enableColumnReorder(self, $headers, headerColumnWidthDiff, setColumns, setupColumnResize, columns, getColumnIndex, uid, trigger);
+            options.enableColumnReorder(self, $headers, headerColumnWidthDiff, setColumns, setupColumnResize, columns, getColumnIndex, uid, trigger);
         } else {
-          setupColumnReorder();
+            setupColumnReorder();
         }
       }
     }
@@ -1363,37 +1363,37 @@ if (typeof Slick === "undefined") {
           var hadSortCol = !!sortColumn;
 
           if (options.tristateMultiColumnSort) {
-            if (!sortColumn) {
-              sortColumn = { columnId: column.id, sortAsc: column.defaultSortAsc };
-            }
-            if (hadSortCol && sortColumn.sortAsc) {
-              // three state: remove sort rather than go back to ASC
-              sortColumns.splice(i, 1);
-              sortColumn = null;
-            }
-            if (!options.multiColumnSort) { sortColumns = []; }
-            if (sortColumn && (!hadSortCol || !options.multiColumnSort)) {
-              sortColumns.push(sortColumn);
-            }
-          } else {
-            // legacy behaviour
-            if (e.metaKey && options.multiColumnSort) {
-              if (sortColumn) {
-                sortColumns.splice(i, 1);
-              }
-            }
-            else {
-              if ((!e.shiftKey && !e.metaKey) || !options.multiColumnSort) {
-                sortColumns = [];
-              }
-
               if (!sortColumn) {
                 sortColumn = { columnId: column.id, sortAsc: column.defaultSortAsc };
-                sortColumns.push(sortColumn);
-              } else if (sortColumns.length === 0) {
+              }
+              if (hadSortCol && sortColumn.sortAsc) {
+                // three state: remove sort rather than go back to ASC
+                sortColumns.splice(i, 1);
+                sortColumn = null;
+              }
+              if (!options.multiColumnSort) { sortColumns = []; }
+              if (sortColumn && (!hadSortCol || !options.multiColumnSort)) {
                 sortColumns.push(sortColumn);
               }
-            }
+          } else {
+              // legacy behaviour
+              if (e.metaKey && options.multiColumnSort) {
+                if (sortColumn) {
+                  sortColumns.splice(i, 1);
+                }
+              }
+              else {
+                if ((!e.shiftKey && !e.metaKey) || !options.multiColumnSort) {
+                  sortColumns = [];
+                }
+
+                if (!sortColumn) {
+                  sortColumn = { columnId: column.id, sortAsc: column.defaultSortAsc };
+                  sortColumns.push(sortColumn);
+                } else if (sortColumns.length === 0) {
+                  sortColumns.push(sortColumn);
+                }
+              }
           }
 
           setSortColumns(sortColumns);
@@ -1408,8 +1408,8 @@ if (typeof Slick === "undefined") {
           } else {
             trigger(self.onSort, {
               multiColumnSort: true,
-              sortCols: $.map(sortColumns, function (col) {
-                return { columnId: columns[getColumnIndex(col.columnId)].id, sortCol: columns[getColumnIndex(col.columnId)], sortAsc: col.sortAsc };
+              sortCols: $.map(sortColumns, function(col) {
+                return {columnId: columns[getColumnIndex(col.columnId)].id, sortCol: columns[getColumnIndex(col.columnId)], sortAsc: col.sortAsc };
               })
             }, e);
           }
@@ -1462,7 +1462,7 @@ if (typeof Slick === "undefined") {
 
     function remove(arr, elem) {
       var index = arr.lastIndexOf(elem);
-      if (index > -1) {
+      if(index > -1) {
         arr.splice(index, 1);
         remove(arr, elem);
       }
@@ -1474,9 +1474,9 @@ if (typeof Slick === "undefined") {
       var positionValid = limit.start <= currentPosition && currentPosition <= limit.end;
 
       return {
-        limit: limit,
+    	limit: limit,
         valid: positionValid,
-        message: positionValid ? '' : 'Column "'.concat($item.text(), '" can be reordered only within the "', limit.group.name, '" group!')
+        message: positionValid? '': 'Column "'.concat($item.text(), '" can be reordered only within the "', limit.group.name, '" group!')
       };
     }
 
@@ -1505,7 +1505,7 @@ if (typeof Slick === "undefined") {
           ui.placeholder.width(ui.helper.outerWidth() - headerColumnWidthDiff);
           canDragScroll = !hasFrozenColumns() ||
             (ui.placeholder.offset().left + ui.placeholder.width()) > $viewportScrollContainerX.offset().left;
-          $(ui.helper).addClass("slick-header-column-active");
+	      $(ui.helper).addClass("slick-header-column-active");
         },
         beforeStop: function (e, ui) {
           $(ui.helper).removeClass("slick-header-column-active");
@@ -1556,28 +1556,28 @@ if (typeof Slick === "undefined") {
           }
           setColumns(reorderedColumns);
 
-          trigger(self.onColumnsReordered, { impactedColumns: getImpactedColumns(limit) });
+          trigger(self.onColumnsReordered, { impactedColumns : getImpactedColumns( limit ) });
           e.stopPropagation();
           setupColumnResize();
         }
       });
     }
 
-    function getImpactedColumns(limit) {
-      var impactedColumns = [];
+    function getImpactedColumns( limit ) {
+    	var impactedColumns = [];
 
-      if (limit) {
+    	if( limit ) {
 
-        for (var i = limit.start; i <= limit.end; i++) {
-          impactedColumns.push(columns[i]);
-        }
-      }
-      else {
+	   		for( var i = limit.start; i <= limit.end; i++ ) {
+	   			impactedColumns.push( columns[i] );
+	   		}
+    	}
+    	else {
 
-        impactedColumns = columns;
-      }
+    		impactedColumns = columns;
+    	}
 
-      return impactedColumns;
+   		return impactedColumns;
     }
 
     function setupColumnResize() {
@@ -1603,178 +1603,76 @@ if (typeof Slick === "undefined") {
         }
         $col = $(e);
         $("<div class='slick-resizable-handle' />")
-          .appendTo(e)
-          .on("dragstart", function (e, dd) {
-            if (!getEditorLock().commitCurrentEdit()) {
-              return false;
-            }
-            pageX = e.pageX;
-            $(this).parent().addClass("slick-header-column-active");
-            var shrinkLeewayOnRight = null, stretchLeewayOnRight = null;
-            // lock each column's width option to current width
-            columnElements.each(function (i, e) {
-              if (i >= columns.length) { return; }
-              columns[i].previousWidth = $(e).outerWidth();
-            });
-            if (options.forceFitColumns) {
-              shrinkLeewayOnRight = 0;
-              stretchLeewayOnRight = 0;
-              // colums on right affect maxPageX/minPageX
-              for (j = i + 1; j < columns.length; j++) {
+            .appendTo(e)
+            .on("dragstart", function (e, dd) {
+              if (!getEditorLock().commitCurrentEdit()) {
+                return false;
+              }
+              pageX = e.pageX;
+              $(this).parent().addClass("slick-header-column-active");
+              var shrinkLeewayOnRight = null, stretchLeewayOnRight = null;
+              // lock each column's width option to current width
+              columnElements.each(function (i, e) {
+                if (i >= columns.length) { return; }
+                columns[i].previousWidth = $(e).outerWidth();
+              });
+              if (options.forceFitColumns) {
+                shrinkLeewayOnRight = 0;
+                stretchLeewayOnRight = 0;
+                // colums on right affect maxPageX/minPageX
+                for (j = i + 1; j < columns.length; j++) {
+                  c = columns[j];
+                  if (c.resizable) {
+                    if (stretchLeewayOnRight !== null) {
+                      if (c.maxWidth) {
+                        stretchLeewayOnRight += c.maxWidth - c.previousWidth;
+                      } else {
+                        stretchLeewayOnRight = null;
+                      }
+                    }
+                    shrinkLeewayOnRight += c.previousWidth - Math.max(c.minWidth || 0, absoluteColumnMinWidth);
+                  }
+                }
+              }
+              var shrinkLeewayOnLeft = 0, stretchLeewayOnLeft = 0;
+              for (j = 0; j <= i; j++) {
+                // columns on left only affect minPageX
                 c = columns[j];
                 if (c.resizable) {
-                  if (stretchLeewayOnRight !== null) {
+                  if (stretchLeewayOnLeft !== null) {
                     if (c.maxWidth) {
-                      stretchLeewayOnRight += c.maxWidth - c.previousWidth;
+                      stretchLeewayOnLeft += c.maxWidth - c.previousWidth;
                     } else {
-                      stretchLeewayOnRight = null;
+                      stretchLeewayOnLeft = null;
                     }
                   }
-                  shrinkLeewayOnRight += c.previousWidth - Math.max(c.minWidth || 0, absoluteColumnMinWidth);
+                  shrinkLeewayOnLeft += c.previousWidth - Math.max(c.minWidth || 0, absoluteColumnMinWidth);
                 }
               }
-            }
-            var shrinkLeewayOnLeft = 0, stretchLeewayOnLeft = 0;
-            for (j = 0; j <= i; j++) {
-              // columns on left only affect minPageX
-              c = columns[j];
-              if (c.resizable) {
-                if (stretchLeewayOnLeft !== null) {
-                  if (c.maxWidth) {
-                    stretchLeewayOnLeft += c.maxWidth - c.previousWidth;
-                  } else {
-                    stretchLeewayOnLeft = null;
-                  }
-                }
-                shrinkLeewayOnLeft += c.previousWidth - Math.max(c.minWidth || 0, absoluteColumnMinWidth);
+              if (shrinkLeewayOnRight === null) {
+                shrinkLeewayOnRight = 100000;
               }
-            }
-            if (shrinkLeewayOnRight === null) {
-              shrinkLeewayOnRight = 100000;
-            }
-            if (shrinkLeewayOnLeft === null) {
-              shrinkLeewayOnLeft = 100000;
-            }
-            if (stretchLeewayOnRight === null) {
-              stretchLeewayOnRight = 100000;
-            }
-            if (stretchLeewayOnLeft === null) {
-              stretchLeewayOnLeft = 100000;
-            }
-            maxPageX = pageX + Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft);
-            minPageX = pageX - Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight);
-          })
-          .on("drag", function (e, dd) {
-            columnResizeDragging = true;
-            var actualMinWidth, d = Math.min(maxPageX, Math.max(minPageX, e.pageX)) - pageX, x;
-            var newCanvasWidthL = 0, newCanvasWidthR = 0;
-
-            if (d < 0) { // shrink column
-              x = d;
-
-              for (j = i; j >= 0; j--) {
-                c = columns[j];
-                if (c.resizable) {
-                  actualMinWidth = Math.max(c.minWidth || 0, absoluteColumnMinWidth);
-                  if (x && c.previousWidth + x < actualMinWidth) {
-                    x += c.previousWidth - actualMinWidth;
-                    c.width = actualMinWidth;
-                  } else {
-                    c.width = c.previousWidth + x;
-                    x = 0;
-                  }
-                }
+              if (shrinkLeewayOnLeft === null) {
+                shrinkLeewayOnLeft = 100000;
               }
-
-              for (k = 0; k <= i; k++) {
-                c = columns[k];
-
-                if (hasFrozenColumns() && (k > options.frozenColumn)) {
-                  newCanvasWidthR += c.width;
-                } else {
-                  newCanvasWidthL += c.width;
-                }
+              if (stretchLeewayOnRight === null) {
+                stretchLeewayOnRight = 100000;
               }
-
-              if (options.forceFitColumns) {
-                x = -d;
-                for (j = i + 1; j < columns.length; j++) {
-                  c = columns[j];
-                  if (c.resizable) {
-                    if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
-                      x -= c.maxWidth - c.previousWidth;
-                      c.width = c.maxWidth;
-                    } else {
-                      c.width = c.previousWidth + x;
-                      x = 0;
-                    }
-
-                    if (hasFrozenColumns() && (j > options.frozenColumn)) {
-                      newCanvasWidthR += c.width;
-                    } else {
-                      newCanvasWidthL += c.width;
-                    }
-                  }
-                }
-              } else {
-                for (j = i + 1; j < columns.length; j++) {
-                  c = columns[j];
-
-                  if (hasFrozenColumns() && (j > options.frozenColumn)) {
-                    newCanvasWidthR += c.width;
-                  } else {
-                    newCanvasWidthL += c.width;
-                  }
-                }
+              if (stretchLeewayOnLeft === null) {
+                stretchLeewayOnLeft = 100000;
               }
+              maxPageX = pageX + Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft);
+              minPageX = pageX - Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight);
+            })
+            .on("drag", function (e, dd) {
+              columnResizeDragging = true;
+              var actualMinWidth, d = Math.min(maxPageX, Math.max(minPageX, e.pageX)) - pageX, x;
+              var newCanvasWidthL = 0, newCanvasWidthR = 0;
 
-              if (options.forceFitColumns) {
-                x = -d;
-                for (j = i + 1; j < columns.length; j++) {
-                  c = columns[j];
-                  if (c.resizable) {
-                    if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
-                      x -= c.maxWidth - c.previousWidth;
-                      c.width = c.maxWidth;
-                    } else {
-                      c.width = c.previousWidth + x;
-                      x = 0;
-                    }
-                  }
-                }
-              }
-            } else { // stretch column
-              x = d;
+              if (d < 0) { // shrink column
+                x = d;
 
-              newCanvasWidthL = 0;
-              newCanvasWidthR = 0;
-
-              for (j = i; j >= 0; j--) {
-                c = columns[j];
-                if (c.resizable) {
-                  if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
-                    x -= c.maxWidth - c.previousWidth;
-                    c.width = c.maxWidth;
-                  } else {
-                    c.width = c.previousWidth + x;
-                    x = 0;
-                  }
-                }
-              }
-
-              for (k = 0; k <= i; k++) {
-                c = columns[k];
-
-                if (hasFrozenColumns() && (k > options.frozenColumn)) {
-                  newCanvasWidthR += c.width;
-                } else {
-                  newCanvasWidthL += c.width;
-                }
-              }
-
-              if (options.forceFitColumns) {
-                x = -d;
-                for (j = i + 1; j < columns.length; j++) {
+                for (j = i; j >= 0; j--) {
                   c = columns[j];
                   if (c.resizable) {
                     actualMinWidth = Math.max(c.minWidth || 0, absoluteColumnMinWidth);
@@ -1785,6 +1683,42 @@ if (typeof Slick === "undefined") {
                       c.width = c.previousWidth + x;
                       x = 0;
                     }
+                  }
+                }
+
+                for (k = 0; k <= i; k++) {
+                  c = columns[k];
+
+                  if (hasFrozenColumns() && (k > options.frozenColumn)) {
+                    newCanvasWidthR += c.width;
+                  } else {
+                    newCanvasWidthL += c.width;
+                  }
+                }
+
+                if (options.forceFitColumns) {
+                  x = -d;
+                  for (j = i + 1; j < columns.length; j++) {
+                    c = columns[j];
+                    if (c.resizable) {
+                      if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
+                        x -= c.maxWidth - c.previousWidth;
+                        c.width = c.maxWidth;
+                      } else {
+                        c.width = c.previousWidth + x;
+                        x = 0;
+                      }
+
+                      if (hasFrozenColumns() && (j > options.frozenColumn)) {
+                        newCanvasWidthR += c.width;
+                      } else {
+                        newCanvasWidthL += c.width;
+                      }
+                    }
+                  }
+                } else {
+                  for (j = i + 1; j < columns.length; j++) {
+                    c = columns[j];
 
                     if (hasFrozenColumns() && (j > options.frozenColumn)) {
                       newCanvasWidthR += c.width;
@@ -1793,56 +1727,122 @@ if (typeof Slick === "undefined") {
                     }
                   }
                 }
-              } else {
-                for (j = i + 1; j < columns.length; j++) {
-                  c = columns[j];
 
-                  if (hasFrozenColumns() && (j > options.frozenColumn)) {
+                if (options.forceFitColumns) {
+                  x = -d;
+                  for (j = i + 1; j < columns.length; j++) {
+                    c = columns[j];
+                    if (c.resizable) {
+                      if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
+                        x -= c.maxWidth - c.previousWidth;
+                        c.width = c.maxWidth;
+                      } else {
+                        c.width = c.previousWidth + x;
+                        x = 0;
+                      }
+                    }
+                  }
+                }
+              } else { // stretch column
+                x = d;
+
+                newCanvasWidthL = 0;
+                newCanvasWidthR = 0;
+
+                for (j = i; j >= 0; j--) {
+                  c = columns[j];
+                  if (c.resizable) {
+                    if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
+                      x -= c.maxWidth - c.previousWidth;
+                      c.width = c.maxWidth;
+                    } else {
+                      c.width = c.previousWidth + x;
+                      x = 0;
+                    }
+                  }
+                }
+
+                for (k = 0; k <= i; k++) {
+                  c = columns[k];
+
+                  if (hasFrozenColumns() && (k > options.frozenColumn)) {
                     newCanvasWidthR += c.width;
                   } else {
                     newCanvasWidthL += c.width;
                   }
                 }
+
+                if (options.forceFitColumns) {
+                  x = -d;
+                  for (j = i + 1; j < columns.length; j++) {
+                    c = columns[j];
+                    if (c.resizable) {
+                      actualMinWidth = Math.max(c.minWidth || 0, absoluteColumnMinWidth);
+                      if (x && c.previousWidth + x < actualMinWidth) {
+                        x += c.previousWidth - actualMinWidth;
+                        c.width = actualMinWidth;
+                      } else {
+                        c.width = c.previousWidth + x;
+                        x = 0;
+                      }
+
+                      if (hasFrozenColumns() && (j > options.frozenColumn)) {
+                        newCanvasWidthR += c.width;
+                      } else {
+                        newCanvasWidthL += c.width;
+                      }
+                    }
+                  }
+                } else {
+                  for (j = i + 1; j < columns.length; j++) {
+                    c = columns[j];
+
+                    if (hasFrozenColumns() && (j > options.frozenColumn)) {
+                      newCanvasWidthR += c.width;
+                    } else {
+                      newCanvasWidthL += c.width;
+                    }
+                  }
+                }
               }
-            }
 
-            if (hasFrozenColumns() && newCanvasWidthL != canvasWidthL) {
-              $headerL.width(newCanvasWidthL + 1000);
-              $paneHeaderR.css('left', newCanvasWidthL);
-            }
+              if (hasFrozenColumns() && newCanvasWidthL != canvasWidthL) {
+                $headerL.width(newCanvasWidthL + 1000);
+                $paneHeaderR.css('left', newCanvasWidthL);
+              }
 
-            applyColumnHeaderWidths();
-            applyColumnGroupHeaderWidths();
-            if (options.syncColumnCellResize) {
-              applyColumnWidths();
-            }
-            trigger(self.onColumnsDrag, {
-              triggeredByColumn: $(this).parent().attr("id").replace(uid, ""),
-              resizeHandle: $(this)
-            });
-          })
-          .on("dragend", function (e, dd) {
-            $(this).parent().removeClass("slick-header-column-active");
-
-            var triggeredByColumn = $(this).parent().attr("id").replace(uid, "");
-            if (trigger(self.onBeforeColumnsResize, { triggeredByColumn: triggeredByColumn }) === true) {
               applyColumnHeaderWidths();
               applyColumnGroupHeaderWidths();
-            }
-            var newWidth;
-            for (j = 0; j < columns.length; j++) {
-              c = columns[j];
-              newWidth = $(columnElements[j]).outerWidth();
-
-              if (c.previousWidth !== newWidth && c.rerenderOnResize) {
-                invalidateAllRows();
+              if (options.syncColumnCellResize) {
+                applyColumnWidths();
               }
-            }
-            updateCanvasWidth(true);
-            render();
-            trigger(self.onColumnsResized, { triggeredByColumn: triggeredByColumn });
-            setTimeout(function () { columnResizeDragging = false; }, 300);
-          });
+              trigger(self.onColumnsDrag, {
+                triggeredByColumn: $(this).parent().attr("id").replace(uid, ""),
+                resizeHandle: $(this)
+              });
+            })
+            .on("dragend", function (e, dd) {
+              $(this).parent().removeClass("slick-header-column-active");
+
+              var triggeredByColumn = $(this).parent().attr("id").replace(uid, "");
+              if (trigger(self.onBeforeColumnsResize, { triggeredByColumn: triggeredByColumn }) === true) {
+                applyColumnHeaderWidths();
+                applyColumnGroupHeaderWidths();
+              }
+              var newWidth;
+              for (j = 0; j < columns.length; j++) {
+                c = columns[j];
+                newWidth = $(columnElements[j]).outerWidth();
+
+                if (c.previousWidth !== newWidth && c.rerenderOnResize) {
+                  invalidateAllRows();
+                }
+              }
+              updateCanvasWidth(true);
+              render();
+              trigger(self.onColumnsResized, { triggeredByColumn: triggeredByColumn });
+              setTimeout(function () { columnResizeDragging = false; }, 300);
+            });
       });
     }
 
@@ -1864,12 +1864,12 @@ if (typeof Slick === "undefined") {
 
       if (options.frozenRow > -1) {
         hasFrozenRows = true;
-        frozenRowsHeight = (options.frozenRow) * options.rowHeight;
+        frozenRowsHeight = ( options.frozenRow ) * options.rowHeight;
 
         var dataLength = getDataLength();
 
-        actualFrozenRow = (options.frozenBottom)
-          ? (dataLength - options.frozenRow)
+        actualFrozenRow = ( options.frozenBottom )
+          ? ( dataLength - options.frozenRow )
           : options.frozenRow;
       } else {
         hasFrozenRows = false;
@@ -1904,23 +1904,23 @@ if (typeof Slick === "undefined") {
 
     function setOverflow() {
       $viewportTopL.css({
-        'overflow-x': (hasFrozenColumns()) ? (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll') : (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'auto'),
-        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : ((hasFrozenColumns()) ? (hasFrozenRows ? 'hidden' : 'hidden') : (hasFrozenRows ? 'scroll' : 'auto'))
+        'overflow-x': ( hasFrozenColumns() ) ? ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll' ) : ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'auto' ),
+        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : (( hasFrozenColumns() ) ? ( hasFrozenRows ? 'hidden' : 'hidden' ) : ( hasFrozenRows ? 'scroll' : 'auto' ))
       });
 
       $viewportTopR.css({
-        'overflow-x': (hasFrozenColumns()) ? (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll') : (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'auto'),
-        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : ((hasFrozenColumns()) ? (hasFrozenRows ? 'scroll' : 'auto') : (hasFrozenRows ? 'scroll' : 'auto'))
+        'overflow-x': ( hasFrozenColumns() ) ? ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll' ) : ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'auto' ),
+        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : (( hasFrozenColumns() ) ? ( hasFrozenRows ? 'scroll' : 'auto'   ) : ( hasFrozenRows ? 'scroll' : 'auto' ))
       });
 
       $viewportBottomL.css({
-        'overflow-x': (hasFrozenColumns()) ? (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'scroll' : 'auto') : (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'auto' : 'auto'),
-        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : ((hasFrozenColumns()) ? (hasFrozenRows ? 'hidden' : 'hidden') : (hasFrozenRows ? 'scroll' : 'auto'))
+        'overflow-x': ( hasFrozenColumns() ) ? ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'scroll' : 'auto'   ): ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'auto' : 'auto'   ),
+        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : (( hasFrozenColumns() ) ? ( hasFrozenRows ? 'hidden' : 'hidden' ): ( hasFrozenRows ? 'scroll' : 'auto' ))
       });
 
       $viewportBottomR.css({
-        'overflow-x': (hasFrozenColumns()) ? (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'scroll' : 'auto') : (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'auto' : 'auto'),
-        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : ((hasFrozenColumns()) ? (hasFrozenRows ? 'auto' : 'auto') : (hasFrozenRows ? 'auto' : 'auto'))
+        'overflow-x': ( hasFrozenColumns() ) ? ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'scroll' : 'auto' ) : ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'auto' : 'auto' ),
+        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : (( hasFrozenColumns() ) ? ( hasFrozenRows ? 'auto' : 'auto'   ) : ( hasFrozenRows ? 'auto' : 'auto' ))
       });
       if (options.viewportClass) {
         $viewportTopL.toggleClass(options.viewportClass, true);
@@ -1973,7 +1973,7 @@ if (typeof Slick === "undefined") {
       // jquery 1.8 changed .width to read the true inner element width if box-sizing is set to border-box, and introduced a setter for .outerWidth
       // so for equivalent functionality, prior to 1.8 use .width, and after use .outerWidth
       var verArray = $.fn.jquery.split('.');
-      jQueryNewWidthBehaviour = (verArray[0] == 1 && verArray[1] >= 8) || verArray[0] >= 2;
+      jQueryNewWidthBehaviour = (verArray[0]==1 && verArray[1]>=8) ||  verArray[0] >=2;
 
       el = $("<div class='ui-state-default slick-header-column' style='visibility:hidden'>-</div>").appendTo($headers);
       headerColumnWidthDiff = headerColumnHeightDiff = 0;
@@ -2078,12 +2078,12 @@ if (typeof Slick === "undefined") {
       trigger(self.onBeforeDestroy, {});
 
       var i = plugins.length;
-      while (i--) {
+      while(i--) {
         unregisterPlugin(plugins[i]);
       }
 
       if (options.enableColumnReorder) {
-        $headers.filter(":ui-sortable").sortable("destroy");
+          $headers.filter(":ui-sortable").sortable("destroy");
       }
 
       unbindAncestorScrollEvents();
@@ -2118,9 +2118,9 @@ if (typeof Slick === "undefined") {
     function autosizeColumns(autosizeMode, isInit) {
       //LogColWidths();
 
-      autosizeMode = autosizeMode || options.autosizeColsMode;
+      autosizeMode =  autosizeMode || options.autosizeColsMode;
       if (autosizeMode === Slick.GridAutosizeColsMode.LegacyForceFit
-        || autosizeMode === Slick.GridAutosizeColsMode.LegacyOff) {
+      || autosizeMode === Slick.GridAutosizeColsMode.LegacyOff) {
         legacyAutosizeColumns();
         return;
       }
@@ -2181,7 +2181,7 @@ if (typeof Slick === "undefined") {
             } else {
               colWidth = c.autoSize.widthPx;
             }
-            if (c.rerenderOnResize && c.width != colWidth) { reRender = true; }
+            if (c.rerenderOnResize && c.width  != colWidth) { reRender = true; }
             c.width = colWidth;
           }
         } else if ((options.viewportSwitchToScrollModeWidthPercent && totalWidthLessSTR + strColsMinWidth > viewportWidth * options.viewportSwitchToScrollModeWidthPercent / 100)
@@ -2209,7 +2209,7 @@ if (typeof Slick === "undefined") {
                 unallocatedViewportWidth -= colWidth;
               }
             }
-            if (c.rerenderOnResize && c.width != colWidth) { reRender = true; }
+            if (c.rerenderOnResize && c.width  != colWidth) { reRender = true; }
             c.width = colWidth;
           }
         }
@@ -2230,8 +2230,8 @@ if (typeof Slick === "undefined") {
       reRenderColumns(reRender);
     }
 
-    function LogColWidths() {
-      var s = "Col Widths:";
+    function LogColWidths () {
+      var s =  "Col Widths:";
       for (var i = 0; i < columns.length; i++) { s += ' ' + columns[i].width; }
       console.log(s);
     }
@@ -2242,7 +2242,7 @@ if (typeof Slick === "undefined") {
       // set to width as default
       autoSize.widthPx = columnDef.width;
       if (autoSize.autosizeMode === Slick.ColAutosizeMode.Locked
-        || autoSize.autosizeMode === Slick.ColAutosizeMode.Guide) {
+      || autoSize.autosizeMode === Slick.ColAutosizeMode.Guide) {
         return;
       }
 
@@ -2260,12 +2260,12 @@ if (typeof Slick === "undefined") {
             colDataTypeOf = typeof colDataItem;
             if (colDataTypeOf === 'object') {
               if (colDataItem instanceof Date) { colDataTypeOf = "date"; }
-              if (typeof moment !== 'undefined' && colDataItem instanceof moment) { colDataTypeOf = "moment"; }
+              if (typeof moment!=='undefined' && colDataItem instanceof moment) { colDataTypeOf = "moment"; }
             }
           }
         }
         if (colDataTypeOf === 'boolean') {
-          autoSize.colValueArray = [true, false];
+          autoSize.colValueArray = [ true, false ];
         }
         if (colDataTypeOf === 'number') {
           autoSize.valueFilterMode = Slick.ValueFilterMode.GetGreatestAndSub;
@@ -2277,17 +2277,17 @@ if (typeof Slick === "undefined") {
           autoSize.allowAddlPercent = 5;
         }
         if (colDataTypeOf === 'date') {
-          autoSize.colValueArray = [new Date(2009, 8, 30, 12, 20, 20)]; // Sep 30th 2009, 12:20:20 AM
+          autoSize.colValueArray = [ new Date(2009, 8, 30, 12, 20, 20) ]; // Sep 30th 2009, 12:20:20 AM
         }
-        if (colDataTypeOf === 'moment' && typeof moment !== 'undefined') {
-          autoSize.colValueArray = [moment([2009, 8, 30, 12, 20, 20])]; // Sep 30th 2009, 12:20:20 AM
+        if (colDataTypeOf === 'moment' && typeof moment!=='undefined') {
+          autoSize.colValueArray = [ moment([2009, 8, 30, 12, 20, 20]) ]; // Sep 30th 2009, 12:20:20 AM
         }
       }
 
       // at this point, the autosizeMode is effectively 'Content', so proceed to get size
       var colWidth = getColContentSize(columnDef, $gridCanvas, isInit);
 
-      var addlPercentMultiplier = (autoSize.allowAddlPercent ? (1 + autoSize.allowAddlPercent / 100) : 1);
+      var addlPercentMultiplier = (autoSize.allowAddlPercent ? (1 + autoSize.allowAddlPercent/100) : 1);
       colWidth = colWidth * addlPercentMultiplier + options.autosizeColPaddingPx;
       if (columnDef.minWidth && colWidth < columnDef.minWidth) { colWidth = columnDef.minWidth; }
       if (columnDef.maxWidth && colWidth > columnDef.maxWidth) { colWidth = columnDef.maxWidth; }
@@ -2321,8 +2321,8 @@ if (typeof Slick === "undefined") {
 
       var rowSelectionMode = (isInit ? autoSize.rowSelectionModeOnInit : undefined) || autoSize.rowSelectionMode;
 
-      if (rowSelectionMode === Slick.RowSelectionMode.FirstRow) { rows = rows.slice(0, 1); }
-      if (rowSelectionMode === Slick.RowSelectionMode.LastRow) { rows = rows.slice(rows.length - 1, rows.length); }
+      if (rowSelectionMode === Slick.RowSelectionMode.FirstRow) { rows = rows.slice(0,1); }
+      if (rowSelectionMode === Slick.RowSelectionMode.LastRow) { rows = rows.slice(rows.length -1, rows.length); }
       if (rowSelectionMode === Slick.RowSelectionMode.FirstNRows) { rows = rows.slice(0, autoSize.rowSelectionCount); }
 
       // now use valueFilterMode to further filter selected rows
@@ -2335,7 +2335,7 @@ if (typeof Slick === "undefined") {
           rows = Object.keys(rowsDict);
         } else {
           rows = [];
-          for (var i in rowsDict) rows.push(i);
+          for (var i in rowsDict)  rows.push(i);
         }
       }
 
@@ -2351,7 +2351,7 @@ if (typeof Slick === "undefined") {
         maxVal = Array(maxVal.length + 1).join("9");
         maxVal = +maxVal;
 
-        rows = [maxVal];
+        rows = [ maxVal ];
       }
 
       if (autoSize.valueFilterMode === Slick.ValueFilterMode.GetLongestTextAndSub) {
@@ -2365,7 +2365,7 @@ if (typeof Slick === "undefined") {
         tempVal = Array(maxLen + 1).join("m");
         widthAdjustRatio = options.autosizeTextAvgToMWidthRatio;
 
-        rows = [tempVal];
+        rows = [ tempVal ];
       }
 
       if (autoSize.valueFilterMode === Slick.ValueFilterMode.GetLongestText) {
@@ -2377,7 +2377,7 @@ if (typeof Slick === "undefined") {
         }
         // now substitute a 'c' for all characters
         tempVal = rows[maxIndex][columnDef.field];
-        rows = [tempVal];
+        rows = [ tempVal ];
       }
 
       maxColWidth = getColWidth(columnDef, $gridCanvas, rows) * widthAdjustRatio;
@@ -2385,59 +2385,59 @@ if (typeof Slick === "undefined") {
     }
 
     function getColWidth(columnDef, $gridCanvas, data) {
-      var colIndex = getColumnIndex(columnDef.id);
+        var colIndex = getColumnIndex(columnDef.id);
 
-      var $rowEl = $('<div class="slick-row ui-widget-content"></div>');
-      var $cellEl = $('<div class="slick-cell"></div>');
-      $cellEl.css({
-        "position": "absolute",
-        "visibility": "hidden",
-        "text-overflow": "initial",
-        "white-space": "nowrap"
-      });
-      $rowEl.append($cellEl);
-
-      $gridCanvas.append($rowEl);
-
-      var len, max = 0, text, maxText, formatterResult, maxWidth = 0, val;
-
-      // use canvas - very fast, but text-only
-      if (canvas_context && columnDef.autoSize.widthEvalMode === Slick.WidthEvalMode.CanvasTextSize) {
-        canvas_context.font = $cellEl.css("font-size") + " " + $cellEl.css("font-family");
-        $(data).each(function (index, row) {
-          // row is either an array or values or a single value
-          val = (Array.isArray(row) ? row[columnDef.field] : row);
-          text = '' + val;
-          len = text ? canvas_context.measureText(text).width : 0;
-          if (len > max) { max = len; maxText = text; }
+        var $rowEl = $('<div class="slick-row ui-widget-content"></div>');
+        var $cellEl = $('<div class="slick-cell"></div>');
+        $cellEl.css({
+            "position": "absolute",
+            "visibility": "hidden",
+            "text-overflow": "initial",
+            "white-space": "nowrap"
         });
+        $rowEl.append($cellEl);
 
-        $cellEl.html(maxText);
-        len = $cellEl.outerWidth();
+        $gridCanvas.append($rowEl);
+
+        var len, max = 0, text, maxText, formatterResult, maxWidth = 0, val;
+
+         // use canvas - very fast, but text-only
+        if (canvas_context && columnDef.autoSize.widthEvalMode === Slick.WidthEvalMode.CanvasTextSize) {
+          canvas_context.font = $cellEl.css("font-size") + " " + $cellEl.css("font-family");
+          $(data).each(function (index, row) {
+              // row is either an array or values or a single value
+              val = (Array.isArray(row) ? row[columnDef.field] : row);
+              text = '' + val;
+              len = text ? canvas_context.measureText(text).width : 0;
+              if (len > max) { max = len; maxText = text; }
+          });
+
+          $cellEl.html(maxText);
+          len = $cellEl.outerWidth();
+
+          $rowEl.remove();
+          return len;
+        }
+
+        $(data).each(function (index, row) {
+            val = (Array.isArray(row) ? row[columnDef.field] : row);
+            if (columnDef.formatterOverride) {
+              // use formatterOverride as first preference
+              formatterResult = columnDef.formatterOverride(index, colIndex, val, columnDef, row);
+            } else if (columnDef.formatter) {
+              // otherwise, use formatter
+              formatterResult = columnDef.formatter(index, colIndex, val, columnDef, row);
+            } else {
+              // otherwise, use plain text
+              formatterResult = '' + val;
+            }
+            applyFormatResultToCellNode(formatterResult, $cellEl[0]);
+            len = $cellEl.outerWidth();
+            if (len > max) { max = len; }
+         });
 
         $rowEl.remove();
-        return len;
-      }
-
-      $(data).each(function (index, row) {
-        val = (Array.isArray(row) ? row[columnDef.field] : row);
-        if (columnDef.formatterOverride) {
-          // use formatterOverride as first preference
-          formatterResult = columnDef.formatterOverride(index, colIndex, val, columnDef, row);
-        } else if (columnDef.formatter) {
-          // otherwise, use formatter
-          formatterResult = columnDef.formatter(index, colIndex, val, columnDef, row);
-        } else {
-          // otherwise, use plain text
-          formatterResult = '' + val;
-        }
-        applyFormatResultToCellNode(formatterResult, $cellEl[0]);
-        len = $cellEl.outerWidth();
-        if (len > max) { max = len; }
-      });
-
-      $rowEl.remove();
-      return max;
+        return max;
     }
 
     function getColHeaderWidth(columnDef) {
@@ -2471,11 +2471,11 @@ if (typeof Slick === "undefined") {
 
     function legacyAutosizeColumns() {
       var i, c,
-        widths = [],
-        shrinkLeeway = 0,
-        total = 0,
-        prevTotal,
-        availWidth = viewportHasVScroll ? viewportW - scrollbarDimensions.width : viewportW;
+          widths = [],
+          shrinkLeeway = 0,
+          total = 0,
+          prevTotal,
+          availWidth = viewportHasVScroll ? viewportW - scrollbarDimensions.width : viewportW;
 
       for (i = 0; i < columns.length; i++) {
         c = columns[i];
@@ -2548,7 +2548,7 @@ if (typeof Slick === "undefined") {
       applyColumnGroupHeaderWidths();
       updateCanvasWidth(true);
 
-      trigger(self.onAutosizeColumns, { "columns": columns });
+      trigger(self.onAutosizeColumns, { "columns": columns});
 
       if (reRender) {
         invalidateAllRows();
@@ -2587,20 +2587,20 @@ if (typeof Slick === "undefined") {
 
         var groupColumns = treeColumns.getColumnsInDepth(depth);
 
-        $().add($groupHeadersL[depth]).add($groupHeadersR[depth]).each(function (i) {
+        $().add($groupHeadersL[depth]).add($groupHeadersR[depth]).each(function(i) {
           var $groupHeader = $(this),
             currentColumnIndex = 0;
 
-          $groupHeader.width(i === 0 ? getHeadersWidthL() : getHeadersWidthR());
+          $groupHeader.width(i === 0? getHeadersWidthL(): getHeadersWidthR());
 
-          $groupHeader.children().each(function () {
+          $groupHeader.children().each(function() {
             var $groupHeaderColumn = $(this);
 
             var m = $(this).data('column');
 
             m.width = 0;
 
-            m.columns.forEach(function () {
+            m.columns.forEach(function() {
               var $headerColumn = $groupHeader.next().children(':eq(' + (currentColumnIndex++) + ')');
               m.width += $headerColumn.outerWidth();
             });
@@ -2621,13 +2621,13 @@ if (typeof Slick === "undefined") {
       for (var i = 0, headers = $headers.children(), ii = columns.length; i < ii; i++) {
         h = $(headers[i]);
         if (jQueryNewWidthBehaviour) {
-          if (h.outerWidth() !== columns[i].width) {
-            h.outerWidth(columns[i].width);
-          }
+            if (h.outerWidth() !== columns[i].width) {
+              h.outerWidth(columns[i].width);
+            }
         } else {
-          if (h.width() !== columns[i].width - headerColumnWidthDiff) {
-            h.width(columns[i].width - headerColumnWidthDiff);
-          }
+            if (h.width() !== columns[i].width - headerColumnWidthDiff) {
+              h.width(columns[i].width - headerColumnWidthDiff);
+            }
         }
       }
 
@@ -2654,7 +2654,7 @@ if (typeof Slick === "undefined") {
     }
 
     function setSortColumn(columnId, ascending) {
-      setSortColumns([{ columnId: columnId, sortAsc: ascending }]);
+      setSortColumns([{ columnId: columnId, sortAsc: ascending}]);
     }
 
     function setSortColumns(cols) {
@@ -2664,12 +2664,12 @@ if (typeof Slick === "undefined") {
       headerColumnEls
         .removeClass("slick-header-column-sorted")
         .find(".slick-sort-indicator")
-        .removeClass("slick-sort-indicator-asc slick-sort-indicator-desc");
+          .removeClass("slick-sort-indicator-asc slick-sort-indicator-desc");
       headerColumnEls
         .find(".slick-sort-indicator-numbered")
-        .text('');
+          .text('');
 
-      $.each(sortColumns, function (i, col) {
+      $.each(sortColumns, function(i, col) {
         if (col.sortAsc == null) {
           col.sortAsc = true;
         }
@@ -2677,12 +2677,12 @@ if (typeof Slick === "undefined") {
         if (columnIndex != null) {
           headerColumnEls.eq(columnIndex)
             .addClass("slick-header-column-sorted")
-            .find(".slick-sort-indicator")
-            .addClass(col.sortAsc ? "slick-sort-indicator-asc" : "slick-sort-indicator-desc");
+              .find(".slick-sort-indicator")
+                .addClass(col.sortAsc ? "slick-sort-indicator-asc" : "slick-sort-indicator-desc");
           if (numberCols) {
             headerColumnEls.eq(columnIndex)
               .find(".slick-sort-indicator-numbered")
-              .text(i + 1);
+                .text(i+1);
           }
         }
       });
@@ -2713,7 +2713,7 @@ if (typeof Slick === "undefined") {
       setCellCssStyles(options.selectedCellCssClass, hash);
 
       if (simpleArrayEquals(previousSelectedRows, selectedRows)) {
-        trigger(self.onSelectedRowsChanged, { rows: getSelectedRows(), previousSelectedRows: previousSelectedRows }, e);
+        trigger(self.onSelectedRowsChanged, {rows: getSelectedRows(), previousSelectedRows: previousSelectedRows}, e);
       }
     }
 
@@ -3029,7 +3029,7 @@ if (typeof Slick === "undefined") {
 
       if (prevScrollTop != newScrollTop) {
         vScrollDir = (prevScrollTop + oldOffset < newScrollTop + offset) ? 1 : -1;
-        lastRenderedScrollTop = (scrollTop = prevScrollTop = newScrollTop);
+        lastRenderedScrollTop = ( scrollTop = prevScrollTop = newScrollTop );
 
         if (hasFrozenColumns()) {
           $viewportTopL[0].scrollTop = newScrollTop;
@@ -3049,7 +3049,7 @@ if (typeof Slick === "undefined") {
       if (value == null) {
         return "";
       } else {
-        return (value + "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        return (value + "").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
       }
     }
 
@@ -3058,33 +3058,33 @@ if (typeof Slick === "undefined") {
 
       // look up by id, then index
       var columnOverrides = rowMetadata &&
-        rowMetadata.columns &&
-        (rowMetadata.columns[column.id] || rowMetadata.columns[getColumnIndex(column.id)]);
+          rowMetadata.columns &&
+          (rowMetadata.columns[column.id] || rowMetadata.columns[getColumnIndex(column.id)]);
 
       return (columnOverrides && columnOverrides.formatter) ||
-        (rowMetadata && rowMetadata.formatter) ||
-        column.formatter ||
-        (options.formatterFactory && options.formatterFactory.getFormatter(column)) ||
-        options.defaultFormatter;
+          (rowMetadata && rowMetadata.formatter) ||
+          column.formatter ||
+          (options.formatterFactory && options.formatterFactory.getFormatter(column)) ||
+          options.defaultFormatter;
     }
 
-    function callFormatter(row, cell, value, m, item, grid) {
+    function callFormatter( row, cell, value, m, item, grid ) {
 
-      var result;
+    	var result;
 
-      // pass metadata to formatter
-      var metadata = data.getItemMetadata && data.getItemMetadata(row);
-      metadata = metadata && metadata.columns;
+        // pass metadata to formatter
+        var metadata = data.getItemMetadata && data.getItemMetadata(row);
+        metadata = metadata && metadata.columns;
 
-      if (metadata) {
-        var columnData = metadata[m.id] || metadata[cell];
-        result = getFormatter(row, m)(row, cell, value, m, item, columnData);
-      }
-      else {
-        result = getFormatter(row, m)(row, cell, value, m, item);
-      }
+        if( metadata ) {
+        	var columnData = metadata[m.id] || metadata[cell];
+        	result = getFormatter(row, m)(row, cell, value, m, item, columnData );
+        }
+        else {
+        	result = getFormatter(row, m)(row, cell, value, m, item);
+        }
 
-      return result;
+        return result;
     }
 
     function getEditor(row, cell) {
@@ -3113,10 +3113,10 @@ if (typeof Slick === "undefined") {
       var d = getDataItem(row);
       var dataLoading = row < dataLength && !d;
       var rowCss = "slick-row" +
-        (hasFrozenRows && row <= options.frozenRow ? ' frozen' : '') +
-        (dataLoading ? " loading" : "") +
-        (row === activeRow && options.showCellSelection ? " active" : "") +
-        (row % 2 == 1 ? " odd" : " even");
+          (hasFrozenRows && row <= options.frozenRow? ' frozen': '') +
+          (dataLoading ? " loading" : "") +
+          (row === activeRow && options.showCellSelection ? " active" : "") +
+          (row % 2 == 1 ? " odd" : " even");
 
       if (!d) {
         rowCss += " " + options.addNewRowCssClass;
@@ -3131,7 +3131,7 @@ if (typeof Slick === "undefined") {
       var frozenRowOffset = getFrozenRowOffset(row);
 
       var rowHtml = "<div class='ui-widget-content " + rowCss + "' style='top:"
-        + (getRowTop(row) - frozenRowOffset)
+        + (getRowTop(row) - frozenRowOffset )
         + "px'>";
 
       stringArrayL.push(rowHtml);
@@ -3159,7 +3159,7 @@ if (typeof Slick === "undefined") {
             break;
           }
 
-          if (hasFrozenColumns() && (i > options.frozenColumn)) {
+          if (hasFrozenColumns() && ( i > options.frozenColumn )) {
             appendCellHtml(stringArrayR, row, i, colspan, d);
           } else {
             appendCellHtml(stringArrayL, row, i, colspan, d);
@@ -3188,7 +3188,7 @@ if (typeof Slick === "undefined") {
 
       var m = columns[cell];
       var cellCss = "slick-cell l" + cell + " r" + Math.min(columns.length - 1, cell + colspan - 1) +
-        (m.cssClass ? " " + m.cssClass : "");
+          (m.cssClass ? " " + m.cssClass : "");
 
       if (hasFrozenColumns() && cell <= options.frozenColumn) {
         cellCss += (" frozen");
@@ -3208,7 +3208,7 @@ if (typeof Slick === "undefined") {
       var value = null, formatterResult = '';
       if (item) {
         value = getDataItemValueForColumn(item, m);
-        formatterResult = getFormatter(row, m)(row, cell, value, m, item, self);
+        formatterResult =  getFormatter(row, m)(row, cell, value, m, item, self);
         if (formatterResult === null || formatterResult === undefined) { formatterResult = ''; }
       }
 
@@ -3218,7 +3218,7 @@ if (typeof Slick === "undefined") {
       var toolTip = formatterResult && formatterResult.toolTip ? "title='" + formatterResult.toolTip + "'" : '';
 
       var customAttrStr = '';
-      if (m.hasOwnProperty('cellAttrs') && m.cellAttrs instanceof Object) {
+      if(m.hasOwnProperty('cellAttrs') && m.cellAttrs instanceof Object) {
         for (var key in m.cellAttrs) {
           if (m.cellAttrs.hasOwnProperty(key)) {
             customAttrStr += ' ' + key + '="' + m.cellAttrs[key] + '" ';
@@ -3230,7 +3230,7 @@ if (typeof Slick === "undefined") {
 
       // if there is a corresponding row (if not, this is the Add New row or this data hasn't been loaded yet)
       if (item) {
-        stringArray.push(Object.prototype.toString.call(formatterResult) !== '[object Object]' ? formatterResult : formatterResult.text);
+        stringArray.push(Object.prototype.toString.call(formatterResult)  !== '[object Object]' ? formatterResult : formatterResult.text);
       }
 
       stringArray.push("</div>");
@@ -3245,17 +3245,17 @@ if (typeof Slick === "undefined") {
         var removeFrozenRow = true;
 
         if (hasFrozenRows
-          && ((options.frozenBottom && i >= actualFrozenRow) // Frozen bottom rows
-            || (!options.frozenBottom && i <= actualFrozenRow) // Frozen top rows
-          )
-        ) {
+          && ( ( options.frozenBottom && i >= actualFrozenRow ) // Frozen bottom rows
+            || ( !options.frozenBottom && i <= actualFrozenRow ) // Frozen top rows
+            )
+          ) {
           removeFrozenRow = false;
         }
 
-        if (((i = parseInt(i, 10)) !== activeRow)
-          && (i < rangeToKeep.top || i > rangeToKeep.bottom)
-          && (removeFrozenRow)
-        ) {
+        if (( ( i = parseInt(i, 10)) !== activeRow )
+          && ( i < rangeToKeep.top || i > rangeToKeep.bottom )
+          && ( removeFrozenRow )
+          ) {
           removeRowFromCache(i);
         }
       }
@@ -3287,7 +3287,7 @@ if (typeof Slick === "undefined") {
           postProcessedCleanupQueue.push({
             actionType: 'C',
             groupId: postProcessgroupId,
-            node: cacheEntry.cellNodesByColumnIdx[columnIdx | 0],
+            node: cacheEntry.cellNodesByColumnIdx[ columnIdx | 0],
             columnIdx: columnIdx | 0,
             rowIdx: rowIdx
           });
@@ -3326,7 +3326,7 @@ if (typeof Slick === "undefined") {
         zombieRowNodeFromLastMouseWheelEvent = cacheEntry.rowNode;
       } else {
 
-        cacheEntry.rowNode.each(function () {
+        cacheEntry.rowNode.each(function() {
           this.parentElement.removeChild(this);
         });
 
@@ -3345,7 +3345,7 @@ if (typeof Slick === "undefined") {
       }
       vScrollDir = 0;
       rl = rows.length;
-      for (i = 0; i < rl; i++) {
+      for (i = 0;  i < rl; i++) {
         if (currentEditor && activeRow === rows[i]) {
           makeActiveCellNormal();
         }
@@ -3362,21 +3362,21 @@ if (typeof Slick === "undefined") {
     }
 
     function applyFormatResultToCellNode(formatterResult, cellNode, suppressRemove) {
-      if (formatterResult === null || formatterResult === undefined) { formatterResult = ''; }
-      if (Object.prototype.toString.call(formatterResult) !== '[object Object]') {
-        cellNode.innerHTML = formatterResult;
-        return;
-      }
-      cellNode.innerHTML = formatterResult.text;
-      if (formatterResult.removeClasses && !suppressRemove) {
-        $(cellNode).removeClass(formatterResult.removeClasses);
-      }
-      if (formatterResult.addClasses) {
-        $(cellNode).addClass(formatterResult.addClasses);
-      }
-      if (formatterResult.toolTip) {
-        $(cellNode).attr("title", formatterResult.toolTip);
-      }
+        if (formatterResult === null || formatterResult === undefined) { formatterResult = ''; }
+        if (Object.prototype.toString.call(formatterResult)  !== '[object Object]') {
+          cellNode.innerHTML = formatterResult;
+          return;
+        }
+        cellNode.innerHTML = formatterResult.text;
+        if (formatterResult.removeClasses && !suppressRemove) {
+          $(cellNode).removeClass(formatterResult.removeClasses);
+        }
+        if (formatterResult.addClasses) {
+          $(cellNode).addClass(formatterResult.addClasses);
+        }
+        if (formatterResult.toolTip) {
+          $(cellNode).attr("title", formatterResult.toolTip);
+        }
     }
 
     function updateCell(row, cell) {
@@ -3389,7 +3389,7 @@ if (typeof Slick === "undefined") {
       if (currentEditor && activeRow === row && activeCell === cell) {
         currentEditor.loadValue(d);
       } else {
-        var formatterResult = d ? getFormatter(row, m)(row, cell, getDataItemValueForColumn(d, m), m, d, self) : "";
+        var formatterResult =  d ? getFormatter(row, m)(row, cell, getDataItemValueForColumn(d, m), m, d, self) : "";
         applyFormatResultToCellNode(formatterResult, cellNode);
         invalidatePostProcessingResults(row);
       }
@@ -3412,12 +3412,12 @@ if (typeof Slick === "undefined") {
 
         columnIdx = columnIdx | 0;
         var m = columns[columnIdx],
-          node = cacheEntry.cellNodesByColumnIdx[columnIdx][0];
+            node = cacheEntry.cellNodesByColumnIdx[columnIdx][0];
 
         if (row === activeRow && columnIdx === activeCell && currentEditor) {
           currentEditor.loadValue(d);
         } else if (d) {
-          formatterResult = getFormatter(row, m)(row, columnIdx, getDataItemValueForColumn(d, m), m, d, self);
+          formatterResult =  getFormatter(row, m)(row, columnIdx, getDataItemValueForColumn(d, m), m, d, self);
           applyFormatResultToCellNode(formatterResult, node);
         } else {
           node.innerHTML = "";
@@ -3429,21 +3429,21 @@ if (typeof Slick === "undefined") {
 
     function getViewportHeight() {
       if (!options.autoHeight || options.frozenColumn != -1) {
-        topPanelH = (options.showTopPanel) ? options.topPanelHeight + getVBoxDelta($topPanelScroller) : 0;
-        headerRowH = (options.showHeaderRow) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
-        footerRowH = (options.showFooterRow) ? options.footerRowHeight + getVBoxDelta($footerRowScroller) : 0;
+        topPanelH = ( options.showTopPanel ) ? options.topPanelHeight + getVBoxDelta($topPanelScroller) : 0;
+        headerRowH = ( options.showHeaderRow ) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
+        footerRowH = ( options.showFooterRow ) ? options.footerRowHeight + getVBoxDelta($footerRowScroller) : 0;
       }
       if (options.autoHeight) {
         var fullHeight = $paneHeaderL.outerHeight();
-        fullHeight += (options.showHeaderRow) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
-        fullHeight += (options.showFooterRow) ? options.footerRowHeight + getVBoxDelta($footerRowScroller) : 0;
+        fullHeight += ( options.showHeaderRow ) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
+        fullHeight += ( options.showFooterRow ) ? options.footerRowHeight + getVBoxDelta($footerRowScroller) : 0;
         fullHeight += (getCanvasWidth() > viewportW) ? scrollbarDimensions.height : 0;
 
         viewportH = options.rowHeight
           * getDataLengthIncludingAddNew()
-          + ((options.frozenColumn == -1) ? fullHeight : 0);
+          + ( ( options.frozenColumn == -1 ) ? fullHeight : 0 );
       } else {
-        var columnNamesH = (options.showColumnHeader) ? parseFloat($.css($headerScroller[0], "height"))
+        var columnNamesH = ( options.showColumnHeader ) ? parseFloat($.css($headerScroller[0], "height"))
           + getVBoxDelta($headerScroller) : 0;
         var preHeaderH = (options.createPreHeaderPanel && options.showPreHeaderPanel) ? options.preHeaderPanelHeight + getVBoxDelta($preHeaderPanelScroller) : 0;
 
@@ -3501,8 +3501,8 @@ if (typeof Slick === "undefined") {
       if (options.autoHeight) {
         if (hasFrozenColumns()) {
           $container.height(
-            paneTopH
-            + parseFloat($.css($headerScrollerL[0], "height"))
+              paneTopH
+              + parseFloat($.css($headerScrollerL[0], "height"))
           );
         }
 
@@ -3583,9 +3583,9 @@ if (typeof Slick === "undefined") {
       render();
     }
 
-    function updatePagingStatusFromView(pagingInfo) {
-      pagingActive = (pagingInfo.pageSize !== 0);
-      pagingIsLastPage = (pagingInfo.pageNum == pagingInfo.totalPages - 1);
+    function updatePagingStatusFromView( pagingInfo ) {
+        pagingActive = (pagingInfo.pageSize !== 0);
+        pagingIsLastPage = (pagingInfo.pageNum == pagingInfo.totalPages - 1);
     }
 
     function updateRowCount() {
@@ -3594,9 +3594,9 @@ if (typeof Slick === "undefined") {
       var dataLength = getDataLength();
       var dataLengthIncludingAddNew = getDataLengthIncludingAddNew();
       var numberOfRows = 0;
-      var oldH = (hasFrozenRows && !options.frozenBottom) ? $canvasBottomL.height() : $canvasTopL.height();
+      var oldH = ( hasFrozenRows && !options.frozenBottom ) ? $canvasBottomL.height() : $canvasTopL.height();
 
-      if (hasFrozenRows) {
+      if (hasFrozenRows ) {
         var numberOfRows = getDataLength() - options.frozenRow;
       } else {
         var numberOfRows = dataLengthIncludingAddNew + (options.leaveSpaceForNewRows ? numVisibleRows - 1 : 0);
@@ -3625,7 +3625,7 @@ if (typeof Slick === "undefined") {
 
       var oldH = h;
       if (options.autoHeight) {
-        h = options.rowHeight * numberOfRows;
+        h =  options.rowHeight * numberOfRows;
       } else {
         th = Math.max(options.rowHeight * numberOfRows, tempViewportH - scrollbarDimensions.height);
         if (th < maxSupportedCssHeight) {
@@ -3746,10 +3746,10 @@ if (typeof Slick === "undefined") {
     function cleanUpCells(range, row) {
       // Ignore frozen rows
       if (hasFrozenRows
-        && ((options.frozenBottom && row > actualFrozenRow) // Frozen bottom rows
-          || (row <= actualFrozenRow)                     // Frozen top rows
-        )
-      ) {
+        && ( ( options.frozenBottom && row > actualFrozenRow ) // Frozen bottom rows
+          || ( row <= actualFrozenRow )                     // Frozen top rows
+          )
+        ) {
         return;
       }
 
@@ -3773,7 +3773,7 @@ if (typeof Slick === "undefined") {
         }
 
         // Ignore alwaysRenderedColumns
-        if (Array.isArray(columns) && columns[i] && columns[i].alwaysRenderColumn) {
+        if (Array.isArray(columns) && columns[i] && columns[i].alwaysRenderColumn){
           continue;
         }
 
@@ -3895,7 +3895,7 @@ if (typeof Slick === "undefined") {
         dataLength = getDataLength();
 
       for (var i = range.top, ii = range.bottom; i <= ii; i++) {
-        if (rowsCache[i] || (hasFrozenRows && options.frozenBottom && i == getDataLength())) {
+        if (rowsCache[i] || ( hasFrozenRows && options.frozenBottom && i == getDataLength() )) {
           continue;
         }
         renderedRows++;
@@ -3935,7 +3935,7 @@ if (typeof Slick === "undefined") {
       xRight.innerHTML = stringArrayR.join("");
 
       for (var i = 0, ii = rows.length; i < ii; i++) {
-        if ((hasFrozenRows) && (rows[i] >= actualFrozenRow)) {
+        if (( hasFrozenRows ) && ( rows[i] >= actualFrozenRow )) {
           if (hasFrozenColumns()) {
             rowsCache[rows[i]].rowNode = $()
               .add($(x.firstChild).appendTo($canvasBottomL))
@@ -4008,25 +4008,25 @@ if (typeof Slick === "undefined") {
       // add new rows & missing cells in existing rows
       if (lastRenderedScrollLeft != scrollLeft) {
 
-        if (hasFrozenRows) {
+    	  if ( hasFrozenRows ) {
 
-          var renderedFrozenRows = jQuery.extend(true, {}, rendered);
+    		  var renderedFrozenRows = jQuery.extend(true, {}, rendered);
 
-          if (options.frozenBottom) {
+    		  if (options.frozenBottom) {
 
-            renderedFrozenRows.top = actualFrozenRow;
-            renderedFrozenRows.bottom = getDataLength();
-          }
-          else {
+    			 renderedFrozenRows.top=actualFrozenRow;
+    			 renderedFrozenRows.bottom=getDataLength();
+    		  }
+    		  else {
 
-            renderedFrozenRows.top = 0;
-            renderedFrozenRows.bottom = options.frozenRow;
-          }
+	             renderedFrozenRows.top=0;
+	             renderedFrozenRows.bottom=options.frozenRow;
+    		  }
 
-          cleanUpAndRenderCells(renderedFrozenRows);
-        }
+    		  cleanUpAndRenderCells(renderedFrozenRows);
+    	  }
 
-        cleanUpAndRenderCells(rendered);
+          cleanUpAndRenderCells(rendered);
       }
 
       // render missing rows
@@ -4034,16 +4034,16 @@ if (typeof Slick === "undefined") {
 
       // Render frozen rows
       if (hasFrozenRows) {
-        if (options.frozenBottom) {
-          renderRows({
-            top: actualFrozenRow, bottom: getDataLength() - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
-          });
-        }
-        else {
-          renderRows({
-            top: 0, bottom: options.frozenRow - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
-          });
-        }
+	      if (options.frozenBottom) {
+	        renderRows({
+	          top: actualFrozenRow, bottom: getDataLength() - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
+	        });
+	      }
+	      else {
+	          renderRows({
+	           top: 0, bottom: options.frozenRow - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
+	          });
+	        }
       }
 
       postProcessFromRow = visible.top;
@@ -4189,7 +4189,7 @@ if (typeof Slick === "undefined") {
         }
       }
 
-      trigger(self.onScroll, { scrollLeft: scrollLeft, scrollTop: scrollTop });
+      trigger(self.onScroll, {scrollLeft: scrollLeft, scrollTop: scrollTop});
 
       if (hScrollDist || vScrollDist) return true;
       return false;
@@ -4398,8 +4398,8 @@ if (typeof Slick === "undefined") {
         var $gridCanvas = $rowNode.parents('.grid-canvas');
         var left = $gridCanvas.hasClass('grid-canvas-left');
 
-        if (zombieRowNodeFromLastMouseWheelEvent && zombieRowNodeFromLastMouseWheelEvent[left ? 0 : 1] != rowNode) {
-          var zombieRow = zombieRowNodeFromLastMouseWheelEvent[left || zombieRowNodeFromLastMouseWheelEvent.length == 1 ? 0 : 1];
+        if (zombieRowNodeFromLastMouseWheelEvent && zombieRowNodeFromLastMouseWheelEvent[left? 0:1] != rowNode) {
+          var zombieRow = zombieRowNodeFromLastMouseWheelEvent[left || zombieRowNodeFromLastMouseWheelEvent.length == 1? 0:1];
           zombieRow.parentElement.removeChild(zombieRow);
 
           zombieRowNodeFromLastMouseWheelEvent = null;
@@ -4453,30 +4453,30 @@ if (typeof Slick === "undefined") {
     }
 
     function handleKeyDown(e) {
-      trigger(self.onKeyDown, { row: activeRow, cell: activeCell }, e);
+      trigger(self.onKeyDown, {row: activeRow, cell: activeCell}, e);
       var handled = e.isImmediatePropagationStopped();
       var keyCode = Slick.keyCode;
 
       if (!handled) {
-        if (!e.shiftKey && !e.altKey) {
-          if (options.editable && currentEditor && currentEditor.keyCaptureList) {
-            if (currentEditor.keyCaptureList.indexOf(e.which) > -1) {
-              return;
+         if (!e.shiftKey && !e.altKey) {
+            if (options.editable && currentEditor && currentEditor.keyCaptureList) {
+               if (currentEditor.keyCaptureList.indexOf(e.which) > -1) {
+                  return;
+               }
             }
-          }
-          if (e.which == keyCode.HOME) {
-            handled = (e.ctrlKey) ? navigateTop() : navigateRowStart();
-          } else if (e.which == keyCode.END) {
-            handled = (e.ctrlKey) ? navigateBottom() : navigateRowEnd();
-          }
-        }
+            if (e.which == keyCode.HOME) {
+               handled = (e.ctrlKey) ? navigateTop() : navigateRowStart();
+            } else if (e.which == keyCode.END) {
+               handled = (e.ctrlKey) ? navigateBottom() : navigateRowEnd();
+            }
+         }
       }
       if (!handled) {
         if (!e.shiftKey && !e.altKey && !e.ctrlKey) {
           // editor may specify an array of keys to bubble
           if (options.editable && currentEditor && currentEditor.keyCaptureList) {
-            if (currentEditor.keyCaptureList.indexOf(e.which) > -1) {
-              return;
+            if (currentEditor.keyCaptureList.indexOf( e.which ) > -1) {
+                return;
             }
           }
           if (e.which == keyCode.ESCAPE) {
@@ -4551,7 +4551,7 @@ if (typeof Slick === "undefined") {
         return;
       }
 
-      trigger(self.onClick, { row: cell.row, cell: cell.cell }, e);
+      trigger(self.onClick, {row: cell.row, cell: cell.cell}, e);
       if (e.isImmediatePropagationStopped()) {
         return;
       }
@@ -4590,7 +4590,7 @@ if (typeof Slick === "undefined") {
         return;
       }
 
-      trigger(self.onDblClick, { row: cell.row, cell: cell.cell }, e);
+      trigger(self.onDblClick, {row: cell.row, cell: cell.cell}, e);
       if (e.isImmediatePropagationStopped()) {
         return;
       }
@@ -4617,7 +4617,7 @@ if (typeof Slick === "undefined") {
     function handleHeaderContextMenu(e) {
       var $header = $(e.target).closest(".slick-header-column", ".slick-header-columns");
       var column = $header && $header.data("column");
-      trigger(self.onHeaderContextMenu, { column: column }, e);
+      trigger(self.onHeaderContextMenu, {column: column}, e);
     }
 
     function handleHeaderClick(e) {
@@ -4625,20 +4625,20 @@ if (typeof Slick === "undefined") {
       var $header = $(e.target).closest(".slick-header-column", ".slick-header-columns");
       var column = $header && $header.data("column");
       if (column) {
-        trigger(self.onHeaderClick, { column: column }, e);
+        trigger(self.onHeaderClick, {column: column}, e);
       }
     }
 
     function handleFooterContextMenu(e) {
       var $footer = $(e.target).closest(".slick-footerrow-column", ".slick-footerrow-columns");
       var column = $footer && $footer.data("column");
-      trigger(self.onFooterContextMenu, { column: column }, e);
+      trigger(self.onFooterContextMenu, {column: column}, e);
     }
 
     function handleFooterClick(e) {
       var $footer = $(e.target).closest(".slick-footerrow-column", ".slick-footerrow-columns");
       var column = $footer && $footer.data("column");
-      trigger(self.onFooterClick, { column: column }, e);
+      trigger(self.onFooterClick, {column: column}, e);
     }
 
     function handleMouseEnter(e) {
@@ -4667,7 +4667,7 @@ if (typeof Slick === "undefined") {
         cell = 0;
       }
 
-      return { row: row, cell: cell - 1 };
+      return {row: row, cell: cell - 1};
     }
 
     function getCellFromNode(cellNode) {
@@ -4683,7 +4683,7 @@ if (typeof Slick === "undefined") {
       for (var row in rowsCache) {
         for (var i in rowsCache[row].rowNode) {
           if (rowsCache[row].rowNode[i] === rowNode)
-            return (row ? parseInt(row) : 0);
+          return (row ? parseInt(row) : 0);
         }
       }
       return null;
@@ -4691,16 +4691,16 @@ if (typeof Slick === "undefined") {
 
     function getFrozenRowOffset(row) {
       var offset =
-        (hasFrozenRows)
-          ? (options.frozenBottom)
-            ? (row >= actualFrozenRow)
-              ? (h < viewportTopH)
-                ? (actualFrozenRow * options.rowHeight)
-                : h
-              : 0
-            : (row >= actualFrozenRow)
-              ? frozenRowsHeight
-              : 0
+        ( hasFrozenRows )
+          ? ( options.frozenBottom )
+          ? ( row >= actualFrozenRow )
+          ? ( h < viewportTopH )
+          ? ( actualFrozenRow * options.rowHeight )
+          : h
+          : 0
+          : ( row >= actualFrozenRow )
+          ? frozenRowsHeight
+          : 0
           : 0;
 
       return offset;
@@ -4723,7 +4723,7 @@ if (typeof Slick === "undefined") {
         var isBottom = $cell.parents('.grid-canvas-bottom').length;
 
         if (isBottom) {
-          rowOffset = (options.frozenBottom) ? $canvasTopL.height() : frozenRowsHeight;
+          rowOffset = ( options.frozenBottom ) ? $canvasTopL.height() : frozenRowsHeight;
         }
 
         row = getCellFromPoint(e.clientX - c.left, e.clientY - c.top + rowOffset + $(document).scrollTop()).row;
@@ -4832,7 +4832,7 @@ if (typeof Slick === "undefined") {
         var isBottom = $activeCellNode.parents('.grid-canvas-bottom').length;
 
         if (hasFrozenRows && isBottom) {
-          rowOffset -= (options.frozenBottom)
+          rowOffset -= ( options.frozenBottom )
             ? $canvasTopL.height()
             : frozenRowsHeight;
         }
@@ -4912,7 +4912,7 @@ if (typeof Slick === "undefined") {
       if (!currentEditor) {
         return;
       }
-      trigger(self.onBeforeCellEditorDestroy, { editor: currentEditor });
+      trigger(self.onBeforeCellEditorDestroy, {editor: currentEditor});
       currentEditor.destroy();
       currentEditor = null;
 
@@ -4922,7 +4922,7 @@ if (typeof Slick === "undefined") {
         if (d) {
           var column = columns[activeCell];
           var formatter = getFormatter(activeRow, column);
-          var formatterResult = formatter(activeRow, activeCell, getDataItemValueForColumn(d, column), column, d, self);
+          var formatterResult =  formatter(activeRow, activeCell, getDataItemValueForColumn(d, column), column, d, self);
           applyFormatResultToCellNode(formatterResult, activeCellNode);
           invalidatePostProcessingResults(activeRow);
         }
@@ -4955,7 +4955,7 @@ if (typeof Slick === "undefined") {
       var columnDef = columns[activeCell];
       var item = getDataItem(activeRow);
 
-      if (trigger(self.onBeforeEditCell, { row: activeRow, cell: activeCell, item: item, column: columnDef }) === false) {
+      if (trigger(self.onBeforeEditCell, {row: activeRow, cell: activeCell, item: item, column: columnDef}) === false) {
         setFocus();
         return;
       }
@@ -4972,7 +4972,7 @@ if (typeof Slick === "undefined") {
 
       var metadata = data.getItemMetadata && data.getItemMetadata(activeRow);
       metadata = metadata && metadata.columns;
-      var columnMetaData = metadata && (metadata[columnDef.id] || metadata[activeCell]);
+      var columnMetaData = metadata && ( metadata[columnDef.id] || metadata[activeCell] );
 
       currentEditor = new useEditor({
         grid: self,
@@ -5099,7 +5099,7 @@ if (typeof Slick === "undefined") {
       if (!activeCellNode) {
         return null;
       } else {
-        return { row: activeRow, cell: activeCell };
+        return {row: activeRow, cell: activeCell};
       }
     }
 
@@ -5108,32 +5108,32 @@ if (typeof Slick === "undefined") {
     }
 
     function scrollRowIntoView(row, doPaging) {
-      if (!hasFrozenRows ||
-        (!options.frozenBottom && row > actualFrozenRow - 1) ||
-        (options.frozenBottom && row < actualFrozenRow - 1)) {
+	    if (!hasFrozenRows ||
+	  	  ( !options.frozenBottom && row > actualFrozenRow - 1 ) ||
+	  	  ( options.frozenBottom && row < actualFrozenRow - 1 ) ) {
 
-        var viewportScrollH = $viewportScrollContainerY.height();
+	      var viewportScrollH = $viewportScrollContainerY.height();
 
-        // if frozen row on top
-        // subtract number of frozen row
-        var rowNumber = (hasFrozenRows && !options.frozenBottom ? row - options.frozenRow : row);
+	      // if frozen row on top
+	      // subtract number of frozen row
+	      var rowNumber = ( hasFrozenRows && !options.frozenBottom ? row - options.frozenRow : row );
 
-        var rowAtTop = rowNumber * options.rowHeight;
-        var rowAtBottom = (rowNumber + 1) * options.rowHeight
-          - viewportScrollH
-          + (viewportHasHScroll ? scrollbarDimensions.height : 0);
+	      var rowAtTop = rowNumber * options.rowHeight;
+	      var rowAtBottom = (rowNumber + 1) * options.rowHeight
+	        - viewportScrollH
+	        + (viewportHasHScroll ? scrollbarDimensions.height : 0);
 
-        // need to page down?
-        if ((rowNumber + 1) * options.rowHeight > scrollTop + viewportScrollH + offset) {
-          scrollTo(doPaging ? rowAtTop : rowAtBottom);
-          render();
-        }
-        // or page up?
-        else if (rowNumber * options.rowHeight < scrollTop + offset) {
-          scrollTo(doPaging ? rowAtBottom : rowAtTop);
-          render();
-        }
-      }
+	      // need to page down?
+	      if ((rowNumber + 1) * options.rowHeight > scrollTop + viewportScrollH + offset) {
+	        scrollTo(doPaging ? rowAtTop : rowAtBottom);
+	        render();
+	      }
+	      // or page up?
+	      else if (rowNumber * options.rowHeight < scrollTop + offset) {
+	        scrollTo(doPaging ? rowAtBottom : rowAtTop);
+	        render();
+	      }
+	    }
     }
 
     function scrollRowToTop(row) {
@@ -5143,8 +5143,8 @@ if (typeof Slick === "undefined") {
 
     function scrollPage(dir) {
       var deltaRows = dir * numVisibleRows;
-      /// First fully visible row crosses the line with
-      /// y == bottomOfTopmostFullyVisibleRow
+        /// First fully visible row crosses the line with
+        /// y == bottomOfTopmostFullyVisibleRow
       var bottomOfTopmostFullyVisibleRow = scrollTop + options.rowHeight - 1;
       scrollTo((getRowFromPosition(bottomOfTopmostFullyVisibleRow) + deltaRows) * options.rowHeight);
       render();
@@ -5182,43 +5182,43 @@ if (typeof Slick === "undefined") {
     }
 
     function navigatePageUp() {
-      scrollPage(-1);
+       scrollPage(-1);
     }
 
     function navigateTop() {
-      navigateToRow(0);
+       navigateToRow(0);
     }
 
     function navigateBottom() {
-      navigateToRow(getDataLength() - 1);
+       navigateToRow(getDataLength()-1);
     }
 
     function navigateToRow(row) {
-      var num_rows = getDataLength();
-      if (!num_rows) return true;
+       var num_rows = getDataLength();
+       if (!num_rows) return true;
 
-      if (row < 0) row = 0;
-      else if (row >= num_rows) row = num_rows - 1;
+       if (row < 0) row = 0;
+       else if (row >= num_rows) row = num_rows - 1;
 
-      scrollCellIntoView(row, 0, true);
-      if (options.enableCellNavigation && activeRow != null) {
-        var cell = 0, prevCell = null;
-        var prevActivePosX = activePosX;
-        while (cell <= activePosX) {
-          if (canCellBeActive(row, cell)) {
-            prevCell = cell;
+       scrollCellIntoView(row, 0, true);
+       if (options.enableCellNavigation && activeRow != null) {
+          var cell = 0, prevCell = null;
+          var prevActivePosX = activePosX;
+          while (cell <= activePosX) {
+             if (canCellBeActive(row, cell)) {
+                prevCell = cell;
+             }
+             cell += getColspan(row, cell);
           }
-          cell += getColspan(row, cell);
-        }
 
-        if (prevCell !== null) {
-          setActiveCellInternal(getCellNode(row, prevCell));
-          activePosX = prevActivePosX;
-        } else {
-          resetActiveCell();
-        }
-      }
-      return true;
+          if (prevCell !== null) {
+             setActiveCellInternal(getCellNode(row, prevCell));
+             activePosX = prevActivePosX;
+          } else {
+             resetActiveCell();
+          }
+       }
+       return true;
     }
 
     function getColspan(row, cell) {
@@ -5430,25 +5430,25 @@ if (typeof Slick === "undefined") {
     }
 
     function gotoRowStart(row, cell, posX) {
-      var newCell = findFirstFocusableCell(row);
-      if (newCell === null) return null;
+       var newCell = findFirstFocusableCell(row);
+       if (newCell === null) return null;
 
-      return {
-        "row": row,
-        "cell": newCell,
-        "posX": newCell
-      };
+       return {
+          "row": row,
+          "cell": newCell,
+          "posX": newCell
+       };
     }
 
     function gotoRowEnd(row, cell, posX) {
-      var newCell = findLastFocusableCell(row);
-      if (newCell === null) return null;
+       var newCell = findLastFocusableCell(row);
+       if (newCell === null) return null;
 
-      return {
-        "row": row,
-        "cell": newCell,
-        "posX": newCell
-      };
+       return {
+          "row": row,
+          "cell": newCell,
+          "posX": newCell
+       };
     }
 
     function navigateRight() {
@@ -5472,15 +5472,15 @@ if (typeof Slick === "undefined") {
     }
 
     function navigatePrev() {
-      return navigate("prev");
+       return navigate("prev");
     }
 
     function navigateRowStart() {
-      return navigate("home");
+       return navigate("home");
     }
 
     function navigateRowEnd() {
-      return navigate("end");
+       return navigate("end");
     }
 
     /**
@@ -5532,9 +5532,9 @@ if (typeof Slick === "undefined") {
 
         var isAddNewRow = (pos.row == getDataLength());
 
-        if ((!options.frozenBottom && pos.row >= actualFrozenRow)
-          || (options.frozenBottom && pos.row < actualFrozenRow)
-        ) {
+        if (( !options.frozenBottom && pos.row >= actualFrozenRow )
+          || ( options.frozenBottom && pos.row < actualFrozenRow )
+          ) {
           scrollCellIntoView(pos.row, pos.cell, !isAddNewRow && options.emulatePagingWhenScrolling);
         }
         setActiveCellInternal(getCellNode(pos.row, pos.cell));
@@ -5591,7 +5591,7 @@ if (typeof Slick === "undefined") {
 
     function canCellBeActive(row, cell) {
       if (!options.enableCellNavigation || row >= getDataLengthIncludingAddNew() ||
-        row < 0 || cell >= columns.length || cell < 0) {
+          row < 0 || cell >= columns.length || cell < 0) {
         return false;
       }
 
@@ -5706,7 +5706,7 @@ if (typeof Slick === "undefined") {
               var newItem = {};
               currentEditor.applyValue(newItem, currentEditor.serializeValue());
               makeActiveCellNormal();
-              trigger(self.onAddNewRow, { item: newItem, column: column });
+              trigger(self.onAddNewRow, {item: newItem, column: column});
             }
 
             // check whether the lock has been re-acquired by event handlers

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -188,7 +188,7 @@ if (typeof Slick === "undefined") {
     var headersWidth, headersWidthL, headersWidthR;
     var viewportHasHScroll, viewportHasVScroll;
     var headerColumnWidthDiff = 0, headerColumnHeightDiff = 0, // border+padding
-        cellWidthDiff = 0, cellHeightDiff = 0, jQueryNewWidthBehaviour = false;
+      cellWidthDiff = 0, cellHeightDiff = 0, jQueryNewWidthBehaviour = false;
     var absoluteColumnMinWidth;
     var hasFrozenRows = false;
     var frozenRowsHeight = 0;
@@ -353,11 +353,11 @@ if (typeof Slick === "undefined") {
       };
 
       $container
-          .empty()
-          .css("overflow", "hidden")
-          .css("outline", 0)
-          .addClass(uid)
-          .addClass("ui-widget");
+        .empty()
+        .css("overflow", "hidden")
+        .css("outline", 0)
+        .addClass(uid)
+        .addClass("ui-widget");
 
       // set up a positioning container if needed
       if (!(/relative|absolute|fixed/).test($container.css("position"))) {
@@ -378,12 +378,12 @@ if (typeof Slick === "undefined") {
         $preHeaderPanelScroller = $("<div class='slick-preheader-panel ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($paneHeaderL);
         $preHeaderPanel = $("<div />").appendTo($preHeaderPanelScroller);
         $preHeaderPanelSpacer = $("<div style='display:block;height:1px;position:absolute;top:0;left:0;'></div>")
-            .appendTo($preHeaderPanelScroller);
+          .appendTo($preHeaderPanelScroller);
 
         $preHeaderPanelScrollerR = $("<div class='slick-preheader-panel ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($paneHeaderR);
         $preHeaderPanelR = $("<div />").appendTo($preHeaderPanelScrollerR);
         $preHeaderPanelSpacerR = $("<div style='display:block;height:1px;position:absolute;top:0;left:0;'></div>")
-            .appendTo($preHeaderPanelScrollerR);
+          .appendTo($preHeaderPanelScrollerR);
 
         if (!options.showPreHeaderPanel) {
           $preHeaderPanelScroller.hide();
@@ -563,22 +563,22 @@ if (typeof Slick === "undefined") {
         bindAncestorScrollEvents();
 
         $container
-            .on("resize.slickgrid", resizeCanvas);
+          .on("resize.slickgrid", resizeCanvas);
         $viewport
-            .on("scroll", handleScroll);
+          .on("scroll", handleScroll);
 
         if (jQuery.fn.mousewheel) {
           $viewport.on("mousewheel", handleMouseWheel);
         }
 
         $headerScroller
-            //.on("scroll", handleHeaderScroll)
-            .on("contextmenu", handleHeaderContextMenu)
-            .on("click", handleHeaderClick)
-            .on("mouseenter", ".slick-header-column", handleHeaderMouseEnter)
-            .on("mouseleave", ".slick-header-column", handleHeaderMouseLeave);
+          //.on("scroll", handleHeaderScroll)
+          .on("contextmenu", handleHeaderContextMenu)
+          .on("click", handleHeaderClick)
+          .on("mouseenter", ".slick-header-column", handleHeaderMouseEnter)
+          .on("mouseleave", ".slick-header-column", handleHeaderMouseLeave);
         $headerRowScroller
-            .on("scroll", handleHeaderRowScroll);
+          .on("scroll", handleHeaderRowScroll);
 
         if (options.createFooterRow) {
           $footerRow
@@ -586,27 +586,27 @@ if (typeof Slick === "undefined") {
             .on("click", handleFooterClick);
 
           $footerRowScroller
-              .on("scroll", handleFooterRowScroll);
+            .on("scroll", handleFooterRowScroll);
         }
 
         if (options.createPreHeaderPanel) {
           $preHeaderPanelScroller
-              .on("scroll", handlePreHeaderPanelScroll);
+            .on("scroll", handlePreHeaderPanelScroll);
         }
 
         $focusSink.add($focusSink2)
-            .on("keydown", handleKeyDown);
+          .on("keydown", handleKeyDown);
         $canvas
-            .on("keydown", handleKeyDown)
-            .on("click", handleClick)
-            .on("dblclick", handleDblClick)
-            .on("contextmenu", handleContextMenu)
-            .on("draginit", handleDragInit)
-            .on("dragstart", {distance: 3}, handleDragStart)
-            .on("drag", handleDrag)
-            .on("dragend", handleDragEnd)
-            .on("mouseenter", ".slick-cell", handleMouseEnter)
-            .on("mouseleave", ".slick-cell", handleMouseLeave);
+          .on("keydown", handleKeyDown)
+          .on("click", handleClick)
+          .on("dblclick", handleDblClick)
+          .on("contextmenu", handleContextMenu)
+          .on("draginit", handleDragInit)
+          .on("dragstart", { distance: 3 }, handleDragStart)
+          .on("drag", handleDrag)
+          .on("dragend", handleDragEnd)
+          .on("mouseenter", ".slick-cell", handleMouseEnter)
+          .on("mouseleave", ".slick-cell", handleMouseLeave);
 
         restoreCssFromHiddenInit();
       }
@@ -615,11 +615,11 @@ if (typeof Slick === "undefined") {
     function cacheCssForHiddenInit() {
       // handle display:none on container or container parents
       $hiddenParents = $container.parents().addBack().not(':visible');
-      $hiddenParents.each(function() {
+      $hiddenParents.each(function () {
         var old = {};
-        for ( var name in cssShow ) {
-          old[ name ] = this.style[ name ];
-          this.style[ name ] = cssShow[ name ];
+        for (var name in cssShow) {
+          old[name] = this.style[name];
+          this.style[name] = cssShow[name];
         }
         oldProps.push(old);
       });
@@ -628,10 +628,10 @@ if (typeof Slick === "undefined") {
     function restoreCssFromHiddenInit() {
       // finish handle display:none on container or container parents
       // - put values back the way they were
-      $hiddenParents.each(function(i) {
+      $hiddenParents.each(function (i) {
         var old = oldProps[i];
-        for ( var name in cssShow ) {
-          this.style[ name ] = old[ name ];
+        for (var name in cssShow) {
+          this.style[name] = old[name];
         }
       });
     }
@@ -658,7 +658,7 @@ if (typeof Slick === "undefined") {
     }
 
     function getPluginByName(name) {
-      for (var i = plugins.length-1; i >= 0; i--) {
+      for (var i = plugins.length - 1; i >= 0; i--) {
         if (plugins[i].pluginName === name) {
           return plugins[i];
         }
@@ -691,10 +691,10 @@ if (typeof Slick === "undefined") {
 
       var idx = (typeof columnIdOrIdx === "number" ? columnIdOrIdx : getColumnIndex(columnIdOrIdx));
 
-      return (hasFrozenRows && rowIndex >= actualFrozenRow + (options.frozenBottom ? 0 : 1) )
-          ?  ((hasFrozenColumns() && idx > options.frozenColumn) ? $canvasBottomR[0] : $canvasBottomL[0])
-          :  ((hasFrozenColumns() && idx > options.frozenColumn) ? $canvasTopR[0] : $canvasTopL[0])
-          ;
+      return (hasFrozenRows && rowIndex >= actualFrozenRow + (options.frozenBottom ? 0 : 1))
+        ? ((hasFrozenColumns() && idx > options.frozenColumn) ? $canvasBottomR[0] : $canvasBottomL[0])
+        : ((hasFrozenColumns() && idx > options.frozenColumn) ? $canvasTopR[0] : $canvasTopL[0])
+        ;
     }
 
     function getActiveCanvasNode(element) {
@@ -746,9 +746,9 @@ if (typeof Slick === "undefined") {
       var includeScrollbar = !options.autoHeight;
 
       for (var i = 0, ii = columns.length; i < ii; i++) {
-        var width = columns[ i ].width;
+        var width = columns[i].width;
 
-        if (( options.frozenColumn ) > -1 && ( i > options.frozenColumn )) {
+        if ((options.frozenColumn) > -1 && (i > options.frozenColumn)) {
           headersWidthR += width;
         } else {
           headersWidthL += width;
@@ -756,7 +756,7 @@ if (typeof Slick === "undefined") {
       }
 
       if (includeScrollbar) {
-        if (( options.frozenColumn ) > -1 && ( i > options.frozenColumn )) {
+        if ((options.frozenColumn) > -1 && (i > options.frozenColumn)) {
           headersWidthR += scrollbarDimensions.width;
         } else {
           headersWidthL += scrollbarDimensions.width;
@@ -778,10 +778,10 @@ if (typeof Slick === "undefined") {
     }
 
     function getHeadersWidthL() {
-      headersWidthL =0;
+      headersWidthL = 0;
 
-      columns.forEach(function(column, i) {
-        if (!(( options.frozenColumn ) > -1 && ( i > options.frozenColumn )))
+      columns.forEach(function (column, i) {
+        if (!((options.frozenColumn) > -1 && (i > options.frozenColumn)))
           headersWidthL += column.width;
       });
 
@@ -796,10 +796,10 @@ if (typeof Slick === "undefined") {
     }
 
     function getHeadersWidthR() {
-      headersWidthR =0;
+      headersWidthR = 0;
 
-      columns.forEach(function(column, i) {
-        if (( options.frozenColumn ) > -1 && ( i > options.frozenColumn ))
+      columns.forEach(function (column, i) {
+        if ((options.frozenColumn) > -1 && (i > options.frozenColumn))
           headersWidthR += column.width;
       });
 
@@ -908,7 +908,7 @@ if (typeof Slick === "undefined") {
           }
         }
 
-        viewportHasHScroll = (canvasWidth > viewportW - scrollbarDimensions.width);
+        viewportHasHScroll = (canvasWidth >= viewportW - scrollbarDimensions.width);
       }
 
       $headerRowSpacerL.width(canvasWidth + (viewportHasVScroll ? scrollbarDimensions.width : 0));
@@ -927,11 +927,11 @@ if (typeof Slick === "undefined") {
     function disableSelection($target) {
       if ($target && $target.jquery) {
         $target
-            .attr("unselectable", "on")
-            .css("MozUserSelect", "none")
-            .on("selectstart.ui", function () {
-              return false;
-            }); // from jquery:ui.core.js 1.7.2
+          .attr("unselectable", "on")
+          .css("MozUserSelect", "none")
+          .on("selectstart.ui", function () {
+            return false;
+          }); // from jquery:ui.core.js 1.7.2
       }
     }
 
@@ -1016,8 +1016,8 @@ if (typeof Slick === "undefined") {
         });
 
         $header
-            .attr("title", toolTip || "")
-            .children().eq(0).html(title);
+          .attr("title", toolTip || "")
+          .children().eq(0).html(title);
 
         trigger(self.onHeaderCellRendered, {
           "node": $header[0],
@@ -1122,8 +1122,8 @@ if (typeof Slick === "undefined") {
 
           var footerRowCell = $("<div class='ui-state-default slick-footerrow-column l" + i + " r" + i + "'></div>")
             .data("column", m)
-            .addClass(hasFrozenColumns() && i <= options.frozenColumn? 'frozen': '')
-            .appendTo(hasFrozenColumns() && (i > options.frozenColumn)? $footerRowR: $footerRowL);
+            .addClass(hasFrozenColumns() && i <= options.frozenColumn ? 'frozen' : '')
+            .appendTo(hasFrozenColumns() && (i > options.frozenColumn) ? $footerRowR : $footerRowL);
 
           trigger(self.onFooterRowCellRendered, {
             "node": footerRowCell[0],
@@ -1153,7 +1153,7 @@ if (typeof Slick === "undefined") {
 
           columnsLength += m.extractColumns().length;
 
-          if (hasFrozenColumns() && index === 0 && (columnsLength-1) === options.frozenColumn)
+          if (hasFrozenColumns() && index === 0 && (columnsLength - 1) === options.frozenColumn)
             frozenColumnsValid = true;
 
           $("<div class='ui-state-default slick-group-header-column' />")
@@ -1162,8 +1162,8 @@ if (typeof Slick === "undefined") {
             .attr("title", m.toolTip || "")
             .data("column", m)
             .addClass(m.headerCssClass || "")
-            .addClass(hasFrozenColumns() && (columnsLength - 1) > options.frozenColumn? 'frozen': '')
-            .appendTo(hasFrozenColumns() && (columnsLength - 1) > options.frozenColumn? $groupHeadersR[index]: $groupHeadersL[index]);
+            .addClass(hasFrozenColumns() && (columnsLength - 1) > options.frozenColumn ? 'frozen' : '')
+            .appendTo(hasFrozenColumns() && (columnsLength - 1) > options.frozenColumn ? $groupHeadersR[index] : $groupHeadersL[index]);
         }
 
         if (hasFrozenColumns() && index === 0 && !frozenColumnsValid) {
@@ -1187,7 +1187,7 @@ if (typeof Slick === "undefined") {
       }
 
       $headers.find(".slick-header-column")
-        .each(function() {
+        .each(function () {
           var columnDef = $(this).data("column");
           if (columnDef) {
             trigger(self.onBeforeHeaderCellDestroy, {
@@ -1207,7 +1207,7 @@ if (typeof Slick === "undefined") {
       $headerR.width(headersWidthR);
 
       $headerRow.find(".slick-headerrow-column")
-        .each(function() {
+        .each(function () {
           var columnDef = $(this).data("column");
           if (columnDef) {
             trigger(self.onBeforeHeaderRowCellDestroy, {
@@ -1223,7 +1223,7 @@ if (typeof Slick === "undefined") {
 
       if (options.createFooterRow) {
         $footerRowL.find(".slick-footerrow-column")
-          .each(function() {
+          .each(function () {
             var columnDef = $(this).data("column");
             if (columnDef) {
               trigger(self.onBeforeFooterRowCellDestroy, {
@@ -1237,7 +1237,7 @@ if (typeof Slick === "undefined") {
 
         if (hasFrozenColumns()) {
           $footerRowR.find(".slick-footerrow-column")
-            .each(function() {
+            .each(function () {
               var columnDef = $(this).data("column");
               if (columnDef) {
                 trigger(self.onBeforeFooterRowCellDestroy, {
@@ -1258,14 +1258,14 @@ if (typeof Slick === "undefined") {
         var $headerRowTarget = hasFrozenColumns() ? ((i <= options.frozenColumn) ? $headerRowL : $headerRowR) : $headerRowL;
 
         var header = $("<div class='ui-state-default slick-header-column' />")
-            .html("<span class='slick-column-name'>" + m.name + "</span>")
-            .width(m.width - headerColumnWidthDiff)
-            .attr("id", "" + uid + m.id)
-            .attr("title", m.toolTip || "")
-            .data("column", m)
-            .addClass(m.headerCssClass || "")
-            .addClass(hasFrozenColumns() && i <= options.frozenColumn? 'frozen': '')
-            .appendTo($headerTarget);
+          .html("<span class='slick-column-name'>" + m.name + "</span>")
+          .width(m.width - headerColumnWidthDiff)
+          .attr("id", "" + uid + m.id)
+          .attr("title", m.toolTip || "")
+          .data("column", m)
+          .addClass(m.headerCssClass || "")
+          .addClass(hasFrozenColumns() && i <= options.frozenColumn ? 'frozen' : '')
+          .appendTo($headerTarget);
 
         if (options.enableColumnReorder || m.sortable) {
           header
@@ -1273,7 +1273,7 @@ if (typeof Slick === "undefined") {
             .on('mouseleave', onMouseLeave);
         }
 
-        if(m.hasOwnProperty('headerCellAttrs') && m.headerCellAttrs instanceof Object) {
+        if (m.hasOwnProperty('headerCellAttrs') && m.headerCellAttrs instanceof Object) {
           for (var key in m.headerCellAttrs) {
             if (m.headerCellAttrs.hasOwnProperty(key)) {
               header.attr(key, m.headerCellAttrs[key]);
@@ -1284,7 +1284,7 @@ if (typeof Slick === "undefined") {
         if (m.sortable) {
           header.addClass("slick-header-sortable");
           header.append("<span class='slick-sort-indicator"
-            + (options.numberedMultiColumnSort && !options.sortColNumberInSeparateSpan ? " slick-sort-indicator-numbered" : "" ) + "' />");
+            + (options.numberedMultiColumnSort && !options.sortColNumberInSeparateSpan ? " slick-sort-indicator-numbered" : "") + "' />");
           if (options.numberedMultiColumnSort && options.sortColNumberInSeparateSpan) { header.append("<span class='slick-sort-indicator-numbered' />"); }
         }
 
@@ -1296,9 +1296,9 @@ if (typeof Slick === "undefined") {
 
         if (options.showHeaderRow) {
           var headerRowCell = $("<div class='ui-state-default slick-headerrow-column l" + i + " r" + i + "'></div>")
-              .data("column", m)
-              .addClass(hasFrozenColumns() && i <= options.frozenColumn? 'frozen': '')
-              .appendTo($headerRowTarget);
+            .data("column", m)
+            .addClass(hasFrozenColumns() && i <= options.frozenColumn ? 'frozen' : '')
+            .appendTo($headerRowTarget);
 
           trigger(self.onHeaderRowCellRendered, {
             "node": headerRowCell[0],
@@ -1307,9 +1307,9 @@ if (typeof Slick === "undefined") {
           });
         }
         if (options.createFooterRow && options.showFooterRow) {
-          var footerRowCell = $("<div class='ui-state-default slick-footerrow-column l" + i   + " r" + i + "'></div>")
-              .data("column", m)
-              .appendTo($footerRow);
+          var footerRowCell = $("<div class='ui-state-default slick-footerrow-column l" + i + " r" + i + "'></div>")
+            .data("column", m)
+            .appendTo($footerRow);
 
           trigger(self.onFooterRowCellRendered, {
             "node": footerRowCell[0],
@@ -1323,9 +1323,9 @@ if (typeof Slick === "undefined") {
       setupColumnResize();
       if (options.enableColumnReorder) {
         if (typeof options.enableColumnReorder == 'function') {
-            options.enableColumnReorder(self, $headers, headerColumnWidthDiff, setColumns, setupColumnResize, columns, getColumnIndex, uid, trigger);
+          options.enableColumnReorder(self, $headers, headerColumnWidthDiff, setColumns, setupColumnResize, columns, getColumnIndex, uid, trigger);
         } else {
-            setupColumnReorder();
+          setupColumnReorder();
         }
       }
     }
@@ -1363,37 +1363,37 @@ if (typeof Slick === "undefined") {
           var hadSortCol = !!sortColumn;
 
           if (options.tristateMultiColumnSort) {
+            if (!sortColumn) {
+              sortColumn = { columnId: column.id, sortAsc: column.defaultSortAsc };
+            }
+            if (hadSortCol && sortColumn.sortAsc) {
+              // three state: remove sort rather than go back to ASC
+              sortColumns.splice(i, 1);
+              sortColumn = null;
+            }
+            if (!options.multiColumnSort) { sortColumns = []; }
+            if (sortColumn && (!hadSortCol || !options.multiColumnSort)) {
+              sortColumns.push(sortColumn);
+            }
+          } else {
+            // legacy behaviour
+            if (e.metaKey && options.multiColumnSort) {
+              if (sortColumn) {
+                sortColumns.splice(i, 1);
+              }
+            }
+            else {
+              if ((!e.shiftKey && !e.metaKey) || !options.multiColumnSort) {
+                sortColumns = [];
+              }
+
               if (!sortColumn) {
                 sortColumn = { columnId: column.id, sortAsc: column.defaultSortAsc };
-              }
-              if (hadSortCol && sortColumn.sortAsc) {
-                // three state: remove sort rather than go back to ASC
-                sortColumns.splice(i, 1);
-                sortColumn = null;
-              }
-              if (!options.multiColumnSort) { sortColumns = []; }
-              if (sortColumn && (!hadSortCol || !options.multiColumnSort)) {
+                sortColumns.push(sortColumn);
+              } else if (sortColumns.length === 0) {
                 sortColumns.push(sortColumn);
               }
-          } else {
-              // legacy behaviour
-              if (e.metaKey && options.multiColumnSort) {
-                if (sortColumn) {
-                  sortColumns.splice(i, 1);
-                }
-              }
-              else {
-                if ((!e.shiftKey && !e.metaKey) || !options.multiColumnSort) {
-                  sortColumns = [];
-                }
-
-                if (!sortColumn) {
-                  sortColumn = { columnId: column.id, sortAsc: column.defaultSortAsc };
-                  sortColumns.push(sortColumn);
-                } else if (sortColumns.length === 0) {
-                  sortColumns.push(sortColumn);
-                }
-              }
+            }
           }
 
           setSortColumns(sortColumns);
@@ -1408,8 +1408,8 @@ if (typeof Slick === "undefined") {
           } else {
             trigger(self.onSort, {
               multiColumnSort: true,
-              sortCols: $.map(sortColumns, function(col) {
-                return {columnId: columns[getColumnIndex(col.columnId)].id, sortCol: columns[getColumnIndex(col.columnId)], sortAsc: col.sortAsc };
+              sortCols: $.map(sortColumns, function (col) {
+                return { columnId: columns[getColumnIndex(col.columnId)].id, sortCol: columns[getColumnIndex(col.columnId)], sortAsc: col.sortAsc };
               })
             }, e);
           }
@@ -1462,7 +1462,7 @@ if (typeof Slick === "undefined") {
 
     function remove(arr, elem) {
       var index = arr.lastIndexOf(elem);
-      if(index > -1) {
+      if (index > -1) {
         arr.splice(index, 1);
         remove(arr, elem);
       }
@@ -1474,9 +1474,9 @@ if (typeof Slick === "undefined") {
       var positionValid = limit.start <= currentPosition && currentPosition <= limit.end;
 
       return {
-    	limit: limit,
+        limit: limit,
         valid: positionValid,
-        message: positionValid? '': 'Column "'.concat($item.text(), '" can be reordered only within the "', limit.group.name, '" group!')
+        message: positionValid ? '' : 'Column "'.concat($item.text(), '" can be reordered only within the "', limit.group.name, '" group!')
       };
     }
 
@@ -1505,7 +1505,7 @@ if (typeof Slick === "undefined") {
           ui.placeholder.width(ui.helper.outerWidth() - headerColumnWidthDiff);
           canDragScroll = !hasFrozenColumns() ||
             (ui.placeholder.offset().left + ui.placeholder.width()) > $viewportScrollContainerX.offset().left;
-	      $(ui.helper).addClass("slick-header-column-active");
+          $(ui.helper).addClass("slick-header-column-active");
         },
         beforeStop: function (e, ui) {
           $(ui.helper).removeClass("slick-header-column-active");
@@ -1556,28 +1556,28 @@ if (typeof Slick === "undefined") {
           }
           setColumns(reorderedColumns);
 
-          trigger(self.onColumnsReordered, { impactedColumns : getImpactedColumns( limit ) });
+          trigger(self.onColumnsReordered, { impactedColumns: getImpactedColumns(limit) });
           e.stopPropagation();
           setupColumnResize();
         }
       });
     }
 
-    function getImpactedColumns( limit ) {
-    	var impactedColumns = [];
+    function getImpactedColumns(limit) {
+      var impactedColumns = [];
 
-    	if( limit ) {
+      if (limit) {
 
-	   		for( var i = limit.start; i <= limit.end; i++ ) {
-	   			impactedColumns.push( columns[i] );
-	   		}
-    	}
-    	else {
+        for (var i = limit.start; i <= limit.end; i++) {
+          impactedColumns.push(columns[i]);
+        }
+      }
+      else {
 
-    		impactedColumns = columns;
-    	}
+        impactedColumns = columns;
+      }
 
-   		return impactedColumns;
+      return impactedColumns;
     }
 
     function setupColumnResize() {
@@ -1603,122 +1603,111 @@ if (typeof Slick === "undefined") {
         }
         $col = $(e);
         $("<div class='slick-resizable-handle' />")
-            .appendTo(e)
-            .on("dragstart", function (e, dd) {
-              if (!getEditorLock().commitCurrentEdit()) {
-                return false;
+          .appendTo(e)
+          .on("dragstart", function (e, dd) {
+            if (!getEditorLock().commitCurrentEdit()) {
+              return false;
+            }
+            pageX = e.pageX;
+            $(this).parent().addClass("slick-header-column-active");
+            var shrinkLeewayOnRight = null, stretchLeewayOnRight = null;
+            // lock each column's width option to current width
+            columnElements.each(function (i, e) {
+              if (i >= columns.length) { return; }
+              columns[i].previousWidth = $(e).outerWidth();
+            });
+            if (options.forceFitColumns) {
+              shrinkLeewayOnRight = 0;
+              stretchLeewayOnRight = 0;
+              // colums on right affect maxPageX/minPageX
+              for (j = i + 1; j < columns.length; j++) {
+                c = columns[j];
+                if (c.resizable) {
+                  if (stretchLeewayOnRight !== null) {
+                    if (c.maxWidth) {
+                      stretchLeewayOnRight += c.maxWidth - c.previousWidth;
+                    } else {
+                      stretchLeewayOnRight = null;
+                    }
+                  }
+                  shrinkLeewayOnRight += c.previousWidth - Math.max(c.minWidth || 0, absoluteColumnMinWidth);
+                }
               }
-              pageX = e.pageX;
-              $(this).parent().addClass("slick-header-column-active");
-              var shrinkLeewayOnRight = null, stretchLeewayOnRight = null;
-              // lock each column's width option to current width
-              columnElements.each(function (i, e) {
-                if (i >= columns.length) { return; }
-                columns[i].previousWidth = $(e).outerWidth();
-              });
+            }
+            var shrinkLeewayOnLeft = 0, stretchLeewayOnLeft = 0;
+            for (j = 0; j <= i; j++) {
+              // columns on left only affect minPageX
+              c = columns[j];
+              if (c.resizable) {
+                if (stretchLeewayOnLeft !== null) {
+                  if (c.maxWidth) {
+                    stretchLeewayOnLeft += c.maxWidth - c.previousWidth;
+                  } else {
+                    stretchLeewayOnLeft = null;
+                  }
+                }
+                shrinkLeewayOnLeft += c.previousWidth - Math.max(c.minWidth || 0, absoluteColumnMinWidth);
+              }
+            }
+            if (shrinkLeewayOnRight === null) {
+              shrinkLeewayOnRight = 100000;
+            }
+            if (shrinkLeewayOnLeft === null) {
+              shrinkLeewayOnLeft = 100000;
+            }
+            if (stretchLeewayOnRight === null) {
+              stretchLeewayOnRight = 100000;
+            }
+            if (stretchLeewayOnLeft === null) {
+              stretchLeewayOnLeft = 100000;
+            }
+            maxPageX = pageX + Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft);
+            minPageX = pageX - Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight);
+          })
+          .on("drag", function (e, dd) {
+            columnResizeDragging = true;
+            var actualMinWidth, d = Math.min(maxPageX, Math.max(minPageX, e.pageX)) - pageX, x;
+            var newCanvasWidthL = 0, newCanvasWidthR = 0;
+
+            if (d < 0) { // shrink column
+              x = d;
+
+              for (j = i; j >= 0; j--) {
+                c = columns[j];
+                if (c.resizable) {
+                  actualMinWidth = Math.max(c.minWidth || 0, absoluteColumnMinWidth);
+                  if (x && c.previousWidth + x < actualMinWidth) {
+                    x += c.previousWidth - actualMinWidth;
+                    c.width = actualMinWidth;
+                  } else {
+                    c.width = c.previousWidth + x;
+                    x = 0;
+                  }
+                }
+              }
+
+              for (k = 0; k <= i; k++) {
+                c = columns[k];
+
+                if (hasFrozenColumns() && (k > options.frozenColumn)) {
+                  newCanvasWidthR += c.width;
+                } else {
+                  newCanvasWidthL += c.width;
+                }
+              }
+
               if (options.forceFitColumns) {
-                shrinkLeewayOnRight = 0;
-                stretchLeewayOnRight = 0;
-                // colums on right affect maxPageX/minPageX
+                x = -d;
                 for (j = i + 1; j < columns.length; j++) {
                   c = columns[j];
                   if (c.resizable) {
-                    if (stretchLeewayOnRight !== null) {
-                      if (c.maxWidth) {
-                        stretchLeewayOnRight += c.maxWidth - c.previousWidth;
-                      } else {
-                        stretchLeewayOnRight = null;
-                      }
-                    }
-                    shrinkLeewayOnRight += c.previousWidth - Math.max(c.minWidth || 0, absoluteColumnMinWidth);
-                  }
-                }
-              }
-              var shrinkLeewayOnLeft = 0, stretchLeewayOnLeft = 0;
-              for (j = 0; j <= i; j++) {
-                // columns on left only affect minPageX
-                c = columns[j];
-                if (c.resizable) {
-                  if (stretchLeewayOnLeft !== null) {
-                    if (c.maxWidth) {
-                      stretchLeewayOnLeft += c.maxWidth - c.previousWidth;
-                    } else {
-                      stretchLeewayOnLeft = null;
-                    }
-                  }
-                  shrinkLeewayOnLeft += c.previousWidth - Math.max(c.minWidth || 0, absoluteColumnMinWidth);
-                }
-              }
-              if (shrinkLeewayOnRight === null) {
-                shrinkLeewayOnRight = 100000;
-              }
-              if (shrinkLeewayOnLeft === null) {
-                shrinkLeewayOnLeft = 100000;
-              }
-              if (stretchLeewayOnRight === null) {
-                stretchLeewayOnRight = 100000;
-              }
-              if (stretchLeewayOnLeft === null) {
-                stretchLeewayOnLeft = 100000;
-              }
-              maxPageX = pageX + Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft);
-              minPageX = pageX - Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight);
-            })
-            .on("drag", function (e, dd) {
-              columnResizeDragging = true;
-              var actualMinWidth, d = Math.min(maxPageX, Math.max(minPageX, e.pageX)) - pageX, x;
-              var newCanvasWidthL = 0, newCanvasWidthR = 0;
-
-              if (d < 0) { // shrink column
-                x = d;
-
-                for (j = i; j >= 0; j--) {
-                  c = columns[j];
-                  if (c.resizable) {
-                    actualMinWidth = Math.max(c.minWidth || 0, absoluteColumnMinWidth);
-                    if (x && c.previousWidth + x < actualMinWidth) {
-                      x += c.previousWidth - actualMinWidth;
-                      c.width = actualMinWidth;
+                    if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
+                      x -= c.maxWidth - c.previousWidth;
+                      c.width = c.maxWidth;
                     } else {
                       c.width = c.previousWidth + x;
                       x = 0;
                     }
-                  }
-                }
-
-                for (k = 0; k <= i; k++) {
-                  c = columns[k];
-
-                  if (hasFrozenColumns() && (k > options.frozenColumn)) {
-                    newCanvasWidthR += c.width;
-                  } else {
-                    newCanvasWidthL += c.width;
-                  }
-                }
-
-                if (options.forceFitColumns) {
-                  x = -d;
-                  for (j = i + 1; j < columns.length; j++) {
-                    c = columns[j];
-                    if (c.resizable) {
-                      if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
-                        x -= c.maxWidth - c.previousWidth;
-                        c.width = c.maxWidth;
-                      } else {
-                        c.width = c.previousWidth + x;
-                        x = 0;
-                      }
-
-                      if (hasFrozenColumns() && (j > options.frozenColumn)) {
-                        newCanvasWidthR += c.width;
-                      } else {
-                        newCanvasWidthL += c.width;
-                      }
-                    }
-                  }
-                } else {
-                  for (j = i + 1; j < columns.length; j++) {
-                    c = columns[j];
 
                     if (hasFrozenColumns() && (j > options.frozenColumn)) {
                       newCanvasWidthR += c.width;
@@ -1727,29 +1716,21 @@ if (typeof Slick === "undefined") {
                     }
                   }
                 }
+              } else {
+                for (j = i + 1; j < columns.length; j++) {
+                  c = columns[j];
 
-                if (options.forceFitColumns) {
-                  x = -d;
-                  for (j = i + 1; j < columns.length; j++) {
-                    c = columns[j];
-                    if (c.resizable) {
-                      if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
-                        x -= c.maxWidth - c.previousWidth;
-                        c.width = c.maxWidth;
-                      } else {
-                        c.width = c.previousWidth + x;
-                        x = 0;
-                      }
-                    }
+                  if (hasFrozenColumns() && (j > options.frozenColumn)) {
+                    newCanvasWidthR += c.width;
+                  } else {
+                    newCanvasWidthL += c.width;
                   }
                 }
-              } else { // stretch column
-                x = d;
+              }
 
-                newCanvasWidthL = 0;
-                newCanvasWidthR = 0;
-
-                for (j = i; j >= 0; j--) {
+              if (options.forceFitColumns) {
+                x = -d;
+                for (j = i + 1; j < columns.length; j++) {
                   c = columns[j];
                   if (c.resizable) {
                     if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
@@ -1761,41 +1742,49 @@ if (typeof Slick === "undefined") {
                     }
                   }
                 }
+              }
+            } else { // stretch column
+              x = d;
 
-                for (k = 0; k <= i; k++) {
-                  c = columns[k];
+              newCanvasWidthL = 0;
+              newCanvasWidthR = 0;
 
-                  if (hasFrozenColumns() && (k > options.frozenColumn)) {
-                    newCanvasWidthR += c.width;
+              for (j = i; j >= 0; j--) {
+                c = columns[j];
+                if (c.resizable) {
+                  if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
+                    x -= c.maxWidth - c.previousWidth;
+                    c.width = c.maxWidth;
                   } else {
-                    newCanvasWidthL += c.width;
+                    c.width = c.previousWidth + x;
+                    x = 0;
                   }
                 }
+              }
 
-                if (options.forceFitColumns) {
-                  x = -d;
-                  for (j = i + 1; j < columns.length; j++) {
-                    c = columns[j];
-                    if (c.resizable) {
-                      actualMinWidth = Math.max(c.minWidth || 0, absoluteColumnMinWidth);
-                      if (x && c.previousWidth + x < actualMinWidth) {
-                        x += c.previousWidth - actualMinWidth;
-                        c.width = actualMinWidth;
-                      } else {
-                        c.width = c.previousWidth + x;
-                        x = 0;
-                      }
+              for (k = 0; k <= i; k++) {
+                c = columns[k];
 
-                      if (hasFrozenColumns() && (j > options.frozenColumn)) {
-                        newCanvasWidthR += c.width;
-                      } else {
-                        newCanvasWidthL += c.width;
-                      }
-                    }
-                  }
+                if (hasFrozenColumns() && (k > options.frozenColumn)) {
+                  newCanvasWidthR += c.width;
                 } else {
-                  for (j = i + 1; j < columns.length; j++) {
-                    c = columns[j];
+                  newCanvasWidthL += c.width;
+                }
+              }
+
+              if (options.forceFitColumns) {
+                x = -d;
+                for (j = i + 1; j < columns.length; j++) {
+                  c = columns[j];
+                  if (c.resizable) {
+                    actualMinWidth = Math.max(c.minWidth || 0, absoluteColumnMinWidth);
+                    if (x && c.previousWidth + x < actualMinWidth) {
+                      x += c.previousWidth - actualMinWidth;
+                      c.width = actualMinWidth;
+                    } else {
+                      c.width = c.previousWidth + x;
+                      x = 0;
+                    }
 
                     if (hasFrozenColumns() && (j > options.frozenColumn)) {
                       newCanvasWidthR += c.width;
@@ -1804,45 +1793,56 @@ if (typeof Slick === "undefined") {
                     }
                   }
                 }
-              }
+              } else {
+                for (j = i + 1; j < columns.length; j++) {
+                  c = columns[j];
 
-              if (hasFrozenColumns() && newCanvasWidthL != canvasWidthL) {
-                $headerL.width(newCanvasWidthL + 1000);
-                $paneHeaderR.css('left', newCanvasWidthL);
-              }
-
-              applyColumnHeaderWidths();
-              applyColumnGroupHeaderWidths();
-              if (options.syncColumnCellResize) {
-                applyColumnWidths();
-              }
-              trigger(self.onColumnsDrag, {
-                triggeredByColumn: $(this).parent().attr("id").replace(uid, ""),
-                resizeHandle: $(this)
-              });
-            })
-            .on("dragend", function (e, dd) {
-              $(this).parent().removeClass("slick-header-column-active");
-
-              var triggeredByColumn = $(this).parent().attr("id").replace(uid, "");
-              if (trigger(self.onBeforeColumnsResize, { triggeredByColumn: triggeredByColumn }) === true) {
-                applyColumnHeaderWidths();
-                applyColumnGroupHeaderWidths();
-              }
-              var newWidth;
-              for (j = 0; j < columns.length; j++) {
-                c = columns[j];
-                newWidth = $(columnElements[j]).outerWidth();
-
-                if (c.previousWidth !== newWidth && c.rerenderOnResize) {
-                  invalidateAllRows();
+                  if (hasFrozenColumns() && (j > options.frozenColumn)) {
+                    newCanvasWidthR += c.width;
+                  } else {
+                    newCanvasWidthL += c.width;
+                  }
                 }
               }
-              updateCanvasWidth(true);
-              render();
-              trigger(self.onColumnsResized, { triggeredByColumn: triggeredByColumn });
-              setTimeout(function () { columnResizeDragging = false; }, 300);
+            }
+
+            if (hasFrozenColumns() && newCanvasWidthL != canvasWidthL) {
+              $headerL.width(newCanvasWidthL + 1000);
+              $paneHeaderR.css('left', newCanvasWidthL);
+            }
+
+            applyColumnHeaderWidths();
+            applyColumnGroupHeaderWidths();
+            if (options.syncColumnCellResize) {
+              applyColumnWidths();
+            }
+            trigger(self.onColumnsDrag, {
+              triggeredByColumn: $(this).parent().attr("id").replace(uid, ""),
+              resizeHandle: $(this)
             });
+          })
+          .on("dragend", function (e, dd) {
+            $(this).parent().removeClass("slick-header-column-active");
+
+            var triggeredByColumn = $(this).parent().attr("id").replace(uid, "");
+            if (trigger(self.onBeforeColumnsResize, { triggeredByColumn: triggeredByColumn }) === true) {
+              applyColumnHeaderWidths();
+              applyColumnGroupHeaderWidths();
+            }
+            var newWidth;
+            for (j = 0; j < columns.length; j++) {
+              c = columns[j];
+              newWidth = $(columnElements[j]).outerWidth();
+
+              if (c.previousWidth !== newWidth && c.rerenderOnResize) {
+                invalidateAllRows();
+              }
+            }
+            updateCanvasWidth(true);
+            render();
+            trigger(self.onColumnsResized, { triggeredByColumn: triggeredByColumn });
+            setTimeout(function () { columnResizeDragging = false; }, 300);
+          });
       });
     }
 
@@ -1864,12 +1864,12 @@ if (typeof Slick === "undefined") {
 
       if (options.frozenRow > -1) {
         hasFrozenRows = true;
-        frozenRowsHeight = ( options.frozenRow ) * options.rowHeight;
+        frozenRowsHeight = (options.frozenRow) * options.rowHeight;
 
         var dataLength = getDataLength();
 
-        actualFrozenRow = ( options.frozenBottom )
-          ? ( dataLength - options.frozenRow )
+        actualFrozenRow = (options.frozenBottom)
+          ? (dataLength - options.frozenRow)
           : options.frozenRow;
       } else {
         hasFrozenRows = false;
@@ -1904,23 +1904,23 @@ if (typeof Slick === "undefined") {
 
     function setOverflow() {
       $viewportTopL.css({
-        'overflow-x': ( hasFrozenColumns() ) ? ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll' ) : ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'auto' ),
-        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : (( hasFrozenColumns() ) ? ( hasFrozenRows ? 'hidden' : 'hidden' ) : ( hasFrozenRows ? 'scroll' : 'auto' ))
+        'overflow-x': (hasFrozenColumns()) ? (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll') : (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'auto'),
+        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : ((hasFrozenColumns()) ? (hasFrozenRows ? 'hidden' : 'hidden') : (hasFrozenRows ? 'scroll' : 'auto'))
       });
 
       $viewportTopR.css({
-        'overflow-x': ( hasFrozenColumns() ) ? ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll' ) : ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'auto' ),
-        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : (( hasFrozenColumns() ) ? ( hasFrozenRows ? 'scroll' : 'auto'   ) : ( hasFrozenRows ? 'scroll' : 'auto' ))
+        'overflow-x': (hasFrozenColumns()) ? (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll') : (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'auto'),
+        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : ((hasFrozenColumns()) ? (hasFrozenRows ? 'scroll' : 'auto') : (hasFrozenRows ? 'scroll' : 'auto'))
       });
 
       $viewportBottomL.css({
-        'overflow-x': ( hasFrozenColumns() ) ? ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'scroll' : 'auto'   ): ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'auto' : 'auto'   ),
-        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : (( hasFrozenColumns() ) ? ( hasFrozenRows ? 'hidden' : 'hidden' ): ( hasFrozenRows ? 'scroll' : 'auto' ))
+        'overflow-x': (hasFrozenColumns()) ? (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'scroll' : 'auto') : (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'auto' : 'auto'),
+        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : ((hasFrozenColumns()) ? (hasFrozenRows ? 'hidden' : 'hidden') : (hasFrozenRows ? 'scroll' : 'auto'))
       });
 
       $viewportBottomR.css({
-        'overflow-x': ( hasFrozenColumns() ) ? ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'scroll' : 'auto' ) : ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'auto' : 'auto' ),
-        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : (( hasFrozenColumns() ) ? ( hasFrozenRows ? 'auto' : 'auto'   ) : ( hasFrozenRows ? 'auto' : 'auto' ))
+        'overflow-x': (hasFrozenColumns()) ? (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'scroll' : 'auto') : (hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'auto' : 'auto'),
+        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : ((hasFrozenColumns()) ? (hasFrozenRows ? 'auto' : 'auto') : (hasFrozenRows ? 'auto' : 'auto'))
       });
       if (options.viewportClass) {
         $viewportTopL.toggleClass(options.viewportClass, true);
@@ -1973,7 +1973,7 @@ if (typeof Slick === "undefined") {
       // jquery 1.8 changed .width to read the true inner element width if box-sizing is set to border-box, and introduced a setter for .outerWidth
       // so for equivalent functionality, prior to 1.8 use .width, and after use .outerWidth
       var verArray = $.fn.jquery.split('.');
-      jQueryNewWidthBehaviour = (verArray[0]==1 && verArray[1]>=8) ||  verArray[0] >=2;
+      jQueryNewWidthBehaviour = (verArray[0] == 1 && verArray[1] >= 8) || verArray[0] >= 2;
 
       el = $("<div class='ui-state-default slick-header-column' style='visibility:hidden'>-</div>").appendTo($headers);
       headerColumnWidthDiff = headerColumnHeightDiff = 0;
@@ -2078,12 +2078,12 @@ if (typeof Slick === "undefined") {
       trigger(self.onBeforeDestroy, {});
 
       var i = plugins.length;
-      while(i--) {
+      while (i--) {
         unregisterPlugin(plugins[i]);
       }
 
       if (options.enableColumnReorder) {
-          $headers.filter(":ui-sortable").sortable("destroy");
+        $headers.filter(":ui-sortable").sortable("destroy");
       }
 
       unbindAncestorScrollEvents();
@@ -2118,9 +2118,9 @@ if (typeof Slick === "undefined") {
     function autosizeColumns(autosizeMode, isInit) {
       //LogColWidths();
 
-      autosizeMode =  autosizeMode || options.autosizeColsMode;
+      autosizeMode = autosizeMode || options.autosizeColsMode;
       if (autosizeMode === Slick.GridAutosizeColsMode.LegacyForceFit
-      || autosizeMode === Slick.GridAutosizeColsMode.LegacyOff) {
+        || autosizeMode === Slick.GridAutosizeColsMode.LegacyOff) {
         legacyAutosizeColumns();
         return;
       }
@@ -2181,7 +2181,7 @@ if (typeof Slick === "undefined") {
             } else {
               colWidth = c.autoSize.widthPx;
             }
-            if (c.rerenderOnResize && c.width  != colWidth) { reRender = true; }
+            if (c.rerenderOnResize && c.width != colWidth) { reRender = true; }
             c.width = colWidth;
           }
         } else if ((options.viewportSwitchToScrollModeWidthPercent && totalWidthLessSTR + strColsMinWidth > viewportWidth * options.viewportSwitchToScrollModeWidthPercent / 100)
@@ -2209,7 +2209,7 @@ if (typeof Slick === "undefined") {
                 unallocatedViewportWidth -= colWidth;
               }
             }
-            if (c.rerenderOnResize && c.width  != colWidth) { reRender = true; }
+            if (c.rerenderOnResize && c.width != colWidth) { reRender = true; }
             c.width = colWidth;
           }
         }
@@ -2230,8 +2230,8 @@ if (typeof Slick === "undefined") {
       reRenderColumns(reRender);
     }
 
-    function LogColWidths () {
-      var s =  "Col Widths:";
+    function LogColWidths() {
+      var s = "Col Widths:";
       for (var i = 0; i < columns.length; i++) { s += ' ' + columns[i].width; }
       console.log(s);
     }
@@ -2242,7 +2242,7 @@ if (typeof Slick === "undefined") {
       // set to width as default
       autoSize.widthPx = columnDef.width;
       if (autoSize.autosizeMode === Slick.ColAutosizeMode.Locked
-      || autoSize.autosizeMode === Slick.ColAutosizeMode.Guide) {
+        || autoSize.autosizeMode === Slick.ColAutosizeMode.Guide) {
         return;
       }
 
@@ -2260,12 +2260,12 @@ if (typeof Slick === "undefined") {
             colDataTypeOf = typeof colDataItem;
             if (colDataTypeOf === 'object') {
               if (colDataItem instanceof Date) { colDataTypeOf = "date"; }
-              if (typeof moment!=='undefined' && colDataItem instanceof moment) { colDataTypeOf = "moment"; }
+              if (typeof moment !== 'undefined' && colDataItem instanceof moment) { colDataTypeOf = "moment"; }
             }
           }
         }
         if (colDataTypeOf === 'boolean') {
-          autoSize.colValueArray = [ true, false ];
+          autoSize.colValueArray = [true, false];
         }
         if (colDataTypeOf === 'number') {
           autoSize.valueFilterMode = Slick.ValueFilterMode.GetGreatestAndSub;
@@ -2277,17 +2277,17 @@ if (typeof Slick === "undefined") {
           autoSize.allowAddlPercent = 5;
         }
         if (colDataTypeOf === 'date') {
-          autoSize.colValueArray = [ new Date(2009, 8, 30, 12, 20, 20) ]; // Sep 30th 2009, 12:20:20 AM
+          autoSize.colValueArray = [new Date(2009, 8, 30, 12, 20, 20)]; // Sep 30th 2009, 12:20:20 AM
         }
-        if (colDataTypeOf === 'moment' && typeof moment!=='undefined') {
-          autoSize.colValueArray = [ moment([2009, 8, 30, 12, 20, 20]) ]; // Sep 30th 2009, 12:20:20 AM
+        if (colDataTypeOf === 'moment' && typeof moment !== 'undefined') {
+          autoSize.colValueArray = [moment([2009, 8, 30, 12, 20, 20])]; // Sep 30th 2009, 12:20:20 AM
         }
       }
 
       // at this point, the autosizeMode is effectively 'Content', so proceed to get size
       var colWidth = getColContentSize(columnDef, $gridCanvas, isInit);
 
-      var addlPercentMultiplier = (autoSize.allowAddlPercent ? (1 + autoSize.allowAddlPercent/100) : 1);
+      var addlPercentMultiplier = (autoSize.allowAddlPercent ? (1 + autoSize.allowAddlPercent / 100) : 1);
       colWidth = colWidth * addlPercentMultiplier + options.autosizeColPaddingPx;
       if (columnDef.minWidth && colWidth < columnDef.minWidth) { colWidth = columnDef.minWidth; }
       if (columnDef.maxWidth && colWidth > columnDef.maxWidth) { colWidth = columnDef.maxWidth; }
@@ -2321,8 +2321,8 @@ if (typeof Slick === "undefined") {
 
       var rowSelectionMode = (isInit ? autoSize.rowSelectionModeOnInit : undefined) || autoSize.rowSelectionMode;
 
-      if (rowSelectionMode === Slick.RowSelectionMode.FirstRow) { rows = rows.slice(0,1); }
-      if (rowSelectionMode === Slick.RowSelectionMode.LastRow) { rows = rows.slice(rows.length -1, rows.length); }
+      if (rowSelectionMode === Slick.RowSelectionMode.FirstRow) { rows = rows.slice(0, 1); }
+      if (rowSelectionMode === Slick.RowSelectionMode.LastRow) { rows = rows.slice(rows.length - 1, rows.length); }
       if (rowSelectionMode === Slick.RowSelectionMode.FirstNRows) { rows = rows.slice(0, autoSize.rowSelectionCount); }
 
       // now use valueFilterMode to further filter selected rows
@@ -2335,7 +2335,7 @@ if (typeof Slick === "undefined") {
           rows = Object.keys(rowsDict);
         } else {
           rows = [];
-          for (var i in rowsDict)  rows.push(i);
+          for (var i in rowsDict) rows.push(i);
         }
       }
 
@@ -2351,7 +2351,7 @@ if (typeof Slick === "undefined") {
         maxVal = Array(maxVal.length + 1).join("9");
         maxVal = +maxVal;
 
-        rows = [ maxVal ];
+        rows = [maxVal];
       }
 
       if (autoSize.valueFilterMode === Slick.ValueFilterMode.GetLongestTextAndSub) {
@@ -2365,7 +2365,7 @@ if (typeof Slick === "undefined") {
         tempVal = Array(maxLen + 1).join("m");
         widthAdjustRatio = options.autosizeTextAvgToMWidthRatio;
 
-        rows = [ tempVal ];
+        rows = [tempVal];
       }
 
       if (autoSize.valueFilterMode === Slick.ValueFilterMode.GetLongestText) {
@@ -2377,7 +2377,7 @@ if (typeof Slick === "undefined") {
         }
         // now substitute a 'c' for all characters
         tempVal = rows[maxIndex][columnDef.field];
-        rows = [ tempVal ];
+        rows = [tempVal];
       }
 
       maxColWidth = getColWidth(columnDef, $gridCanvas, rows) * widthAdjustRatio;
@@ -2385,59 +2385,59 @@ if (typeof Slick === "undefined") {
     }
 
     function getColWidth(columnDef, $gridCanvas, data) {
-        var colIndex = getColumnIndex(columnDef.id);
+      var colIndex = getColumnIndex(columnDef.id);
 
-        var $rowEl = $('<div class="slick-row ui-widget-content"></div>');
-        var $cellEl = $('<div class="slick-cell"></div>');
-        $cellEl.css({
-            "position": "absolute",
-            "visibility": "hidden",
-            "text-overflow": "initial",
-            "white-space": "nowrap"
-        });
-        $rowEl.append($cellEl);
+      var $rowEl = $('<div class="slick-row ui-widget-content"></div>');
+      var $cellEl = $('<div class="slick-cell"></div>');
+      $cellEl.css({
+        "position": "absolute",
+        "visibility": "hidden",
+        "text-overflow": "initial",
+        "white-space": "nowrap"
+      });
+      $rowEl.append($cellEl);
 
-        $gridCanvas.append($rowEl);
+      $gridCanvas.append($rowEl);
 
-        var len, max = 0, text, maxText, formatterResult, maxWidth = 0, val;
+      var len, max = 0, text, maxText, formatterResult, maxWidth = 0, val;
 
-         // use canvas - very fast, but text-only
-        if (canvas_context && columnDef.autoSize.widthEvalMode === Slick.WidthEvalMode.CanvasTextSize) {
-          canvas_context.font = $cellEl.css("font-size") + " " + $cellEl.css("font-family");
-          $(data).each(function (index, row) {
-              // row is either an array or values or a single value
-              val = (Array.isArray(row) ? row[columnDef.field] : row);
-              text = '' + val;
-              len = text ? canvas_context.measureText(text).width : 0;
-              if (len > max) { max = len; maxText = text; }
-          });
-
-          $cellEl.html(maxText);
-          len = $cellEl.outerWidth();
-
-          $rowEl.remove();
-          return len;
-        }
-
+      // use canvas - very fast, but text-only
+      if (canvas_context && columnDef.autoSize.widthEvalMode === Slick.WidthEvalMode.CanvasTextSize) {
+        canvas_context.font = $cellEl.css("font-size") + " " + $cellEl.css("font-family");
         $(data).each(function (index, row) {
-            val = (Array.isArray(row) ? row[columnDef.field] : row);
-            if (columnDef.formatterOverride) {
-              // use formatterOverride as first preference
-              formatterResult = columnDef.formatterOverride(index, colIndex, val, columnDef, row);
-            } else if (columnDef.formatter) {
-              // otherwise, use formatter
-              formatterResult = columnDef.formatter(index, colIndex, val, columnDef, row);
-            } else {
-              // otherwise, use plain text
-              formatterResult = '' + val;
-            }
-            applyFormatResultToCellNode(formatterResult, $cellEl[0]);
-            len = $cellEl.outerWidth();
-            if (len > max) { max = len; }
-         });
+          // row is either an array or values or a single value
+          val = (Array.isArray(row) ? row[columnDef.field] : row);
+          text = '' + val;
+          len = text ? canvas_context.measureText(text).width : 0;
+          if (len > max) { max = len; maxText = text; }
+        });
+
+        $cellEl.html(maxText);
+        len = $cellEl.outerWidth();
 
         $rowEl.remove();
-        return max;
+        return len;
+      }
+
+      $(data).each(function (index, row) {
+        val = (Array.isArray(row) ? row[columnDef.field] : row);
+        if (columnDef.formatterOverride) {
+          // use formatterOverride as first preference
+          formatterResult = columnDef.formatterOverride(index, colIndex, val, columnDef, row);
+        } else if (columnDef.formatter) {
+          // otherwise, use formatter
+          formatterResult = columnDef.formatter(index, colIndex, val, columnDef, row);
+        } else {
+          // otherwise, use plain text
+          formatterResult = '' + val;
+        }
+        applyFormatResultToCellNode(formatterResult, $cellEl[0]);
+        len = $cellEl.outerWidth();
+        if (len > max) { max = len; }
+      });
+
+      $rowEl.remove();
+      return max;
     }
 
     function getColHeaderWidth(columnDef) {
@@ -2471,11 +2471,11 @@ if (typeof Slick === "undefined") {
 
     function legacyAutosizeColumns() {
       var i, c,
-          widths = [],
-          shrinkLeeway = 0,
-          total = 0,
-          prevTotal,
-          availWidth = viewportHasVScroll ? viewportW - scrollbarDimensions.width : viewportW;
+        widths = [],
+        shrinkLeeway = 0,
+        total = 0,
+        prevTotal,
+        availWidth = viewportHasVScroll ? viewportW - scrollbarDimensions.width : viewportW;
 
       for (i = 0; i < columns.length; i++) {
         c = columns[i];
@@ -2548,7 +2548,7 @@ if (typeof Slick === "undefined") {
       applyColumnGroupHeaderWidths();
       updateCanvasWidth(true);
 
-      trigger(self.onAutosizeColumns, { "columns": columns});
+      trigger(self.onAutosizeColumns, { "columns": columns });
 
       if (reRender) {
         invalidateAllRows();
@@ -2587,20 +2587,20 @@ if (typeof Slick === "undefined") {
 
         var groupColumns = treeColumns.getColumnsInDepth(depth);
 
-        $().add($groupHeadersL[depth]).add($groupHeadersR[depth]).each(function(i) {
+        $().add($groupHeadersL[depth]).add($groupHeadersR[depth]).each(function (i) {
           var $groupHeader = $(this),
             currentColumnIndex = 0;
 
-          $groupHeader.width(i === 0? getHeadersWidthL(): getHeadersWidthR());
+          $groupHeader.width(i === 0 ? getHeadersWidthL() : getHeadersWidthR());
 
-          $groupHeader.children().each(function() {
+          $groupHeader.children().each(function () {
             var $groupHeaderColumn = $(this);
 
             var m = $(this).data('column');
 
             m.width = 0;
 
-            m.columns.forEach(function() {
+            m.columns.forEach(function () {
               var $headerColumn = $groupHeader.next().children(':eq(' + (currentColumnIndex++) + ')');
               m.width += $headerColumn.outerWidth();
             });
@@ -2621,13 +2621,13 @@ if (typeof Slick === "undefined") {
       for (var i = 0, headers = $headers.children(), ii = columns.length; i < ii; i++) {
         h = $(headers[i]);
         if (jQueryNewWidthBehaviour) {
-            if (h.outerWidth() !== columns[i].width) {
-              h.outerWidth(columns[i].width);
-            }
+          if (h.outerWidth() !== columns[i].width) {
+            h.outerWidth(columns[i].width);
+          }
         } else {
-            if (h.width() !== columns[i].width - headerColumnWidthDiff) {
-              h.width(columns[i].width - headerColumnWidthDiff);
-            }
+          if (h.width() !== columns[i].width - headerColumnWidthDiff) {
+            h.width(columns[i].width - headerColumnWidthDiff);
+          }
         }
       }
 
@@ -2654,7 +2654,7 @@ if (typeof Slick === "undefined") {
     }
 
     function setSortColumn(columnId, ascending) {
-      setSortColumns([{ columnId: columnId, sortAsc: ascending}]);
+      setSortColumns([{ columnId: columnId, sortAsc: ascending }]);
     }
 
     function setSortColumns(cols) {
@@ -2664,12 +2664,12 @@ if (typeof Slick === "undefined") {
       headerColumnEls
         .removeClass("slick-header-column-sorted")
         .find(".slick-sort-indicator")
-          .removeClass("slick-sort-indicator-asc slick-sort-indicator-desc");
+        .removeClass("slick-sort-indicator-asc slick-sort-indicator-desc");
       headerColumnEls
         .find(".slick-sort-indicator-numbered")
-          .text('');
+        .text('');
 
-      $.each(sortColumns, function(i, col) {
+      $.each(sortColumns, function (i, col) {
         if (col.sortAsc == null) {
           col.sortAsc = true;
         }
@@ -2677,12 +2677,12 @@ if (typeof Slick === "undefined") {
         if (columnIndex != null) {
           headerColumnEls.eq(columnIndex)
             .addClass("slick-header-column-sorted")
-              .find(".slick-sort-indicator")
-                .addClass(col.sortAsc ? "slick-sort-indicator-asc" : "slick-sort-indicator-desc");
+            .find(".slick-sort-indicator")
+            .addClass(col.sortAsc ? "slick-sort-indicator-asc" : "slick-sort-indicator-desc");
           if (numberCols) {
             headerColumnEls.eq(columnIndex)
               .find(".slick-sort-indicator-numbered")
-                .text(i+1);
+              .text(i + 1);
           }
         }
       });
@@ -2713,7 +2713,7 @@ if (typeof Slick === "undefined") {
       setCellCssStyles(options.selectedCellCssClass, hash);
 
       if (simpleArrayEquals(previousSelectedRows, selectedRows)) {
-        trigger(self.onSelectedRowsChanged, {rows: getSelectedRows(), previousSelectedRows: previousSelectedRows}, e);
+        trigger(self.onSelectedRowsChanged, { rows: getSelectedRows(), previousSelectedRows: previousSelectedRows }, e);
       }
     }
 
@@ -3029,7 +3029,7 @@ if (typeof Slick === "undefined") {
 
       if (prevScrollTop != newScrollTop) {
         vScrollDir = (prevScrollTop + oldOffset < newScrollTop + offset) ? 1 : -1;
-        lastRenderedScrollTop = ( scrollTop = prevScrollTop = newScrollTop );
+        lastRenderedScrollTop = (scrollTop = prevScrollTop = newScrollTop);
 
         if (hasFrozenColumns()) {
           $viewportTopL[0].scrollTop = newScrollTop;
@@ -3049,7 +3049,7 @@ if (typeof Slick === "undefined") {
       if (value == null) {
         return "";
       } else {
-        return (value + "").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+        return (value + "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
       }
     }
 
@@ -3058,33 +3058,33 @@ if (typeof Slick === "undefined") {
 
       // look up by id, then index
       var columnOverrides = rowMetadata &&
-          rowMetadata.columns &&
-          (rowMetadata.columns[column.id] || rowMetadata.columns[getColumnIndex(column.id)]);
+        rowMetadata.columns &&
+        (rowMetadata.columns[column.id] || rowMetadata.columns[getColumnIndex(column.id)]);
 
       return (columnOverrides && columnOverrides.formatter) ||
-          (rowMetadata && rowMetadata.formatter) ||
-          column.formatter ||
-          (options.formatterFactory && options.formatterFactory.getFormatter(column)) ||
-          options.defaultFormatter;
+        (rowMetadata && rowMetadata.formatter) ||
+        column.formatter ||
+        (options.formatterFactory && options.formatterFactory.getFormatter(column)) ||
+        options.defaultFormatter;
     }
 
-    function callFormatter( row, cell, value, m, item, grid ) {
+    function callFormatter(row, cell, value, m, item, grid) {
 
-    	var result;
+      var result;
 
-        // pass metadata to formatter
-        var metadata = data.getItemMetadata && data.getItemMetadata(row);
-        metadata = metadata && metadata.columns;
+      // pass metadata to formatter
+      var metadata = data.getItemMetadata && data.getItemMetadata(row);
+      metadata = metadata && metadata.columns;
 
-        if( metadata ) {
-        	var columnData = metadata[m.id] || metadata[cell];
-        	result = getFormatter(row, m)(row, cell, value, m, item, columnData );
-        }
-        else {
-        	result = getFormatter(row, m)(row, cell, value, m, item);
-        }
+      if (metadata) {
+        var columnData = metadata[m.id] || metadata[cell];
+        result = getFormatter(row, m)(row, cell, value, m, item, columnData);
+      }
+      else {
+        result = getFormatter(row, m)(row, cell, value, m, item);
+      }
 
-        return result;
+      return result;
     }
 
     function getEditor(row, cell) {
@@ -3113,10 +3113,10 @@ if (typeof Slick === "undefined") {
       var d = getDataItem(row);
       var dataLoading = row < dataLength && !d;
       var rowCss = "slick-row" +
-          (hasFrozenRows && row <= options.frozenRow? ' frozen': '') +
-          (dataLoading ? " loading" : "") +
-          (row === activeRow && options.showCellSelection ? " active" : "") +
-          (row % 2 == 1 ? " odd" : " even");
+        (hasFrozenRows && row <= options.frozenRow ? ' frozen' : '') +
+        (dataLoading ? " loading" : "") +
+        (row === activeRow && options.showCellSelection ? " active" : "") +
+        (row % 2 == 1 ? " odd" : " even");
 
       if (!d) {
         rowCss += " " + options.addNewRowCssClass;
@@ -3131,7 +3131,7 @@ if (typeof Slick === "undefined") {
       var frozenRowOffset = getFrozenRowOffset(row);
 
       var rowHtml = "<div class='ui-widget-content " + rowCss + "' style='top:"
-        + (getRowTop(row) - frozenRowOffset )
+        + (getRowTop(row) - frozenRowOffset)
         + "px'>";
 
       stringArrayL.push(rowHtml);
@@ -3159,7 +3159,7 @@ if (typeof Slick === "undefined") {
             break;
           }
 
-          if (hasFrozenColumns() && ( i > options.frozenColumn )) {
+          if (hasFrozenColumns() && (i > options.frozenColumn)) {
             appendCellHtml(stringArrayR, row, i, colspan, d);
           } else {
             appendCellHtml(stringArrayL, row, i, colspan, d);
@@ -3188,7 +3188,7 @@ if (typeof Slick === "undefined") {
 
       var m = columns[cell];
       var cellCss = "slick-cell l" + cell + " r" + Math.min(columns.length - 1, cell + colspan - 1) +
-          (m.cssClass ? " " + m.cssClass : "");
+        (m.cssClass ? " " + m.cssClass : "");
 
       if (hasFrozenColumns() && cell <= options.frozenColumn) {
         cellCss += (" frozen");
@@ -3208,7 +3208,7 @@ if (typeof Slick === "undefined") {
       var value = null, formatterResult = '';
       if (item) {
         value = getDataItemValueForColumn(item, m);
-        formatterResult =  getFormatter(row, m)(row, cell, value, m, item, self);
+        formatterResult = getFormatter(row, m)(row, cell, value, m, item, self);
         if (formatterResult === null || formatterResult === undefined) { formatterResult = ''; }
       }
 
@@ -3218,7 +3218,7 @@ if (typeof Slick === "undefined") {
       var toolTip = formatterResult && formatterResult.toolTip ? "title='" + formatterResult.toolTip + "'" : '';
 
       var customAttrStr = '';
-      if(m.hasOwnProperty('cellAttrs') && m.cellAttrs instanceof Object) {
+      if (m.hasOwnProperty('cellAttrs') && m.cellAttrs instanceof Object) {
         for (var key in m.cellAttrs) {
           if (m.cellAttrs.hasOwnProperty(key)) {
             customAttrStr += ' ' + key + '="' + m.cellAttrs[key] + '" ';
@@ -3230,7 +3230,7 @@ if (typeof Slick === "undefined") {
 
       // if there is a corresponding row (if not, this is the Add New row or this data hasn't been loaded yet)
       if (item) {
-        stringArray.push(Object.prototype.toString.call(formatterResult)  !== '[object Object]' ? formatterResult : formatterResult.text);
+        stringArray.push(Object.prototype.toString.call(formatterResult) !== '[object Object]' ? formatterResult : formatterResult.text);
       }
 
       stringArray.push("</div>");
@@ -3245,17 +3245,17 @@ if (typeof Slick === "undefined") {
         var removeFrozenRow = true;
 
         if (hasFrozenRows
-          && ( ( options.frozenBottom && i >= actualFrozenRow ) // Frozen bottom rows
-            || ( !options.frozenBottom && i <= actualFrozenRow ) // Frozen top rows
-            )
-          ) {
+          && ((options.frozenBottom && i >= actualFrozenRow) // Frozen bottom rows
+            || (!options.frozenBottom && i <= actualFrozenRow) // Frozen top rows
+          )
+        ) {
           removeFrozenRow = false;
         }
 
-        if (( ( i = parseInt(i, 10)) !== activeRow )
-          && ( i < rangeToKeep.top || i > rangeToKeep.bottom )
-          && ( removeFrozenRow )
-          ) {
+        if (((i = parseInt(i, 10)) !== activeRow)
+          && (i < rangeToKeep.top || i > rangeToKeep.bottom)
+          && (removeFrozenRow)
+        ) {
           removeRowFromCache(i);
         }
       }
@@ -3287,7 +3287,7 @@ if (typeof Slick === "undefined") {
           postProcessedCleanupQueue.push({
             actionType: 'C',
             groupId: postProcessgroupId,
-            node: cacheEntry.cellNodesByColumnIdx[ columnIdx | 0],
+            node: cacheEntry.cellNodesByColumnIdx[columnIdx | 0],
             columnIdx: columnIdx | 0,
             rowIdx: rowIdx
           });
@@ -3326,7 +3326,7 @@ if (typeof Slick === "undefined") {
         zombieRowNodeFromLastMouseWheelEvent = cacheEntry.rowNode;
       } else {
 
-        cacheEntry.rowNode.each(function() {
+        cacheEntry.rowNode.each(function () {
           this.parentElement.removeChild(this);
         });
 
@@ -3345,7 +3345,7 @@ if (typeof Slick === "undefined") {
       }
       vScrollDir = 0;
       rl = rows.length;
-      for (i = 0;  i < rl; i++) {
+      for (i = 0; i < rl; i++) {
         if (currentEditor && activeRow === rows[i]) {
           makeActiveCellNormal();
         }
@@ -3362,21 +3362,21 @@ if (typeof Slick === "undefined") {
     }
 
     function applyFormatResultToCellNode(formatterResult, cellNode, suppressRemove) {
-        if (formatterResult === null || formatterResult === undefined) { formatterResult = ''; }
-        if (Object.prototype.toString.call(formatterResult)  !== '[object Object]') {
-          cellNode.innerHTML = formatterResult;
-          return;
-        }
-        cellNode.innerHTML = formatterResult.text;
-        if (formatterResult.removeClasses && !suppressRemove) {
-          $(cellNode).removeClass(formatterResult.removeClasses);
-        }
-        if (formatterResult.addClasses) {
-          $(cellNode).addClass(formatterResult.addClasses);
-        }
-        if (formatterResult.toolTip) {
-          $(cellNode).attr("title", formatterResult.toolTip);
-        }
+      if (formatterResult === null || formatterResult === undefined) { formatterResult = ''; }
+      if (Object.prototype.toString.call(formatterResult) !== '[object Object]') {
+        cellNode.innerHTML = formatterResult;
+        return;
+      }
+      cellNode.innerHTML = formatterResult.text;
+      if (formatterResult.removeClasses && !suppressRemove) {
+        $(cellNode).removeClass(formatterResult.removeClasses);
+      }
+      if (formatterResult.addClasses) {
+        $(cellNode).addClass(formatterResult.addClasses);
+      }
+      if (formatterResult.toolTip) {
+        $(cellNode).attr("title", formatterResult.toolTip);
+      }
     }
 
     function updateCell(row, cell) {
@@ -3389,7 +3389,7 @@ if (typeof Slick === "undefined") {
       if (currentEditor && activeRow === row && activeCell === cell) {
         currentEditor.loadValue(d);
       } else {
-        var formatterResult =  d ? getFormatter(row, m)(row, cell, getDataItemValueForColumn(d, m), m, d, self) : "";
+        var formatterResult = d ? getFormatter(row, m)(row, cell, getDataItemValueForColumn(d, m), m, d, self) : "";
         applyFormatResultToCellNode(formatterResult, cellNode);
         invalidatePostProcessingResults(row);
       }
@@ -3412,12 +3412,12 @@ if (typeof Slick === "undefined") {
 
         columnIdx = columnIdx | 0;
         var m = columns[columnIdx],
-            node = cacheEntry.cellNodesByColumnIdx[columnIdx][0];
+          node = cacheEntry.cellNodesByColumnIdx[columnIdx][0];
 
         if (row === activeRow && columnIdx === activeCell && currentEditor) {
           currentEditor.loadValue(d);
         } else if (d) {
-          formatterResult =  getFormatter(row, m)(row, columnIdx, getDataItemValueForColumn(d, m), m, d, self);
+          formatterResult = getFormatter(row, m)(row, columnIdx, getDataItemValueForColumn(d, m), m, d, self);
           applyFormatResultToCellNode(formatterResult, node);
         } else {
           node.innerHTML = "";
@@ -3429,21 +3429,21 @@ if (typeof Slick === "undefined") {
 
     function getViewportHeight() {
       if (!options.autoHeight || options.frozenColumn != -1) {
-        topPanelH = ( options.showTopPanel ) ? options.topPanelHeight + getVBoxDelta($topPanelScroller) : 0;
-        headerRowH = ( options.showHeaderRow ) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
-        footerRowH = ( options.showFooterRow ) ? options.footerRowHeight + getVBoxDelta($footerRowScroller) : 0;
+        topPanelH = (options.showTopPanel) ? options.topPanelHeight + getVBoxDelta($topPanelScroller) : 0;
+        headerRowH = (options.showHeaderRow) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
+        footerRowH = (options.showFooterRow) ? options.footerRowHeight + getVBoxDelta($footerRowScroller) : 0;
       }
       if (options.autoHeight) {
         var fullHeight = $paneHeaderL.outerHeight();
-        fullHeight += ( options.showHeaderRow ) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
-        fullHeight += ( options.showFooterRow ) ? options.footerRowHeight + getVBoxDelta($footerRowScroller) : 0;
+        fullHeight += (options.showHeaderRow) ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0;
+        fullHeight += (options.showFooterRow) ? options.footerRowHeight + getVBoxDelta($footerRowScroller) : 0;
         fullHeight += (getCanvasWidth() > viewportW) ? scrollbarDimensions.height : 0;
 
         viewportH = options.rowHeight
           * getDataLengthIncludingAddNew()
-          + ( ( options.frozenColumn == -1 ) ? fullHeight : 0 );
+          + ((options.frozenColumn == -1) ? fullHeight : 0);
       } else {
-        var columnNamesH = ( options.showColumnHeader ) ? parseFloat($.css($headerScroller[0], "height"))
+        var columnNamesH = (options.showColumnHeader) ? parseFloat($.css($headerScroller[0], "height"))
           + getVBoxDelta($headerScroller) : 0;
         var preHeaderH = (options.createPreHeaderPanel && options.showPreHeaderPanel) ? options.preHeaderPanelHeight + getVBoxDelta($preHeaderPanelScroller) : 0;
 
@@ -3501,8 +3501,8 @@ if (typeof Slick === "undefined") {
       if (options.autoHeight) {
         if (hasFrozenColumns()) {
           $container.height(
-              paneTopH
-              + parseFloat($.css($headerScrollerL[0], "height"))
+            paneTopH
+            + parseFloat($.css($headerScrollerL[0], "height"))
           );
         }
 
@@ -3583,9 +3583,9 @@ if (typeof Slick === "undefined") {
       render();
     }
 
-    function updatePagingStatusFromView( pagingInfo ) {
-        pagingActive = (pagingInfo.pageSize !== 0);
-        pagingIsLastPage = (pagingInfo.pageNum == pagingInfo.totalPages - 1);
+    function updatePagingStatusFromView(pagingInfo) {
+      pagingActive = (pagingInfo.pageSize !== 0);
+      pagingIsLastPage = (pagingInfo.pageNum == pagingInfo.totalPages - 1);
     }
 
     function updateRowCount() {
@@ -3594,9 +3594,9 @@ if (typeof Slick === "undefined") {
       var dataLength = getDataLength();
       var dataLengthIncludingAddNew = getDataLengthIncludingAddNew();
       var numberOfRows = 0;
-      var oldH = ( hasFrozenRows && !options.frozenBottom ) ? $canvasBottomL.height() : $canvasTopL.height();
+      var oldH = (hasFrozenRows && !options.frozenBottom) ? $canvasBottomL.height() : $canvasTopL.height();
 
-      if (hasFrozenRows ) {
+      if (hasFrozenRows) {
         var numberOfRows = getDataLength() - options.frozenRow;
       } else {
         var numberOfRows = dataLengthIncludingAddNew + (options.leaveSpaceForNewRows ? numVisibleRows - 1 : 0);
@@ -3625,7 +3625,7 @@ if (typeof Slick === "undefined") {
 
       var oldH = h;
       if (options.autoHeight) {
-        h =  options.rowHeight * numberOfRows;
+        h = options.rowHeight * numberOfRows;
       } else {
         th = Math.max(options.rowHeight * numberOfRows, tempViewportH - scrollbarDimensions.height);
         if (th < maxSupportedCssHeight) {
@@ -3746,10 +3746,10 @@ if (typeof Slick === "undefined") {
     function cleanUpCells(range, row) {
       // Ignore frozen rows
       if (hasFrozenRows
-        && ( ( options.frozenBottom && row > actualFrozenRow ) // Frozen bottom rows
-          || ( row <= actualFrozenRow )                     // Frozen top rows
-          )
-        ) {
+        && ((options.frozenBottom && row > actualFrozenRow) // Frozen bottom rows
+          || (row <= actualFrozenRow)                     // Frozen top rows
+        )
+      ) {
         return;
       }
 
@@ -3773,7 +3773,7 @@ if (typeof Slick === "undefined") {
         }
 
         // Ignore alwaysRenderedColumns
-        if (Array.isArray(columns) && columns[i] && columns[i].alwaysRenderColumn){
+        if (Array.isArray(columns) && columns[i] && columns[i].alwaysRenderColumn) {
           continue;
         }
 
@@ -3895,7 +3895,7 @@ if (typeof Slick === "undefined") {
         dataLength = getDataLength();
 
       for (var i = range.top, ii = range.bottom; i <= ii; i++) {
-        if (rowsCache[i] || ( hasFrozenRows && options.frozenBottom && i == getDataLength() )) {
+        if (rowsCache[i] || (hasFrozenRows && options.frozenBottom && i == getDataLength())) {
           continue;
         }
         renderedRows++;
@@ -3935,7 +3935,7 @@ if (typeof Slick === "undefined") {
       xRight.innerHTML = stringArrayR.join("");
 
       for (var i = 0, ii = rows.length; i < ii; i++) {
-        if (( hasFrozenRows ) && ( rows[i] >= actualFrozenRow )) {
+        if ((hasFrozenRows) && (rows[i] >= actualFrozenRow)) {
           if (hasFrozenColumns()) {
             rowsCache[rows[i]].rowNode = $()
               .add($(x.firstChild).appendTo($canvasBottomL))
@@ -4008,25 +4008,25 @@ if (typeof Slick === "undefined") {
       // add new rows & missing cells in existing rows
       if (lastRenderedScrollLeft != scrollLeft) {
 
-    	  if ( hasFrozenRows ) {
+        if (hasFrozenRows) {
 
-    		  var renderedFrozenRows = jQuery.extend(true, {}, rendered);
+          var renderedFrozenRows = jQuery.extend(true, {}, rendered);
 
-    		  if (options.frozenBottom) {
+          if (options.frozenBottom) {
 
-    			 renderedFrozenRows.top=actualFrozenRow;
-    			 renderedFrozenRows.bottom=getDataLength();
-    		  }
-    		  else {
+            renderedFrozenRows.top = actualFrozenRow;
+            renderedFrozenRows.bottom = getDataLength();
+          }
+          else {
 
-	             renderedFrozenRows.top=0;
-	             renderedFrozenRows.bottom=options.frozenRow;
-    		  }
+            renderedFrozenRows.top = 0;
+            renderedFrozenRows.bottom = options.frozenRow;
+          }
 
-    		  cleanUpAndRenderCells(renderedFrozenRows);
-    	  }
+          cleanUpAndRenderCells(renderedFrozenRows);
+        }
 
-          cleanUpAndRenderCells(rendered);
+        cleanUpAndRenderCells(rendered);
       }
 
       // render missing rows
@@ -4034,16 +4034,16 @@ if (typeof Slick === "undefined") {
 
       // Render frozen rows
       if (hasFrozenRows) {
-	      if (options.frozenBottom) {
-	        renderRows({
-	          top: actualFrozenRow, bottom: getDataLength() - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
-	        });
-	      }
-	      else {
-	          renderRows({
-	           top: 0, bottom: options.frozenRow - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
-	          });
-	        }
+        if (options.frozenBottom) {
+          renderRows({
+            top: actualFrozenRow, bottom: getDataLength() - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
+          });
+        }
+        else {
+          renderRows({
+            top: 0, bottom: options.frozenRow - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
+          });
+        }
       }
 
       postProcessFromRow = visible.top;
@@ -4189,7 +4189,7 @@ if (typeof Slick === "undefined") {
         }
       }
 
-      trigger(self.onScroll, {scrollLeft: scrollLeft, scrollTop: scrollTop});
+      trigger(self.onScroll, { scrollLeft: scrollLeft, scrollTop: scrollTop });
 
       if (hScrollDist || vScrollDist) return true;
       return false;
@@ -4398,8 +4398,8 @@ if (typeof Slick === "undefined") {
         var $gridCanvas = $rowNode.parents('.grid-canvas');
         var left = $gridCanvas.hasClass('grid-canvas-left');
 
-        if (zombieRowNodeFromLastMouseWheelEvent && zombieRowNodeFromLastMouseWheelEvent[left? 0:1] != rowNode) {
-          var zombieRow = zombieRowNodeFromLastMouseWheelEvent[left || zombieRowNodeFromLastMouseWheelEvent.length == 1? 0:1];
+        if (zombieRowNodeFromLastMouseWheelEvent && zombieRowNodeFromLastMouseWheelEvent[left ? 0 : 1] != rowNode) {
+          var zombieRow = zombieRowNodeFromLastMouseWheelEvent[left || zombieRowNodeFromLastMouseWheelEvent.length == 1 ? 0 : 1];
           zombieRow.parentElement.removeChild(zombieRow);
 
           zombieRowNodeFromLastMouseWheelEvent = null;
@@ -4453,30 +4453,30 @@ if (typeof Slick === "undefined") {
     }
 
     function handleKeyDown(e) {
-      trigger(self.onKeyDown, {row: activeRow, cell: activeCell}, e);
+      trigger(self.onKeyDown, { row: activeRow, cell: activeCell }, e);
       var handled = e.isImmediatePropagationStopped();
       var keyCode = Slick.keyCode;
 
       if (!handled) {
-         if (!e.shiftKey && !e.altKey) {
-            if (options.editable && currentEditor && currentEditor.keyCaptureList) {
-               if (currentEditor.keyCaptureList.indexOf(e.which) > -1) {
-                  return;
-               }
+        if (!e.shiftKey && !e.altKey) {
+          if (options.editable && currentEditor && currentEditor.keyCaptureList) {
+            if (currentEditor.keyCaptureList.indexOf(e.which) > -1) {
+              return;
             }
-            if (e.which == keyCode.HOME) {
-               handled = (e.ctrlKey) ? navigateTop() : navigateRowStart();
-            } else if (e.which == keyCode.END) {
-               handled = (e.ctrlKey) ? navigateBottom() : navigateRowEnd();
-            }
-         }
+          }
+          if (e.which == keyCode.HOME) {
+            handled = (e.ctrlKey) ? navigateTop() : navigateRowStart();
+          } else if (e.which == keyCode.END) {
+            handled = (e.ctrlKey) ? navigateBottom() : navigateRowEnd();
+          }
+        }
       }
       if (!handled) {
         if (!e.shiftKey && !e.altKey && !e.ctrlKey) {
           // editor may specify an array of keys to bubble
           if (options.editable && currentEditor && currentEditor.keyCaptureList) {
-            if (currentEditor.keyCaptureList.indexOf( e.which ) > -1) {
-                return;
+            if (currentEditor.keyCaptureList.indexOf(e.which) > -1) {
+              return;
             }
           }
           if (e.which == keyCode.ESCAPE) {
@@ -4551,7 +4551,7 @@ if (typeof Slick === "undefined") {
         return;
       }
 
-      trigger(self.onClick, {row: cell.row, cell: cell.cell}, e);
+      trigger(self.onClick, { row: cell.row, cell: cell.cell }, e);
       if (e.isImmediatePropagationStopped()) {
         return;
       }
@@ -4590,7 +4590,7 @@ if (typeof Slick === "undefined") {
         return;
       }
 
-      trigger(self.onDblClick, {row: cell.row, cell: cell.cell}, e);
+      trigger(self.onDblClick, { row: cell.row, cell: cell.cell }, e);
       if (e.isImmediatePropagationStopped()) {
         return;
       }
@@ -4617,7 +4617,7 @@ if (typeof Slick === "undefined") {
     function handleHeaderContextMenu(e) {
       var $header = $(e.target).closest(".slick-header-column", ".slick-header-columns");
       var column = $header && $header.data("column");
-      trigger(self.onHeaderContextMenu, {column: column}, e);
+      trigger(self.onHeaderContextMenu, { column: column }, e);
     }
 
     function handleHeaderClick(e) {
@@ -4625,20 +4625,20 @@ if (typeof Slick === "undefined") {
       var $header = $(e.target).closest(".slick-header-column", ".slick-header-columns");
       var column = $header && $header.data("column");
       if (column) {
-        trigger(self.onHeaderClick, {column: column}, e);
+        trigger(self.onHeaderClick, { column: column }, e);
       }
     }
 
     function handleFooterContextMenu(e) {
       var $footer = $(e.target).closest(".slick-footerrow-column", ".slick-footerrow-columns");
       var column = $footer && $footer.data("column");
-      trigger(self.onFooterContextMenu, {column: column}, e);
+      trigger(self.onFooterContextMenu, { column: column }, e);
     }
 
     function handleFooterClick(e) {
       var $footer = $(e.target).closest(".slick-footerrow-column", ".slick-footerrow-columns");
       var column = $footer && $footer.data("column");
-      trigger(self.onFooterClick, {column: column}, e);
+      trigger(self.onFooterClick, { column: column }, e);
     }
 
     function handleMouseEnter(e) {
@@ -4667,7 +4667,7 @@ if (typeof Slick === "undefined") {
         cell = 0;
       }
 
-      return {row: row, cell: cell - 1};
+      return { row: row, cell: cell - 1 };
     }
 
     function getCellFromNode(cellNode) {
@@ -4683,7 +4683,7 @@ if (typeof Slick === "undefined") {
       for (var row in rowsCache) {
         for (var i in rowsCache[row].rowNode) {
           if (rowsCache[row].rowNode[i] === rowNode)
-          return (row ? parseInt(row) : 0);
+            return (row ? parseInt(row) : 0);
         }
       }
       return null;
@@ -4691,16 +4691,16 @@ if (typeof Slick === "undefined") {
 
     function getFrozenRowOffset(row) {
       var offset =
-        ( hasFrozenRows )
-          ? ( options.frozenBottom )
-          ? ( row >= actualFrozenRow )
-          ? ( h < viewportTopH )
-          ? ( actualFrozenRow * options.rowHeight )
-          : h
-          : 0
-          : ( row >= actualFrozenRow )
-          ? frozenRowsHeight
-          : 0
+        (hasFrozenRows)
+          ? (options.frozenBottom)
+            ? (row >= actualFrozenRow)
+              ? (h < viewportTopH)
+                ? (actualFrozenRow * options.rowHeight)
+                : h
+              : 0
+            : (row >= actualFrozenRow)
+              ? frozenRowsHeight
+              : 0
           : 0;
 
       return offset;
@@ -4723,7 +4723,7 @@ if (typeof Slick === "undefined") {
         var isBottom = $cell.parents('.grid-canvas-bottom').length;
 
         if (isBottom) {
-          rowOffset = ( options.frozenBottom ) ? $canvasTopL.height() : frozenRowsHeight;
+          rowOffset = (options.frozenBottom) ? $canvasTopL.height() : frozenRowsHeight;
         }
 
         row = getCellFromPoint(e.clientX - c.left, e.clientY - c.top + rowOffset + $(document).scrollTop()).row;
@@ -4832,7 +4832,7 @@ if (typeof Slick === "undefined") {
         var isBottom = $activeCellNode.parents('.grid-canvas-bottom').length;
 
         if (hasFrozenRows && isBottom) {
-          rowOffset -= ( options.frozenBottom )
+          rowOffset -= (options.frozenBottom)
             ? $canvasTopL.height()
             : frozenRowsHeight;
         }
@@ -4912,7 +4912,7 @@ if (typeof Slick === "undefined") {
       if (!currentEditor) {
         return;
       }
-      trigger(self.onBeforeCellEditorDestroy, {editor: currentEditor});
+      trigger(self.onBeforeCellEditorDestroy, { editor: currentEditor });
       currentEditor.destroy();
       currentEditor = null;
 
@@ -4922,7 +4922,7 @@ if (typeof Slick === "undefined") {
         if (d) {
           var column = columns[activeCell];
           var formatter = getFormatter(activeRow, column);
-          var formatterResult =  formatter(activeRow, activeCell, getDataItemValueForColumn(d, column), column, d, self);
+          var formatterResult = formatter(activeRow, activeCell, getDataItemValueForColumn(d, column), column, d, self);
           applyFormatResultToCellNode(formatterResult, activeCellNode);
           invalidatePostProcessingResults(activeRow);
         }
@@ -4955,7 +4955,7 @@ if (typeof Slick === "undefined") {
       var columnDef = columns[activeCell];
       var item = getDataItem(activeRow);
 
-      if (trigger(self.onBeforeEditCell, {row: activeRow, cell: activeCell, item: item, column: columnDef}) === false) {
+      if (trigger(self.onBeforeEditCell, { row: activeRow, cell: activeCell, item: item, column: columnDef }) === false) {
         setFocus();
         return;
       }
@@ -4972,7 +4972,7 @@ if (typeof Slick === "undefined") {
 
       var metadata = data.getItemMetadata && data.getItemMetadata(activeRow);
       metadata = metadata && metadata.columns;
-      var columnMetaData = metadata && ( metadata[columnDef.id] || metadata[activeCell] );
+      var columnMetaData = metadata && (metadata[columnDef.id] || metadata[activeCell]);
 
       currentEditor = new useEditor({
         grid: self,
@@ -5099,7 +5099,7 @@ if (typeof Slick === "undefined") {
       if (!activeCellNode) {
         return null;
       } else {
-        return {row: activeRow, cell: activeCell};
+        return { row: activeRow, cell: activeCell };
       }
     }
 
@@ -5108,32 +5108,32 @@ if (typeof Slick === "undefined") {
     }
 
     function scrollRowIntoView(row, doPaging) {
-	    if (!hasFrozenRows ||
-	  	  ( !options.frozenBottom && row > actualFrozenRow - 1 ) ||
-	  	  ( options.frozenBottom && row < actualFrozenRow - 1 ) ) {
+      if (!hasFrozenRows ||
+        (!options.frozenBottom && row > actualFrozenRow - 1) ||
+        (options.frozenBottom && row < actualFrozenRow - 1)) {
 
-	      var viewportScrollH = $viewportScrollContainerY.height();
+        var viewportScrollH = $viewportScrollContainerY.height();
 
-	      // if frozen row on top
-	      // subtract number of frozen row
-	      var rowNumber = ( hasFrozenRows && !options.frozenBottom ? row - options.frozenRow : row );
+        // if frozen row on top
+        // subtract number of frozen row
+        var rowNumber = (hasFrozenRows && !options.frozenBottom ? row - options.frozenRow : row);
 
-	      var rowAtTop = rowNumber * options.rowHeight;
-	      var rowAtBottom = (rowNumber + 1) * options.rowHeight
-	        - viewportScrollH
-	        + (viewportHasHScroll ? scrollbarDimensions.height : 0);
+        var rowAtTop = rowNumber * options.rowHeight;
+        var rowAtBottom = (rowNumber + 1) * options.rowHeight
+          - viewportScrollH
+          + (viewportHasHScroll ? scrollbarDimensions.height : 0);
 
-	      // need to page down?
-	      if ((rowNumber + 1) * options.rowHeight > scrollTop + viewportScrollH + offset) {
-	        scrollTo(doPaging ? rowAtTop : rowAtBottom);
-	        render();
-	      }
-	      // or page up?
-	      else if (rowNumber * options.rowHeight < scrollTop + offset) {
-	        scrollTo(doPaging ? rowAtBottom : rowAtTop);
-	        render();
-	      }
-	    }
+        // need to page down?
+        if ((rowNumber + 1) * options.rowHeight > scrollTop + viewportScrollH + offset) {
+          scrollTo(doPaging ? rowAtTop : rowAtBottom);
+          render();
+        }
+        // or page up?
+        else if (rowNumber * options.rowHeight < scrollTop + offset) {
+          scrollTo(doPaging ? rowAtBottom : rowAtTop);
+          render();
+        }
+      }
     }
 
     function scrollRowToTop(row) {
@@ -5143,8 +5143,8 @@ if (typeof Slick === "undefined") {
 
     function scrollPage(dir) {
       var deltaRows = dir * numVisibleRows;
-        /// First fully visible row crosses the line with
-        /// y == bottomOfTopmostFullyVisibleRow
+      /// First fully visible row crosses the line with
+      /// y == bottomOfTopmostFullyVisibleRow
       var bottomOfTopmostFullyVisibleRow = scrollTop + options.rowHeight - 1;
       scrollTo((getRowFromPosition(bottomOfTopmostFullyVisibleRow) + deltaRows) * options.rowHeight);
       render();
@@ -5182,43 +5182,43 @@ if (typeof Slick === "undefined") {
     }
 
     function navigatePageUp() {
-       scrollPage(-1);
+      scrollPage(-1);
     }
 
     function navigateTop() {
-       navigateToRow(0);
+      navigateToRow(0);
     }
 
     function navigateBottom() {
-       navigateToRow(getDataLength()-1);
+      navigateToRow(getDataLength() - 1);
     }
 
     function navigateToRow(row) {
-       var num_rows = getDataLength();
-       if (!num_rows) return true;
+      var num_rows = getDataLength();
+      if (!num_rows) return true;
 
-       if (row < 0) row = 0;
-       else if (row >= num_rows) row = num_rows - 1;
+      if (row < 0) row = 0;
+      else if (row >= num_rows) row = num_rows - 1;
 
-       scrollCellIntoView(row, 0, true);
-       if (options.enableCellNavigation && activeRow != null) {
-          var cell = 0, prevCell = null;
-          var prevActivePosX = activePosX;
-          while (cell <= activePosX) {
-             if (canCellBeActive(row, cell)) {
-                prevCell = cell;
-             }
-             cell += getColspan(row, cell);
+      scrollCellIntoView(row, 0, true);
+      if (options.enableCellNavigation && activeRow != null) {
+        var cell = 0, prevCell = null;
+        var prevActivePosX = activePosX;
+        while (cell <= activePosX) {
+          if (canCellBeActive(row, cell)) {
+            prevCell = cell;
           }
+          cell += getColspan(row, cell);
+        }
 
-          if (prevCell !== null) {
-             setActiveCellInternal(getCellNode(row, prevCell));
-             activePosX = prevActivePosX;
-          } else {
-             resetActiveCell();
-          }
-       }
-       return true;
+        if (prevCell !== null) {
+          setActiveCellInternal(getCellNode(row, prevCell));
+          activePosX = prevActivePosX;
+        } else {
+          resetActiveCell();
+        }
+      }
+      return true;
     }
 
     function getColspan(row, cell) {
@@ -5430,25 +5430,25 @@ if (typeof Slick === "undefined") {
     }
 
     function gotoRowStart(row, cell, posX) {
-       var newCell = findFirstFocusableCell(row);
-       if (newCell === null) return null;
+      var newCell = findFirstFocusableCell(row);
+      if (newCell === null) return null;
 
-       return {
-          "row": row,
-          "cell": newCell,
-          "posX": newCell
-       };
+      return {
+        "row": row,
+        "cell": newCell,
+        "posX": newCell
+      };
     }
 
     function gotoRowEnd(row, cell, posX) {
-       var newCell = findLastFocusableCell(row);
-       if (newCell === null) return null;
+      var newCell = findLastFocusableCell(row);
+      if (newCell === null) return null;
 
-       return {
-          "row": row,
-          "cell": newCell,
-          "posX": newCell
-       };
+      return {
+        "row": row,
+        "cell": newCell,
+        "posX": newCell
+      };
     }
 
     function navigateRight() {
@@ -5472,15 +5472,15 @@ if (typeof Slick === "undefined") {
     }
 
     function navigatePrev() {
-       return navigate("prev");
+      return navigate("prev");
     }
 
     function navigateRowStart() {
-       return navigate("home");
+      return navigate("home");
     }
 
     function navigateRowEnd() {
-       return navigate("end");
+      return navigate("end");
     }
 
     /**
@@ -5532,9 +5532,9 @@ if (typeof Slick === "undefined") {
 
         var isAddNewRow = (pos.row == getDataLength());
 
-        if (( !options.frozenBottom && pos.row >= actualFrozenRow )
-          || ( options.frozenBottom && pos.row < actualFrozenRow )
-          ) {
+        if ((!options.frozenBottom && pos.row >= actualFrozenRow)
+          || (options.frozenBottom && pos.row < actualFrozenRow)
+        ) {
           scrollCellIntoView(pos.row, pos.cell, !isAddNewRow && options.emulatePagingWhenScrolling);
         }
         setActiveCellInternal(getCellNode(pos.row, pos.cell));
@@ -5591,7 +5591,7 @@ if (typeof Slick === "undefined") {
 
     function canCellBeActive(row, cell) {
       if (!options.enableCellNavigation || row >= getDataLengthIncludingAddNew() ||
-          row < 0 || cell >= columns.length || cell < 0) {
+        row < 0 || cell >= columns.length || cell < 0) {
         return false;
       }
 
@@ -5706,7 +5706,7 @@ if (typeof Slick === "undefined") {
               var newItem = {};
               currentEditor.applyValue(newItem, currentEditor.serializeValue());
               makeActiveCellNormal();
-              trigger(self.onAddNewRow, {item: newItem, column: column});
+              trigger(self.onAddNewRow, { item: newItem, column: column });
             }
 
             // check whether the lock has been re-acquired by event handlers


### PR DESCRIPTION
Our company use the slickgrid and we had an issue with the vertical scrollbar not going all the way down in some scenarios. There is a gap at the bottom and there is no way to drag the scrollbar all the way down. The horizontal scrollbar is visible and the fault is that the code does not acknowledge this. There is a line in the code that determines if the horizontal scrollbar is visible but this misses with one pixel. The changed formula uses greater than or equal instead of only greater than. I saw that this solution was proposed in a PR long time ago to mleibman:
https://github.com/mleibman/SlickGrid/pull/1030/files