### PR TITLE
feat: add columnId to onColumnsChanged event

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -214,6 +214,7 @@
       }
 
       if ($(e.target).is(":checkbox")) {
+        var columnId = $(e.target).data("column-id") || "";
         var visibleColumns = [];
         $.each(columnCheckboxes, function (i) {
           if ($(this).is(":checked")) {
@@ -227,7 +228,7 @@
         }
 
         _grid.setColumns(visibleColumns);
-        onColumnsChanged.notify({ allColumns: columns, columns: visibleColumns, grid: _grid });
+        onColumnsChanged.notify({ columnId: columnId, allColumns: columns, columns: visibleColumns, grid: _grid });
       }
     }
 

--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -229,7 +229,7 @@
         }
 
         _grid.setColumns(visibleColumns);
-        onColumnsChanged.notify({ columnId: columnId, isColumnShown: isChecked, allColumns: columns, columns: visibleColumns, grid: _grid });
+        onColumnsChanged.notify({ columnId: columnId, showing: isChecked, allColumns: columns, columns: visibleColumns, grid: _grid });
       }
     }
 

--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -214,6 +214,7 @@
       }
 
       if ($(e.target).is(":checkbox")) {
+        var isChecked = e.target.checked;
         var columnId = $(e.target).data("column-id") || "";
         var visibleColumns = [];
         $.each(columnCheckboxes, function (i) {
@@ -228,7 +229,7 @@
         }
 
         _grid.setColumns(visibleColumns);
-        onColumnsChanged.notify({ columnId: columnId, allColumns: columns, columns: visibleColumns, grid: _grid });
+        onColumnsChanged.notify({ columnId: columnId, isColumnShown: isChecked, allColumns: columns, columns: visibleColumns, grid: _grid });
       }
     }
 

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -600,6 +600,7 @@
       }
 
       if ($(e.target).is(":checkbox")) {
+        var columnId = $(e.target).data("column-id") || "";
         var visibleColumns = [];
         $.each(columnCheckboxes, function (i) {
           if ($(this).is(":checked")) {
@@ -613,6 +614,7 @@
         }
 
         var callbackArgs = {
+          "columnId": columnId,
           "grid": _grid,
           "allColumns": columns,
           "columns": visibleColumns

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -616,7 +616,7 @@
 
         var callbackArgs = {
           "columnId": columnId,
-          "isColumnShown": isChecked,
+          "showing": isChecked,
           "grid": _grid,
           "allColumns": columns,
           "columns": visibleColumns

--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -600,6 +600,7 @@
       }
 
       if ($(e.target).is(":checkbox")) {
+        var isChecked = e.target.checked;
         var columnId = $(e.target).data("column-id") || "";
         var visibleColumns = [];
         $.each(columnCheckboxes, function (i) {
@@ -615,6 +616,7 @@
 
         var callbackArgs = {
           "columnId": columnId,
+          "isColumnShown": isChecked,
           "grid": _grid,
           "allColumns": columns,
           "columns": visibleColumns


### PR DESCRIPTION
- in some cases it's useful to know which column from the picker triggered the hide/show
- for my use case, I need to know when a column is shown/hidden so that I can readjust the `frozenColumn` index if need be (that is if the column is on the left pinned container, I need to do +/- 1 on the index because SlickGrid doesn't automatically readjust it)