### PR TITLE
feat: add enableMouseWheelScrollHandler option to allow dynamic load

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2907,6 +2907,13 @@ if (typeof Slick === "undefined") {
       if (!suppressColumnSet) {
         setColumns(treeColumns.extractColumns());
       }
+
+      if (options.enableMouseWheelScrollHandler && $viewport && jQuery.fn.mousewheel) {
+        var viewportEvents = $._data($viewport[0], "events");
+        if (!viewportEvents || !viewportEvents.mousewheel) {
+          $viewport.on("mousewheel", handleMouseWheel);
+        }
+      }
     }
 
     function validateAndEnforceOptions() {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -113,6 +113,7 @@ if (typeof Slick === "undefined") {
       minRowBuffer: 3,
       emulatePagingWhenScrolling: true, // when scrolling off bottom of viewport, place new row at top of viewport
       editorCellNavOnLRKeys: false,
+      enableMouseWheelScrollHandler: true,
       doPaging: true,
       autosizeColsMode: Slick.GridAutosizeColsMode.LegacyOff,
       autosizeColPaddingPx: 4,
@@ -567,7 +568,7 @@ if (typeof Slick === "undefined") {
         $viewport
             .on("scroll", handleScroll);
 
-        if (jQuery.fn.mousewheel) {
+        if (jQuery.fn.mousewheel && options.enableMouseWheelScrollHandler) {
           $viewport.on("mousewheel", handleMouseWheel);
         }
 


### PR DESCRIPTION
- when using TypeScript, we must always import the mousewheel jquery lib even if we don't need it because TypeScript does not yet support dynamic import. So providing a grid option to only use the mousewheel handler when we really want it is the only bulletproof way to only use that handler only when we really need it (typically when using a frozen grid)
- ref Angular-Slickgrid [issue](https://github.com/ghiscoding/Angular-Slickgrid/issues/618)