### PR TITLE
fix: remove mousewheel scroll handler when option is disable

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2928,6 +2928,8 @@ if (typeof Slick === "undefined") {
         if (!viewportEvents || !viewportEvents.mousewheel) {
           $viewport.on("mousewheel", handleMouseWheel);
         }
+      } else if (options.enableMouseWheelScrollHandler === false) {
+        $viewport.off("mousewheel"); // remove scroll handler when option is disable
       }
     }
 


### PR DESCRIPTION
this goes with PR #555, just forgot to remove mousewheel scroll handler when the option is disabled and is used by `setOptions`