### PR TITLE
fix(core): we should never show vertical scroll on left frozen container

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1905,7 +1905,7 @@ if (typeof Slick === "undefined") {
     function setOverflow() {
       $viewportTopL.css({
         'overflow-x': ( hasFrozenColumns() ) ? ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll' ) : ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'hidden' : 'auto' ),
-        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : (( hasFrozenColumns() ) ? ( hasFrozenRows ? 'hidden' : 'hidden' ) : ( hasFrozenRows ? 'scroll' : 'auto' ))
+        'overflow-y': (!hasFrozenColumns() && options.alwaysShowVerticalScroll) ? "scroll" : (( hasFrozenColumns() ) ? ( hasFrozenRows ? 'hidden' : 'hidden' ) : ( hasFrozenRows ? 'scroll' : 'auto' ))
       });
 
       $viewportTopR.css({
@@ -1915,7 +1915,7 @@ if (typeof Slick === "undefined") {
 
       $viewportBottomL.css({
         'overflow-x': ( hasFrozenColumns() ) ? ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'scroll' : 'auto'   ): ( hasFrozenRows && !options.alwaysAllowHorizontalScroll ? 'auto' : 'auto'   ),
-        'overflow-y': options.alwaysShowVerticalScroll ? "scroll" : (( hasFrozenColumns() ) ? ( hasFrozenRows ? 'hidden' : 'hidden' ): ( hasFrozenRows ? 'scroll' : 'auto' ))
+        'overflow-y': (!hasFrozenColumns() && options.alwaysShowVerticalScroll) ? "scroll" : (( hasFrozenColumns() ) ? ( hasFrozenRows ? 'hidden' : 'hidden' ): ( hasFrozenRows ? 'scroll' : 'auto' ))
       });
 
       $viewportBottomR.css({


### PR DESCRIPTION
- we should never show a vertical scroll on the left container when having a frozen grid, even when flag `alwaysShowVerticalScroll` is set to True (in that case, the flag should display a scroll ONLY for the right container)
- for reference, the flag `alwaysShowVerticalScroll` is only used for 1 reason, to show a vertical scroll so that the Grid Menu icon doesn't go over a header column title (see print screen 2).

**without the fix**
![image](https://user-images.githubusercontent.com/643976/95117678-fa99f200-0716-11eb-93c3-b0192f941cbc.png)

**with the Fix**
![image](https://user-images.githubusercontent.com/643976/95117833-3339cb80-0717-11eb-8576-fe38a29515c9.png)

