### PR TITLE
WIP - fix(dataView): add option to apply row selection to all pages

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "Cypress Open GUI",
       "type": "shell",
-      "command": "npm run cypress:open",
+      "command": "npm run cypress",
       "problemMatcher": []
     },
     {

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ We also welcome any new contributions (tests or fixes) and if you wish to add Cy
 ```bash
 npm install             # install all npm packages
 npm run serve           # run a local http server on port 8080
-npm run cypress:open    # open Cypress tool
+npm run cypress         # open Cypress tool
 ```
 Once the Cypress UI is open, you can then click on "Run all Specs" to execute all E2E browser tests.

--- a/cypress/integration/example-checkbox-header-row.spec.js
+++ b/cypress/integration/example-checkbox-header-row.spec.js
@@ -98,4 +98,59 @@ describe('Example - Checkbox Header Row', () => {
       expect(win.console.log).to.be.calledWith('Selected Rows: ');
     });
   });
+
+  it('Should display "Showing page 1 of 4" text after changing Pagination to 25 items per page', () => {
+    cy.get('.ui-icon-lightbulb')
+      .click();
+
+    cy.get('.slick-pager-settings-expanded')
+      .should('be.visible');
+
+    cy.get('.slick-pager-settings-expanded')
+      .contains('25')
+      .click();
+
+    cy.get('.slick-pager-status')
+      .contains('Showing page 1 of 4');
+  });
+
+  it('should click on "Select All" checkbox and expect all row selected in current page', () => {
+    const expectedRows = '1,3,5,7,9,11,13,15,17,19,21,23';
+
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .click({ force: true });
+
+    cy.get('#selectedRows')
+      .contains(expectedRows);
+
+    cy.window().then((win) => {
+      expect(win.console.log).to.have.callCount(2);
+      expect(win.console.log).to.be.calledWith('Previously Selected Rows: ');
+      expect(win.console.log).to.be.calledWith(`Selected Rows: ${expectedRows}`);
+    });
+  });
+
+  it('should go to next page and still expect all row selected in current page', () => {
+    cy.get('.ui-icon-seek-next')
+      .click();
+
+    cy.get('.slick-cell-checkboxsel input:checked')
+    .should('have.length', 11);
+  });
+
+  it('should go to last page and still expect all row selected in current page', () => {
+    cy.get('.ui-icon-seek-end')
+      .click();
+
+    cy.get('.slick-cell-checkboxsel input:checked')
+    .should('have.length', 11);
+  });
+
+  it('should go back to first page and still expect all row selected in current page', () => {
+    cy.get('.ui-icon-seek-first')
+      .click();
+
+    cy.get('.slick-cell-checkboxsel input:checked')
+    .should('have.length', 11);
+  });
 });

--- a/cypress/integration/example-checkbox-header-row.spec.js
+++ b/cypress/integration/example-checkbox-header-row.spec.js
@@ -88,9 +88,9 @@ describe('Example - Checkbox Header Row', () => {
       .click({ force: true });
 
     cy.get('#selectedRows')
-    .invoke('text').then((text => {
+      .invoke('text').then((text => {
         expect(text.trim()).to.eq('')
-    }));
+      }));
 
     cy.window().then((win) => {
       expect(win.console.log).to.have.callCount(2);
@@ -114,7 +114,7 @@ describe('Example - Checkbox Header Row', () => {
       .contains('Showing page 1 of 4');
   });
 
-  it('should click on "Select All" checkbox and expect all row selected in current page', () => {
+  it('should click on "Select All" checkbox and expect all rows selected in current page', () => {
     const expectedRows = '1,3,5,7,9,11,13,15,17,19,21,23';
 
     cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
@@ -130,27 +130,91 @@ describe('Example - Checkbox Header Row', () => {
     });
   });
 
-  it('should go to next page and still expect all row selected in current page', () => {
+  it('should go to next page and still expect all rows selected in current page', () => {
     cy.get('.ui-icon-seek-next')
       .click();
 
     cy.get('.slick-cell-checkboxsel input:checked')
-    .should('have.length', 11);
+      .should('have.length', 11);
   });
 
-  it('should go to last page and still expect all row selected in current page', () => {
+  it('should go to last page and still expect all rows selected in current page', () => {
     cy.get('.ui-icon-seek-end')
       .click();
 
     cy.get('.slick-cell-checkboxsel input:checked')
-    .should('have.length', 11);
+      .should('have.length', 11);
+
+    cy.get('.slick-pager-status')
+      .contains('Showing page 4 of 4');
+
+    cy.get('#selectedRows')
+      .should('contain', '0,2,4,6,8,10,12,14,16,18,20,22,24');
+
+    cy.get('#selectedIds')
+      .should('contain', '9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99,101,103,105,107');
   });
 
-  it('should go back to first page and still expect all row selected in current page', () => {
+  it('should uncheck first checkbox and expect the "Select All" button to be unchecked', () => {
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .should('be.checked');
+
+    cy.get('.slick-row:nth(0) .slick-cell:nth(0) input[type=checkbox]')
+      .click({ force: true });
+
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .should('not.be.checked');
+
+    cy.get('.slick-cell-checkboxsel input:checked')
+      .should('have.length', 10);
+
+    cy.get('#selectedRows')
+      .should('contain', '2,4,6,8,10,12,14,16,18,20,22,24');
+
+    cy.get('#selectedIds')
+      .should('contain', '9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,85,87,89,91,93,95,97,99,101,103,105,107');
+  });
+
+  it('should go back to first page and still expect all rows selected in current page', () => {
     cy.get('.ui-icon-seek-first')
       .click();
 
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .should('not.be.checked');
+
     cy.get('.slick-cell-checkboxsel input:checked')
-    .should('have.length', 11);
+      .should('have.length', 11);
+
+    cy.get('.slick-pager-status')
+      .contains('Showing page 1 of 4');
+
+    cy.get('#selectedRows')
+      .should('contain', '1,3,5,7,9,11,13,15,17,19,21,23');
+
+    cy.get('#selectedIds')
+      .should('contain', '9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,85,87,89,91,93,95,97,99,101,103,105,107');
+  });
+
+  it('should go back to last page then re-select the first row and expect "Select All" to be checked', () => {
+    cy.get('.ui-icon-seek-end')
+      .click();
+
+    cy.get('.slick-row:nth(0) .slick-cell:nth(0) input[type=checkbox]')
+      .click({ force: true });
+
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .should('be.checked');
+
+    cy.get('.slick-cell-checkboxsel input:checked')
+      .should('have.length', 11);
+
+    cy.get('.slick-pager-status')
+      .contains('Showing page 4 of 4');
+
+    cy.get('#selectedRows')
+      .should('contain', '0,2,4,6,8,10,12,14,16,18,20,22,24');
+
+    cy.get('#selectedIds')
+      .should('contain', '9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99,101,103,105,107');
   });
 });

--- a/cypress/integration/example-checkbox-header-row.spec.js
+++ b/cypress/integration/example-checkbox-header-row.spec.js
@@ -66,7 +66,7 @@ describe('Example - Checkbox Header Row', () => {
   });
 
   it('should click on Select All and display previous and new selected rows', () => {
-    const expectedRows = '1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99';
+    const expectedRows = '1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99,101,103,105,107,109,111,113,115,117,119,121,123,125,127,129,131,133,135,137,139,141,143,145,147,149';
 
     cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
       .click({ force: true });
@@ -82,7 +82,7 @@ describe('Example - Checkbox Header Row', () => {
   });
 
   it('should click on Select All again and expect no new selected rows', () => {
-    const expectedPreviousRows = '1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99';
+    const expectedPreviousRows = '1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99,101,103,105,107,109,111,113,115,117,119,121,123,125,127,129,131,133,135,137,139,141,143,145,147,149';
 
     cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
       .click({ force: true });
@@ -99,7 +99,7 @@ describe('Example - Checkbox Header Row', () => {
     });
   });
 
-  it('Should display "Showing page 1 of 4" text after changing Pagination to 25 items per page', () => {
+  it('Should display "Showing page 1 of 6" text after changing Pagination to 25 items per page', () => {
     cy.get('.ui-icon-lightbulb')
       .click();
 
@@ -111,7 +111,7 @@ describe('Example - Checkbox Header Row', () => {
       .click();
 
     cy.get('.slick-pager-status')
-      .contains('Showing page 1 of 4');
+      .contains('Showing page 1 of 6');
   });
 
   it('should click on "Select All" checkbox and expect all rows selected in current page', () => {
@@ -146,7 +146,7 @@ describe('Example - Checkbox Header Row', () => {
       .should('have.length', 11);
 
     cy.get('.slick-pager-status')
-      .contains('Showing page 4 of 4');
+      .contains('Showing page 6 of 6');
 
     cy.get('#selectedRows')
       .should('contain', '0,2,4,6,8,10,12,14,16,18,20,22,24');
@@ -172,7 +172,7 @@ describe('Example - Checkbox Header Row', () => {
       .should('contain', '2,4,6,8,10,12,14,16,18,20,22,24');
 
     cy.get('#selectedIds')
-      .should('contain', '9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,85,87,89,91,93,95,97,99,101,103,105,107');
+      .should('contain', '9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99,101,103,105,107,109,111,113,115,117,119,121,123,125,127,129,131,135,137,139,141,143,145,147,149,151,153,155,157');
   });
 
   it('should go back to first page and still expect all rows selected in current page', () => {
@@ -186,13 +186,13 @@ describe('Example - Checkbox Header Row', () => {
       .should('have.length', 11);
 
     cy.get('.slick-pager-status')
-      .contains('Showing page 1 of 4');
+      .contains('Showing page 1 of 6');
 
     cy.get('#selectedRows')
       .should('contain', '1,3,5,7,9,11,13,15,17,19,21,23');
 
     cy.get('#selectedIds')
-      .should('contain', '9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,85,87,89,91,93,95,97,99,101,103,105,107');
+      .should('contain', '9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99,101,103,105,107,109,111,113,115,117,119,121,123,125,127,129,131,135,137,139,141,143,145,147,149,151,153,155,157');
   });
 
   it('should go back to last page then re-select the first row and expect "Select All" to be checked', () => {
@@ -209,12 +209,61 @@ describe('Example - Checkbox Header Row', () => {
       .should('have.length', 11);
 
     cy.get('.slick-pager-status')
-      .contains('Showing page 4 of 4');
+      .contains('Showing page 6 of 6');
 
     cy.get('#selectedRows')
       .should('contain', '0,2,4,6,8,10,12,14,16,18,20,22,24');
 
     cy.get('#selectedIds')
       .should('contain', '9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99,101,103,105,107');
+  });
+
+  it('should have lower count of selected Ids after filtering data', () => {
+    let prevSelectedIdsCount = 0;
+    let newSelectedIdsCount = 0;
+    let prevSelectedRowsCount = 0;
+    let newSelectedRowsCount = 0;
+
+    cy.get('#idsCount')
+      .then($elm => {
+        console.log($elm)
+        prevSelectedIdsCount = +$elm[0].textContent;
+        expect(prevSelectedIdsCount).to.be.greaterThan(0);
+      });
+
+    cy.get('#rowsCount')
+      .then($elm => {
+        console.log($elm)
+        prevSelectedRowsCount = +$elm[0].textContent;
+        expect(prevSelectedRowsCount).to.be.greaterThan(0);
+        expect(prevSelectedIdsCount).not.to.be.eq(prevSelectedRowsCount);
+      });
+
+    cy.get('.slick-pager-status')
+      .should('not.contain', 'Showing page 1 of 1');
+
+    cy.get('#myGrid')
+      .find('.slick-headerrow-column.l1.r1')
+      .find('input')
+      .type('5');
+
+    cy.get('#idsCount')
+      .then($elm => {
+        newSelectedIdsCount = +$elm[0].textContent;
+        expect(newSelectedIdsCount).to.be.lessThan(prevSelectedIdsCount);
+      });
+
+    cy.get('#rowsCount')
+      .then($elm => {
+        newSelectedRowsCount = +$elm[0].textContent;
+      });
+
+    cy.get('.slick-pager-status')
+      .then($elm => {
+        const pagerInfo = $elm[0].textContent;
+        if (pagerInfo === 'Showing page 1 of 1') {
+          expect(newSelectedIdsCount).to.be.eq(newSelectedRowsCount);
+        }
+      });
   });
 });

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -94,12 +94,12 @@
 
     <hr/>
 
-    <h3>Selected Rows:</h3>
+    <h3>Selected Rows (<span id="rowsCount">0</span>):</h3>
     <div id="selectedRows" style="overflow-x: auto;"></div>
     
     <hr/>
 
-    <h3>Selected Ids (index/id offset=<span id="idOffset"></span>):</h3>
+    <h3>Selected Ids (<span id="idsCount">0</span>) with index/id offset=<span id="idOffset"></span>:</h3>
     <div id="selectedIds" style="overflow-x: auto;"></div>
   </div>
 </div>
@@ -137,7 +137,7 @@
   
   // add an offset so that the IDs are not equal to the row number, to fully validate that DataView selected IDs work as intended
   var idOffset = 8;
-  $('#idOffset').text(idOffset); 
+  $('#idOffset').text(idOffset);
 
   checkboxSelector = new Slick.CheckboxSelectColumn({
     cssClass: "slick-cell-checkboxsel",
@@ -188,7 +188,7 @@
   }
 
   $(function () {
-    for (var i = 0; i < 100; i++) {
+    for (var i = 0; i < 150; i++) {
       var d = (data[i] = {});
       d["id"] = i + idOffset;
       for (var j = 0; j < columns.length; j++) {
@@ -223,12 +223,14 @@
       console.log("Previously Selected Rows: " + previousSelectedRows.toString());
       console.log("Selected Rows: " + sortedSelectedRows.toString());
       $('#selectedRows').text(sortedSelectedRows.toString());
+      $('#rowsCount').text(sortedSelectedRows.length); 
     });
     
     dataView.onSelectedRowIdsChanged.subscribe(function(e, args) {
-      var sortedSelectedIds = args.ids.sort(function (a, b) { return a - b });
-      // console.log("Selected Ids: " + sortedSelectedRows.toString());
+      var sortedSelectedIds = args.filteredIds.sort(function (a, b) { return a - b });
+      // console.log("Selected Ids: " + sortedSelectedIds.toString());
       $('#selectedIds').text(sortedSelectedIds.toString());
+      $('#idsCount').text(sortedSelectedIds.length); 
     });
 
     $(grid.getHeaderRow()).on("change keyup", ":input", function (e) {

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -96,6 +96,11 @@
 
     <h3>Selected Rows:</h3>
     <div id="selectedRows" style="overflow-x: auto;"></div>
+    
+    <hr/>
+
+    <h3>Selected Ids (index/id offset=<span id="idOffset"></span>):</h3>
+    <div id="selectedIds" style="overflow-x: auto;"></div>
   </div>
 </div>
 
@@ -129,6 +134,10 @@
   var checkboxSelector;
   var isSelectAllCheckboxHidden = false;
   var isSelectAllShownAsColumnTitle = false;
+  
+  // add an offset so that the IDs are not equal to the row number, to fully validate that DataView selected IDs work as intended
+  var idOffset = 8;
+  $('#idOffset').text(idOffset); 
 
   checkboxSelector = new Slick.CheckboxSelectColumn({
     cssClass: "slick-cell-checkboxsel",
@@ -146,7 +155,7 @@
 
   for (var i = 0; i < 10; i++) {
     columns.push({
-      id: i,
+      id: i + idOffset,
       name: String.fromCharCode("A".charCodeAt(0) + i),
       field: i,
       width: 60
@@ -181,7 +190,7 @@
   $(function () {
     for (var i = 0; i < 100; i++) {
       var d = (data[i] = {});
-      d["id"] = i;
+      d["id"] = i + idOffset;
       for (var j = 0; j < columns.length; j++) {
         d[j] = Math.round(Math.random() * 10);
       }
@@ -214,6 +223,12 @@
       console.log("Previously Selected Rows: " + previousSelectedRows.toString());
       console.log("Selected Rows: " + sortedSelectedRows.toString());
       $('#selectedRows').text(sortedSelectedRows.toString());
+    });
+    
+    dataView.onSelectedRowIdsChanged.subscribe(function(e, args) {
+      var sortedSelectedIds = args.ids.sort(function (a, b) { return a - b });
+      // console.log("Selected Ids: " + sortedSelectedRows.toString());
+      $('#selectedIds').text(sortedSelectedIds.toString());
     });
 
     $(grid.getHeaderRow()).on("change keyup", ":input", function (e) {

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -5,6 +5,7 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
+  <link rel="stylesheet" href="../controls/slick.pager.css" type="text/css" />
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" crossorigin="anonymous">
@@ -69,6 +70,7 @@
 <div style="position:relative">
   <div style="width:600px;">
     <div id="myGrid" style="width:100%;height:500px;"></div>
+    <div id="pager" style="width:100%;height:20px;"></div>
   </div>
 
   <div class="options-panel">
@@ -105,6 +107,7 @@
 
 <script src="../plugins/slick.checkboxselectcolumn.js"></script>
 <script src="../plugins/slick.rowselectionmodel.js"></script>
+<script src="../controls/slick.pager.js"></script>
 <script src="../controls/slick.columnpicker.js"></script>
 
 <script src="../slick.core.js"></script>
@@ -129,6 +132,7 @@
 
   checkboxSelector = new Slick.CheckboxSelectColumn({
     cssClass: "slick-cell-checkboxsel",
+    applySelectOnAllPages: true, // defaults to false, when that is enabled the "Select All" will be applied to all pages
     hideInColumnTitleRow: !isSelectAllShownAsColumnTitle,
     hideInFilterHeaderRow: isSelectAllShownAsColumnTitle,
 
@@ -187,7 +191,9 @@
     grid = new Slick.Grid("#myGrid", dataView, columns, options);
     grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
     grid.registerPlugin(checkboxSelector);
+    dataView.syncGridSelection(grid, true, true);
 
+    var pager = new Slick.Controls.Pager(dataView, grid, $("#pager"));
     var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "slickgrid",
-  "version": "2.4.28",
+  "version": "2.4.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -198,9 +198,9 @@
       "dev": true
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
-      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
+      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
       "dev": true
     },
     "@types/sizzle": {
@@ -578,9 +578,9 @@
       }
     },
     "cypress": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.1.0.tgz",
-      "integrity": "sha512-craPRO+Viu4268s7eBvX5VJW8aBYcAQT+EwEccQSMY+eH1ZPwnxIgyDlmMWvxLVX9SkWxOlZbEycPyzanQScBQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.4.0.tgz",
+      "integrity": "sha512-BJR+u3DRSYMqaBS1a3l1rbh5AkMRHugbxcYYzkl+xYlO6dzcJVE8uAhghzVI/hxijCyBg1iuSe4TRp/g1PUg8Q==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -1809,9 +1809,9 @@
       }
     },
     "moment": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
       "dev": true
     },
     "ms": {
@@ -2104,9 +2104,9 @@
       }
     },
     "rxjs": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-      "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -2386,9 +2386,9 @@
       }
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/6pac/SlickGrid#readme",
   "scripts": {
     "cypress:ci": "node node_modules/cypress/bin/cypress run --reporter xunit --reporter-options output=testresult.xml",
-    "cypress:open": "node node_modules/cypress/bin/cypress open",
+    "cypress": "node node_modules/cypress/bin/cypress open",
     "serve": "http-server ./ -p 8080 -a localhost -s"
   },
   "dependencies": {
@@ -34,7 +34,7 @@
     "jquery-ui": ">=1.8.0"
   },
   "devDependencies": {
-    "cypress": "^5.1.0",
+    "cypress": "^5.4.0",
     "eslint": "^7.8.1",
     "http-server": "^0.12.3"
   }

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -159,7 +159,7 @@
     }
 
     function handleDataViewSelectedIdsChanged(e, args) {
-      var selectedIds = _dataView.getAllSelectedIds();
+      var selectedIds = _dataView.getAllSelectedFilteredIds();
       var disabledCount = 0;
       if (typeof _selectableOverride === 'function') {
         for (k = 0; k < _dataView.getItemsCount(); k++) {
@@ -260,7 +260,7 @@
 
         var isAllSelected = $(e.target).is(":checked") || false;
         var rows = [];
-        if (isAllSelected) {          
+        if (isAllSelected) {
           for (var i = 0; i < _grid.getDataLength(); i++) {
             // Get the row and check it's a selectable row before pushing it onto the stack
             var rowItem = _grid.getDataItem(i);

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -246,7 +246,6 @@
           isAllSelected = true;
         }
         if (_isUsingDataView && _dataView && _dataView.setAllSelectedIds && options.applySelectOnAllPages) {
-          console.log('setAllSelectedIds')
           _dataView.setAllSelectedIds(isAllSelected);
         }
         _grid.setSelectedRows(rows);

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -138,7 +138,7 @@
       _grid.render();
       _isSelectAllChecked = selectedRows.length && selectedRows.length + disabledCount >= _grid.getDataLength();
 
-      if (!_isUsingDataView) {
+      if (!_isUsingDataView || !_options.applySelectOnAllPages) {
         if (!_options.hideInColumnTitleRow && !_options.hideSelectAllCheckbox) {
           renderSelectAllCheckbox(_isSelectAllChecked);
         }
@@ -147,7 +147,7 @@
           selectAllElm.prop("checked", _isSelectAllChecked);
         }
       }
-      
+
       // Remove items that shouln't of been selected in the first place (Got here Ctrl + click)
       if (removeList.length > 0) {
         for (i = 0; i < removeList.length; i++) {

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -160,18 +160,24 @@
 
     function handleDataViewSelectedIdsChanged(e, args) {
       var selectedIds = _dataView.getAllSelectedFilteredIds();
+      var filteredItems = _dataView.getFilteredItems();
       var disabledCount = 0;
-      if (typeof _selectableOverride === 'function') {
+
+      if (typeof _selectableOverride === 'function' && selectedIds.length > 0) {
         for (k = 0; k < _dataView.getItemsCount(); k++) {
           // If we are allowed to select the row
           var dataItem = _dataView.getItemByIdx(k);
-          if (!checkSelectableOverride(i, dataItem, _grid)) {
+          var idProperty = _dataView.getIdPropertyName();
+          var dataItemId = dataItem[idProperty];
+          var foundItemIdx = filteredItems.findIndex(function (item) {
+            return item[idProperty] === dataItemId;
+          });
+          if (foundItemIdx >= 0 && !checkSelectableOverride(i, dataItem, _grid)) {
             disabledCount++;
           }
         }
       }
-
-      _isSelectAllChecked = selectedIds.length && selectedIds.length + disabledCount >= _dataView.getItemsCount();
+      _isSelectAllChecked = selectedIds.length && selectedIds.length + disabledCount >= filteredItems.length;
 
       if (!_options.hideInColumnTitleRow && !_options.hideSelectAllCheckbox) {
         renderSelectAllCheckbox(_isSelectAllChecked);

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -1159,7 +1159,7 @@
      */
     function getAllSelectedFilteredIds() {
       return getAllSelectedFilteredItems().map(function (item) {
-        return filteredItems[idProperty];
+        return item[idProperty];
       });
     }
 
@@ -1216,6 +1216,8 @@
      * Note: when using Pagination it will also include hidden selections assuming `preserveHiddenOnSelectionChange` is set to true.
      */
     function getAllSelectedFilteredItems() {
+      if (!Array.isArray(selectedRowIds)) { return []; }
+
       var intersection = filteredItems.filter(function (a) {
         return selectedRowIds.some(function (b) {
           return a[idProperty] === b;

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -23,6 +23,7 @@
    */
   function DataView(options) {
     var self = this;
+    var _grid; // grid object will be defined only after using "syncGridSelection()" method"
 
     var defaults = {
       groupItemMetadataProvider: null,
@@ -79,6 +80,7 @@
     var totalRows = 0;
 
     // events
+    var onSelectedRowIdsChanged = new Slick.Event();
     var onSetItemsCalled = new Slick.Event();
     var onRowCountChanged = new Slick.Event();
     var onRowsChanged = new Slick.Event();
@@ -469,6 +471,10 @@
         }
       }
       return low;
+    }
+
+    function getItemsCount() {
+      return items.length;
     }
 
     function getLength() {
@@ -1073,10 +1079,10 @@
      * @method syncGridSelection
      */
     function syncGridSelection(grid, preserveHidden, preserveHiddenOnSelectionChange) {
+      _grid = grid;
       var self = this;
       var inHandler;
       selectedRowIds = self.mapRowsToIds(grid.getSelectedRows());
-      var onSelectedRowIdsChanged = new Slick.Event();
 
       function setSelectedRowIds(rowIds) {
         if (selectedRowIds.join(",") == rowIds.join(",")) {
@@ -1152,6 +1158,11 @@
           return item[idProperty];
         });
       }
+      onSelectedRowIdsChanged.notify({
+        "grid": _grid,
+        "ids": selectedRowIds,
+        "dataView": self
+      }, new Slick.EventData(), self);
     }
 
     /** 
@@ -1162,6 +1173,11 @@
       if (Array.isArray(selectedIds)) {
         selectedRowIds = selectedIds;
       }
+      onSelectedRowIdsChanged.notify({
+        "grid": _grid,
+        "ids": selectedRowIds,
+        "dataView": self
+      }, new Slick.EventData(), self);
     }
 
     /**
@@ -1287,11 +1303,13 @@
       "syncGridCellCssStyles": syncGridCellCssStyles,
 
       // data provider methods
+      "getItemsCount": getItemsCount,
       "getLength": getLength,
       "getItem": getItem,
       "getItemMetadata": getItemMetadata,
 
       // events
+      "onSelectedRowIdsChanged": onSelectedRowIdsChanged, // NOTE this will only work when used with "syncGridSelection"
       "onSetItemsCalled": onSetItemsCalled,
       "onRowCountChanged": onRowCountChanged,
       "onRowsChanged": onRowsChanged,

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -654,7 +654,7 @@
         }
       }
 
-      if(groups.length) {
+      if (groups.length) {
         addTotals(groups, level);
       }
 
@@ -1122,17 +1122,37 @@
       return onSelectedRowIdsChanged;
     }
 
-    /** Get all selected IDs */
-    function getAllSelectedIds(){
+    /** 
+     * Get all selected IDs 
+     * Note: when using Pagination it will also include hidden selections assuming `preserveHiddenOnSelectionChange` is set to true. 
+     */
+    function getAllSelectedIds() {
       return selectedRowIds;
     }
 
-    /** Get all selected dataContext items */
+    /** 
+     * Set all selected IDs is similar to `grid.setSelectedRows()` method except that if it's used with Pagination it will also apply the selection to all pages.
+     * This function was created mostly to be used by the CheckboxSelectColumn plugin (when option `applySelectOnAllPages` is set to true)
+     */
+    function setAllSelectedIds(isAllSelected) {
+      if (isAllSelected === false) {
+        selectedRowIds = [];
+      } else {
+        selectedRowIds = items.map(function (item) {
+          return item[idProperty];
+        });
+      }
+    }
+
+  /**
+   * Get all selected dataContext items
+   * Note: when using Pagination it will also include hidden selections assuming `preserveHiddenOnSelectionChange` is set to true.
+   */
     function getAllSelectedItems() {
       var selectedData = [];
       var selectedIds = getAllSelectedIds();
       selectedIds.forEach(function (id) {
-          selectedData.push(self.getItemById(id));
+        selectedData.push(self.getItemById(id));
       });
       return selectedData;
     }
@@ -1208,6 +1228,7 @@
       "expandGroup": expandGroup,
       "getGroups": getGroups,
       "getAllSelectedIds": getAllSelectedIds,
+      "setAllSelectedIds": setAllSelectedIds,
       "getAllSelectedItems": getAllSelectedItems,
       "getIdxById": getIdxById,
       "getRowByItem": getRowByItem,

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -1131,6 +1131,16 @@
     }
 
     /** 
+     * Get all selected filtered IDs (similar to "getAllSelectedIds" but only return filtered data)
+     * Note: when using Pagination it will also include hidden selections assuming `preserveHiddenOnSelectionChange` is set to true. 
+     */
+    function getAllSelectedFilteredIds() {
+      return getAllSelectedFilteredItems().map(function (item) {
+        return item[idProperty];
+      });  
+    }
+
+    /** 
      * Set all selected IDs is similar to `grid.setSelectedRows()` method except that if it's used with Pagination it will also apply the selection to all pages.
      * This function was created mostly to be used by the CheckboxSelectColumn plugin (when option `applySelectOnAllPages` is set to true)
      */
@@ -1144,10 +1154,10 @@
       }
     }
 
-  /**
-   * Get all selected dataContext items
-   * Note: when using Pagination it will also include hidden selections assuming `preserveHiddenOnSelectionChange` is set to true.
-   */
+    /**
+     * Get all selected dataContext items
+     * Note: when using Pagination it will also include hidden selections assuming `preserveHiddenOnSelectionChange` is set to true.
+     */
     function getAllSelectedItems() {
       var selectedData = [];
       var selectedIds = getAllSelectedIds();
@@ -1155,6 +1165,19 @@
         selectedData.push(self.getItemById(id));
       });
       return selectedData;
+    }
+
+    /**
+     * Get all selected filtered dataContext items (similar to "getAllSelectedItems" but only return filtered data)
+     * Note: when using Pagination it will also include hidden selections assuming `preserveHiddenOnSelectionChange` is set to true.
+     */
+    function getAllSelectedFilteredItems() {
+      var intersection = filteredItems.filter(function(a) {
+        return selectedRowIds.some(function(b) { 
+          return a[idProperty] === b;
+        });
+      });
+      return intersection || [];
     }
 
     function syncGridCellCssStyles(grid, key) {
@@ -1230,6 +1253,8 @@
       "getAllSelectedIds": getAllSelectedIds,
       "setAllSelectedIds": setAllSelectedIds,
       "getAllSelectedItems": getAllSelectedItems,
+      "getAllSelectedFilteredIds": getAllSelectedFilteredIds,
+      "getAllSelectedFilteredItems": getAllSelectedFilteredItems,
       "getIdxById": getIdxById,
       "getRowByItem": getRowByItem,
       "getRowById": getRowById,

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -1154,6 +1154,16 @@
       }
     }
 
+    /** 
+     * Set and override currently selected IDs array (regardless of Pagination) 
+     * NOTE: This will NOT the selection in the grid, if you need to do that then you still need to call "grid.setSelectedRows(rows)"
+     */
+    function setSelectedIds(selectedIds) {
+      if (Array.isArray(selectedIds)) {
+        selectedRowIds = selectedIds;
+      }
+    }
+
     /**
      * Get all selected dataContext items
      * Note: when using Pagination it will also include hidden selections assuming `preserveHiddenOnSelectionChange` is set to true.
@@ -1255,6 +1265,7 @@
       "getAllSelectedItems": getAllSelectedItems,
       "getAllSelectedFilteredIds": getAllSelectedFilteredIds,
       "getAllSelectedFilteredItems": getAllSelectedFilteredItems,
+      "setSelectedIds": setSelectedIds,
       "getIdxById": getIdxById,
       "getRowByItem": getRowByItem,
       "getRowById": getRowById,


### PR DESCRIPTION
- when using local Pagination and DataView, it was applying row selection only to current page but most users would expect the selection to be applied to all pages, to fix that we added:
   -  new CheckboxSelectColumn plugin option `applySelectOnAllPages` was added, its default is `false` so it won't affect previous grids
   - add few more DataView functions
      - `getItemsCount` for an easy access to items length
      - `setAllSelectedIds` which is called by CheckboxSelectColumn plugin `applySelectOnAllPages` is set to true
      - `getAllSelectedFilteredIds` and `getAllSelectedFilteredItems`  to get all filtered data when using Pagination `getAllSelectedFilteredIds` and `getAllSelectedFilteredItems`
- fixes issue identified and discussed in this issue [comment](https://github.com/6pac/SlickGrid/pull/542#issuecomment-709557314)

#### TODOs
- [x] modify `example-checkbox-header-row.html` to demo the feature with `applySelectOnAllPages`
- [x] test with `selectableOverride` callback
- [x] add Cypress E2E tests and fix failing tests
  - [x] add test to make sure "Select All" gets unchecked when unselecting any row
- [ ] `selectedIds` should be updated after filtering data (we should use `filteredItems`)

#### WITH FIX
![tePoBbFn9a](https://user-images.githubusercontent.com/643976/96602324-e6322980-12c0-11eb-9ff5-169c1a274f40.gif)

#### without fix
![L0kahu5ej5](https://user-images.githubusercontent.com/643976/96475913-92610b00-1202-11eb-9216-1c904f04ad37.gif)
