### PR TITLE
Adds optimized bulk operations to DataView

### DIFF
--- a/cypress/integration/example-optimizing-updates.spec.js
+++ b/cypress/integration/example-optimizing-updates.spec.js
@@ -1,0 +1,101 @@
+/// <reference types="Cypress" />
+
+describe('Example - Optimizing Updates', () => {
+  const titles = ['#', 'Severity', 'Time', 'Message'];
+
+  beforeEach(() => {
+    // create a console.log spy for later use
+    cy.window().then((win) => {
+      cy.spy(win.console, "log");
+    });
+  });
+
+  it('should display Example Multi-grid Basic', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example-optimizing-updates.html`);
+    cy.get('.options-panel > b').should('contain', 'Description:');
+    cy.contains('This page demonstrates how the bulk update operations ');
+  });
+
+  it('should have exact Column Titles in the grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(titles[index]));
+  });
+
+  it('should show initial rows', () => {
+    cy.get('#pager')  
+      .find('.slick-pager-status')
+      .should('contain', 'Showing all 300 rows');    
+  });
+
+  it('should update the rows on inefficient click', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example-optimizing-updates.html`);
+    
+    cy.get('#myGrid')  
+      .find('.slick-row')
+      .each(($child, index) => {
+          const message = $child.find('.cell-message').text();
+          const number = parseInt(message.substring("Log Entry ".length));
+          expect(number).to.be.lessThan(1000)
+      });
+      
+    cy.get('.options-panel button')  
+      .contains('inefficient')
+      .click();
+      
+    cy.get('#myGrid')  
+      .find('.slick-row')
+      .each(($child, index) => {
+          const message = $child.find('.cell-message').text();
+          const number = parseInt(message.substring("Log Entry ".length));
+          expect(number).to.be.greaterThan(90000)
+      });
+  });
+    
+  it('should update the rows on efficient click', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example-optimizing-updates.html`);
+    
+    cy.get('#myGrid')  
+      .find('.slick-row')
+      .each(($child, index) => {
+          const message = $child.find('.cell-message').text();
+          const number = parseInt(message.substring("Log Entry ".length));
+          expect(number).to.be.lessThan(1000)
+      });
+      
+    cy.get('.options-panel button')  
+      .contains('efficient')
+      .click();
+
+    cy.get('#myGrid')  
+      .find('.slick-row')
+      .each(($child, index) => {
+          const message = $child.find('.cell-message').text();
+          const number = parseInt(message.substring("Log Entry ".length));
+          expect(number).to.be.greaterThan(90000)
+      });
+  });
+  
+  it('should need less time on efficient than inefficient', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example-optimizing-updates.html`);
+
+    cy.get('#duration').invoke('text', '').should('be.empty');
+    cy.get('.options-panel button')  
+      .contains('(inefficient)')
+      .click();
+    cy.get('#duration').should('not.be.empty').then($duration => {
+        let inEfficientTime = parseInt($duration.text());
+        
+        cy.get('#duration').invoke('text', '').should('be.empty');
+        cy.get('.options-panel button')  
+          .contains('(efficient)')
+          .click();
+        cy.get('#duration').should('not.be.empty').then($duration2 => {
+            let efficientTime = parseInt($duration2.text());
+            expect(efficientTime).to.be.lessThan(inEfficientTime / 2);
+        });
+    });
+
+  });
+});

--- a/examples/example-optimizing-updates.html
+++ b/examples/example-optimizing-updates.html
@@ -1,0 +1,178 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
+  <title>SlickGrid example: Optimizing Updates</title>
+  <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
+  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
+  <link rel="stylesheet" href="../controls/slick.pager.css" type="text/css"/>
+  <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <style>
+    .cell-title {
+      font-weight: bold;
+    }
+
+    .cell-effort-driven {
+      text-align: center;
+    }
+
+    .cell-selection {
+      border-right-color: silver;
+      border-right-style: solid;
+      background: #f5f5f5;
+      color: gray;
+      text-align: right;
+      font-size: 10px;
+    }
+  </style>
+</head>
+<body>
+<div style="position:relative">
+  <div style="width:600px;">
+    <div class="grid-header" style="width:100%">
+      <label>SlickGrid</label>
+    </div>
+    <div id="myGrid" style="width:100%;height:500px;"></div>
+    <div id="pager" style="width:100%;height:20px;"></div>
+  </div>
+
+  <div class="options-panel">
+    <b>Description:</b>
+    <hr/>
+   
+    <p>
+      This page demonstrates how the bulk update operations can be used efficiently
+      delete and insert new rows into the table. The example simulates a log viewer
+      where for each log severity always 100 items are shown in a ring-buffer fashion.
+      If you use the browser profiler to compare the two different operations below 
+      you will notice the significant performance difference which can be crucial for 
+      systems where a lot of new events are provided from an external source and 
+      then updated.
+    </p>
+    <h2>Controls</h2>
+    <button onclick="simulateLogs(10000, false)">Add 10000 entries of each severity (inefficient)</button>
+    <button onclick="simulateLogs(10000, true)">Add 10000 entries of each severity (efficient)</button>
+    <h2>View Source:</h2>
+    <ul>
+      <li><a href="https://github.com/6pac/SlickGrid/blob/master/examples/example-optimizing-updates.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+    </ul>
+  </div>
+</div>
+
+<script src="../lib/jquery-1.12.4.min.js"></script>
+<script src="../lib/jquery-ui.min.js"></script>
+<script src="../lib/jquery.event.drag-2.3.0.js"></script>
+
+<script src="../slick.core.js"></script>
+<script src="../slick.formatters.js"></script>
+<script src="../slick.grid.js"></script>
+<script src="../slick.dataview.js"></script>
+<script src="../controls/slick.pager.js"></script>
+
+<script>
+  var dataView;
+  var grid;
+  var data = [];
+  var columns = [
+    {id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 40, resizable: false, selectable: false },
+    {id: "severity", name: "Severity", field: "severity", width: 120, minWidth: 120, cssClass: "cell-severity"},
+    {id: "time", name: "Time", field: "time", width: 120, minWidth: 120, cssClass: "cell-time"},
+    {id: "message", name: "Message", field: "message", minWidth: 300, cssClass: "cell-message"},
+  ];
+
+  var options = {
+    editable: false,
+    enableAddRow: false,
+    enableCellNavigation: true
+  };
+
+  var eventIndex = 0;
+  var severities = ['Info', 'Warning', 'Error'];
+  var maxItemsPerSeverity = 100;
+  
+  function LogEntry() {
+    eventIndex++;
+    this.id = "id_" + eventIndex;
+    this.severity = severities[eventIndex % severities.length];
+    this.time = new Date().toISOString().substring(0,19);
+    this.message = "Log Entry " + eventIndex;
+  }
+    
+  // our ringbuffer to keep only 10 items per severity
+  var logsPerSeverity = {}; 
+  for (var i = 0; i < severities.length; i++) {
+    logsPerSeverity[severities[i]] = [];
+  }  
+  
+  // the logic to simulate new events
+  
+  function simulateLogs(count, efficient) {
+      var chunks = 10;
+      for(var i = 0; i < chunks; i++) {
+          simulateLogChunk(count / chunks, efficient);
+      }
+  }
+  function simulateLogChunk(count, efficient) {
+    if(efficient) {
+        dataView.beginUpdate(true); // efficient bulk update 
+        var logs = []; // we will first collect all items to be added
+        for (var i = 0; i < count; i++) {
+          var log = new LogEntry();
+          var group = logsPerSeverity[log.severity];
+          if(group.length > maxItemsPerSeverity) {
+            try {
+              dataView.deleteItem(group.pop().id);
+            } catch(e) {
+              // item not yet fully inserted
+            }
+          }
+          
+          group.unshift(log);
+          logs[i] = log;
+        }
+        // then we insert all items in one go.
+        dataView.insertItems(0, logs);    
+        dataView.endUpdate();          
+    } else {
+        dataView.beginUpdate(); // just a normal update 
+        for (var i = 0; i < count; i++) {
+          var log = new LogEntry();
+          var group = logsPerSeverity[log.severity];
+          if(group.length > maxItemsPerSeverity) {
+            try {
+              dataView.deleteItem(group.pop().id);
+            } catch(e) {
+              // item not yet fully inserted
+            }
+          }
+          
+          group.unshift(log);
+          dataView.insertItem(0, log); // individual inserts
+        }
+        dataView.endUpdate();  
+    }
+  }
+
+  $(function () {
+    dataView = new Slick.Data.DataView({ inlineFilters: true });
+    grid = new Slick.Grid("#myGrid", dataView, columns, options);
+    var pager = new Slick.Controls.Pager(dataView, grid, $("#pager"));
+
+    // wire up model events to drive the grid
+    dataView.onRowCountChanged.subscribe(function (e, args) {
+      grid.updateRowCount();
+      grid.render();
+    });
+
+    dataView.onRowsChanged.subscribe(function (e, args) {
+      grid.invalidateRows(args.rows);
+      grid.render();
+    });
+
+    // prepare some data
+    simulateLogs(severities.length * maxItemsPerSeverity, true)
+  })
+</script>
+</body>
+</html>

--- a/examples/example-optimizing-updates.html
+++ b/examples/example-optimizing-updates.html
@@ -51,8 +51,11 @@
       then updated.
     </p>
     <h2>Controls</h2>
-    <button onclick="simulateLogs(100000, false)">Add 100000 entries of each severity (inefficient)</button>
-    <button onclick="simulateLogs(100000, true)">Add 100000 entries of each severity (efficient)</button>
+    <button onclick="simulateLogs(100000, false, true)">Add 100000 entries of each severity (inefficient)</button>
+    <button onclick="simulateLogs(100000, true, true)">Add 100000 entries of each severity (efficient)</button>
+    <div>
+        Last update took: <span id="duration"></span>
+    </div>
     <h2>View Source:</h2>
     <ul>
       <li><a href="https://github.com/6pac/SlickGrid/blob/master/examples/example-optimizing-updates.html" target="_sourcewindow"> View the source for this example on Github</a></li>
@@ -107,13 +110,18 @@
   
   // the logic to simulate new events
   
-  function simulateLogs(count, efficient) {
-      var chunks = 10;
-      for(var i = 0; i < chunks; i++) {
-          simulateLogChunk(count / chunks, efficient);
-      }
+  function simulateLogs(count, efficient, update) {
+    var chunks = 10;
+    var start = new Date();
+    for(var i = 0; i < chunks; i++) {
+        simulateLogChunk(count / chunks, efficient);
+    }
+    var end = new Date();
+    if (update) {
+        $('#duration').text(end - start + 'ms');
+    }      
   }
-  function simulateLogChunk(count, efficient) {
+  function simulateLogChunk(count, efficient, update) {
     if(efficient) {
       dataView.beginUpdate(true); // efficient bulk update 
       var logs = []; // we will first collect all items to be added

--- a/examples/example-optimizing-updates.html
+++ b/examples/example-optimizing-updates.html
@@ -51,8 +51,8 @@
       then updated.
     </p>
     <h2>Controls</h2>
-    <button onclick="simulateLogs(10000, false)">Add 10000 entries of each severity (inefficient)</button>
-    <button onclick="simulateLogs(10000, true)">Add 10000 entries of each severity (efficient)</button>
+    <button onclick="simulateLogs(100000, false)">Add 100000 entries of each severity (inefficient)</button>
+    <button onclick="simulateLogs(100000, true)">Add 100000 entries of each severity (efficient)</button>
     <h2>View Source:</h2>
     <ul>
       <li><a href="https://github.com/6pac/SlickGrid/blob/master/examples/example-optimizing-updates.html" target="_sourcewindow"> View the source for this example on Github</a></li>
@@ -115,42 +115,38 @@
   }
   function simulateLogChunk(count, efficient) {
     if(efficient) {
-        dataView.beginUpdate(true); // efficient bulk update 
-        var logs = []; // we will first collect all items to be added
-        for (var i = 0; i < count; i++) {
-          var log = new LogEntry();
-          var group = logsPerSeverity[log.severity];
-          if(group.length > maxItemsPerSeverity) {
-            try {
-              dataView.deleteItem(group.pop().id);
-            } catch(e) {
-              // item not yet fully inserted
-            }
-          }
-          
-          group.unshift(log);
-          logs[i] = log;
+      dataView.beginUpdate(true); // efficient bulk update 
+      var logs = []; // we will first collect all items to be added
+      for (var i = 0; i < count; i++) {
+        var log = new LogEntry();
+        var group = logsPerSeverity[log.severity];
+        if(group.length > maxItemsPerSeverity) {
+          dataView.deleteItem(group.pop().id);
         }
-        // then we insert all items in one go.
-        dataView.insertItems(0, logs);    
-        dataView.endUpdate();          
+        
+        group.unshift(log);
+        logs[i] = log;
+      }
+      // then we insert all items in one go.
+      dataView.insertItems(0, logs);    
+      dataView.endUpdate();          
     } else {
-        dataView.beginUpdate(); // just a normal update 
-        for (var i = 0; i < count; i++) {
-          var log = new LogEntry();
-          var group = logsPerSeverity[log.severity];
-          if(group.length > maxItemsPerSeverity) {
-            try {
-              dataView.deleteItem(group.pop().id);
-            } catch(e) {
-              // item not yet fully inserted
-            }
+      dataView.beginUpdate(); // just a normal update 
+      for (var i = 0; i < count; i++) {
+        var log = new LogEntry();
+        var group = logsPerSeverity[log.severity];
+        if(group.length > maxItemsPerSeverity) {
+          try {
+            dataView.deleteItem(group.pop().id);
+          } catch(e) {
+            // item not yet fully inserted
           }
-          
-          group.unshift(log);
-          dataView.insertItem(0, log); // individual inserts
         }
-        dataView.endUpdate();  
+        
+        group.unshift(log);
+        dataView.insertItem(0, log); // individual inserts
+      }
+      dataView.endUpdate();  
     }
   }
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -60,6 +60,7 @@
       <li><a href="example-totals-via-data-provider.html">Implementing a totals row via a data provider</a></li>
       <li>(most comprehensive) <a href="example4-model.html">Using a filtered data view to drive the grid</a></li>
       <li><a href="example-optimizing-dataview.html">Optimizing DataView for 500’000 rows</a></li>
+      <li><a href="example-optimizing-updates.html">Optimizing DataView for updates</a></li>
       <li><a href="example6-ajax-loading.html">AJAX-loading data with search</a></li>
       <li><a href="example6-ajax-loading-yahoo.html">AJAX-loading data, second example</a></li>
       <li><a href="example13-getItem-sorting.html">Sorting by an index, getItem method</a></li>

--- a/slick.compositeeditor.js
+++ b/slick.compositeeditor.js
@@ -1,11 +1,4 @@
 (function ($) {
-  $.extend(true, window, {
-    Slick: {
-      CompositeEditor: CompositeEditor
-    }
-  });
-
-
   /***
    * A composite SlickGrid editor factory.
    * Generates an editor that is composed of multiple editors for given columns.
@@ -260,4 +253,11 @@
     editor.prototype = this;
     return editor;
   }
+  
+  // exports
+  $.extend(true, window, {
+    Slick: {
+      CompositeEditor: CompositeEditor
+    }
+  });  
 })(jQuery);

--- a/slick.core.js
+++ b/slick.core.js
@@ -698,6 +698,62 @@
       });
     };
   }
+  
+  /***
+   * Polyfill for Map to support old browsers but
+   * benefit of the Map speed in modern browsers.
+   * @class Map
+   * @constructor
+   */
+  var Map = 'Map' in window ? window.Map : function Map() {
+    var data = {};
+    
+    /***
+     * Gets the item with the given key from the map or undefined if
+     * the map does not contain the item. 
+     * @method get
+     * @param key {Map} The key of the item in the map.
+     */
+    this.get = function(key) {
+      return data[key];
+    };
+
+    /***
+     * Adds or updates the item with the given key in the map. 
+     * @method set
+     * @param key The key of the item in the map.
+     * @param value The value to insert into the map of the item in the map.
+     */
+    this.set = function(key, value) {
+      data[key] = value;
+    };
+    
+    /***
+     * Gets a value indicating whether the given key is present in the map.
+     * @method has
+     * @param key The key of the item in the map.
+     * @return {Boolean}
+     */    
+    this.has = function(key) {
+      return key in data;
+    };
+    
+    /***
+     * Removes the item with the given key from the map. 
+     * @method delete
+     * @param key The key of the item in the map.
+     */
+    this.delete = function(key) {
+      delete data[key];
+    };
+  };
+  // Register Map in SlickGrid.
+  // this is done down here after we defined what "Map" will be
+  $.extend(true, window, {
+    "Slick": {
+      "Map": Map,
+    }
+  });
 })(jQuery);
 
 

--- a/slick.core.js
+++ b/slick.core.js
@@ -5,85 +5,6 @@
  */
 
 (function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "Event": Event,
-      "EventData": EventData,
-      "EventHandler": EventHandler,
-      "Range": Range,
-      "NonDataRow": NonDataItem,
-      "Group": Group,
-      "GroupTotals": GroupTotals,
-      "EditorLock": EditorLock,
-  
-      /***
-       * A global singleton editor lock.
-       * @class GlobalEditorLock
-       * @static
-       * @constructor
-       */
-      "GlobalEditorLock": new EditorLock(),
-      "TreeColumns": TreeColumns,
-
-      "keyCode": {
-        SPACE: 8,
-        BACKSPACE: 8,
-        DELETE: 46,
-        DOWN: 40,
-        END: 35,
-        ENTER: 13,
-        ESCAPE: 27,
-        HOME: 36,
-        INSERT: 45,
-        LEFT: 37,
-        PAGE_DOWN: 34,
-        PAGE_UP: 33,
-        RIGHT: 39,
-        TAB: 9,
-        UP: 38,
-        A: 65
-      },
-      "preClickClassName" : "slick-edit-preclick",
-      
-      "GridAutosizeColsMode": {
-        None: 'NOA',
-        LegacyOff: 'LOF',
-        LegacyForceFit: 'LFF',
-        IgnoreViewport: 'IGV',
-        FitColsToViewport: 'FCV',
-        FitViewportToCols: 'FVC'
-      },
-      
-      "ColAutosizeMode": {
-          Locked: 'LCK',
-          Guide: 'GUI',
-          Content: 'CON',
-          ContentIntelligent: 'CTI'
-      },
-      
-      "RowSelectionMode": {
-          FirstRow: 'FS1',
-          FirstNRows: 'FSN',
-          AllRows: 'ALL',
-          LastRow: 'LS1'
-      },
-      
-      "ValueFilterMode": {
-          None: 'NONE',
-          DeDuplicate: 'DEDP',
-          GetGreatestAndSub: 'GR8T',
-          GetLongestTextAndSub: 'LNSB',
-          GetLongestText: 'LNSC'
-      },
-      
-      "WidthEvalMode": {
-          CanvasTextSize: 'CANV',
-          HTML: 'HTML'
-      }      
-    }
-  });
-    
   /***
    * An event object for passing data to event handlers and letting them control propagation.
    * <p>This is pretty much identical to how W3C and jQuery implement events.</p>
@@ -747,11 +668,84 @@
       delete data[key];
     };
   };
-  // Register Map in SlickGrid.
-  // this is done down here after we defined what "Map" will be
+  
+  // exports
   $.extend(true, window, {
     "Slick": {
-      "Map": Map,
+      "Event": Event,
+      "EventData": EventData,
+      "EventHandler": EventHandler,
+      "Range": Range,
+      "Map": Map,      
+      "NonDataRow": NonDataItem,
+      "Group": Group,
+      "GroupTotals": GroupTotals,
+      "EditorLock": EditorLock,
+  
+      /***
+       * A global singleton editor lock.
+       * @class GlobalEditorLock
+       * @static
+       * @constructor
+       */
+      "GlobalEditorLock": new EditorLock(),
+      "TreeColumns": TreeColumns,
+
+      "keyCode": {
+        SPACE: 8,
+        BACKSPACE: 8,
+        DELETE: 46,
+        DOWN: 40,
+        END: 35,
+        ENTER: 13,
+        ESCAPE: 27,
+        HOME: 36,
+        INSERT: 45,
+        LEFT: 37,
+        PAGE_DOWN: 34,
+        PAGE_UP: 33,
+        RIGHT: 39,
+        TAB: 9,
+        UP: 38,
+        A: 65
+      },
+      "preClickClassName" : "slick-edit-preclick",
+      
+      "GridAutosizeColsMode": {
+        None: 'NOA',
+        LegacyOff: 'LOF',
+        LegacyForceFit: 'LFF',
+        IgnoreViewport: 'IGV',
+        FitColsToViewport: 'FCV',
+        FitViewportToCols: 'FVC'
+      },
+      
+      "ColAutosizeMode": {
+          Locked: 'LCK',
+          Guide: 'GUI',
+          Content: 'CON',
+          ContentIntelligent: 'CTI'
+      },
+      
+      "RowSelectionMode": {
+          FirstRow: 'FS1',
+          FirstNRows: 'FSN',
+          AllRows: 'ALL',
+          LastRow: 'LS1'
+      },
+      
+      "ValueFilterMode": {
+          None: 'NONE',
+          DeDuplicate: 'DEDP',
+          GetGreatestAndSub: 'GR8T',
+          GetLongestTextAndSub: 'LNSB',
+          GetLongestText: 'LNSC'
+      },
+      
+      "WidthEvalMode": {
+          CanvasTextSize: 'CANV',
+          HTML: 'HTML'
+      }      
     }
   });
 })(jQuery);

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -1,19 +1,4 @@
 (function ($) {
-  $.extend(true, window, {
-    Slick: {
-      Data: {
-        DataView: DataView,
-        Aggregators: {
-          Avg: AvgAggregator,
-          Min: MinAggregator,
-          Max: MaxAggregator,
-          Sum: SumAggregator,
-          Count: CountAggregator
-        }
-      }
-    }
-  });
-
   /***
    * A sample Model implementation.
    * Provides a filtered view of the underlying data.
@@ -1561,4 +1546,19 @@
   // TODO:  add more built-in aggregators
   // TODO:  merge common aggregators in one to prevent needles iterating
 
+  // exports
+  $.extend(true, window, {
+    Slick: {
+      Data: {
+        DataView: DataView,
+        Aggregators: {
+          Avg: AvgAggregator,
+          Min: MinAggregator,
+          Max: MaxAggregator,
+          Sum: SumAggregator,
+          Count: CountAggregator
+        }
+      }
+    }
+  });
 })(jQuery);

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -115,7 +115,7 @@
 
     function beginUpdate(bulkUpdate) {
       suspend = true;
-      isBulkSuspend = !!bulkUpdate;
+      isBulkSuspend = bulkUpdate === true;
     }
 
     function endUpdate() {
@@ -176,6 +176,7 @@
       }
       
       items.length = newIdx;
+      bulkDeleteIds = new SlickMap();
     }
 
     function updateIdxById(startingIndex) {

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -486,9 +486,12 @@
       refresh();
     }
     
-    function updateItems(id, items) {
-      for (var i = 0; i < items.length; i++) {
-        updateSingleItem(id, items);
+    function updateItems(ids, items) {
+      if(ids.length !== items.length) {
+        throw new Error("Mismatch on the length of ids and items provided to update");
+      }          
+      for (var i = 0, l = items.length; i < l; i++) {
+        updateSingleItem(id[i], items);
       }
       refresh();
     }

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -521,13 +521,13 @@
     }
 
     function deleteItem(id) {
-      var idx = idxById.get(id);
-      if (idx === undefined) {
-        throw new Error("Invalid id");
-      }
       if (isBulkSuspend) {
         bulkDeleteIds.set(id, true);
       } else {
+        var idx = idxById.get(id);
+        if (idx === undefined) {
+          throw new Error("Invalid id");
+        }
         idxById.delete(id);
         items.splice(idx, 1);
         updateIdxById(idx);

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -491,7 +491,7 @@
         throw new Error("Mismatch on the length of ids and items provided to update");
       }          
       for (var i = 0, l = items.length; i < l; i++) {
-        updateSingleItem(id[i], items);
+        updateSingleItem(ids[i], items[i]);
       }
       refresh();
     }
@@ -503,7 +503,7 @@
     }
 
     function insertItems(insertBefore, newItems) {
-      items.prototype.splice.apply(newItems, [insertBefore, 0].concat(newItems));
+      Array.prototype.splice.apply(items, [insertBefore, 0].concat(newItems));
       updateIdxById(insertBefore);
       refresh();
     }
@@ -542,16 +542,18 @@
       
       if (isBulkSuspend) {
         for (var i = 0, l = ids.length; i < l; i++) {
+          var id = ids[i];
           var idx = idxById.get(id);
           if (idx === undefined) {
             throw new Error("Invalid id");
           }
-          bulkDeleteIds.set(ids[i], true);
+          bulkDeleteIds.set(id, true);
         }
       } else {      
         // collect all indexes
         var indexesToDelete = [];
         for (var i = 0, l = ids.length; i < l; i++) {
+          var id = ids[i];
           var idx = idxById.get(id);
           if (idx === undefined) {
             throw new Error("Invalid id");

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -190,7 +190,7 @@
         if (id === undefined) {
           throw new Error("Each data element must implement a unique 'id' property");
         }
-        idxById(id, i);
+        idxById.set(id, i);
       }
     }
 

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -390,7 +390,7 @@
       return ids;
     }
 
-    function updateItem(id, item) {
+    function updateSingleItem(id, item) {
       // see also https://github.com/mleibman/SlickGrid/issues/1082
       if (idxById[id] === undefined) {
         throw new Error("Invalid id");
@@ -427,11 +427,28 @@
         updated = {};
       }
       updated[id] = true;
+    }
+    
+    function updateItem(id, item) {
+      updateSingleItem(id, item);
+      refresh();
+    }
+    
+    function updateItems(id, items) {
+      for (var i = 0; i < items.length; i++) {
+        updateSingleItem(id, items);
+      }
+      refresh();
+    }
+    
+    function insertItem(insertBefore, item) {
+      items.splice(insertBefore, 0, item);
+      updateIdxById(insertBefore);
       refresh();
     }
 
-    function insertItem(insertBefore, item) {
-      items.splice(insertBefore, 0, item);
+    function insertItems(insertBefore, newItems) {
+      items.prototype.splice.apply(newItems, [insertBefore, 0].concat(newItems));
       updateIdxById(insertBefore);
       refresh();
     }
@@ -439,6 +456,12 @@
     function addItem(item) {
       items.push(item);
       updateIdxById(items.length - 1);
+      refresh();
+    }
+
+    function addItems(newItems) {
+      items = items.concat(newItems);
+      updateIdxById(items.length - newItems.length);
       refresh();
     }
 
@@ -450,6 +473,33 @@
       delete idxById[id];
       items.splice(idx, 1);
       updateIdxById(idx);
+      refresh();
+    }
+
+    function deleteItems(ids) {
+      if (ids.length === 0) {
+        return;
+      }
+      
+      // collect all indexes
+      var indexesToDelete = [];
+      for (var i = 0; i < ids.length; i++) {
+        var idx = idxById[id];
+        if (idx === undefined) {
+          throw new Error("Invalid id");
+        }
+        delete idxById[id];
+        indexesToDelete.push(idx);        
+      }
+      
+      // Remove from back to front
+      indexesToDelete.sort();
+      for (var i = indexesToDelete.length - 1; i >= 0; --i) {
+        items.splice(indexesToDelete[i], 1);
+      }
+      
+      // update lookup from front to back
+      updateIdxById(indexesToDelete[0]);
       refresh();
     }
 
@@ -1249,9 +1299,13 @@
       "setFilterArgs": setFilterArgs,
       "refresh": refresh,
       "updateItem": updateItem,
+      "updateItems": updateItems,
       "insertItem": insertItem,
+      "insertItems": insertItems,
       "addItem": addItem,
+      "addItems": addItems,
       "deleteItem": deleteItem,
+      "deleteItems": deleteItems,
       "sortedAddItem": sortedAddItem,
       "sortedUpdateItem": sortedUpdateItem,
       "syncGridSelection": syncGridSelection,

--- a/slick.editors.js
+++ b/slick.editors.js
@@ -5,22 +5,6 @@
  */
 
 (function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "Editors": {
-        "Text": TextEditor,
-        "Integer": IntegerEditor,
-        "Float": FloatEditor,
-        "Date": DateEditor,
-        "YesNoSelect": YesNoSelectEditor,
-        "Checkbox": CheckboxEditor,
-        "PercentComplete": PercentCompleteEditor,
-        "LongText": LongTextEditor
-      }
-    }
-  });
-
   function TextEditor(args) {
     var $input;
     var defaultValue;
@@ -783,4 +767,19 @@
     }
   }
 
+  // exports
+  $.extend(true, window, {
+    "Slick": {
+      "Editors": {
+        "Text": TextEditor,
+        "Integer": IntegerEditor,
+        "Float": FloatEditor,
+        "Date": DateEditor,
+        "YesNoSelect": YesNoSelectEditor,
+        "Checkbox": CheckboxEditor,
+        "PercentComplete": PercentCompleteEditor,
+        "LongText": LongTextEditor
+      }
+    }
+  });
 })(jQuery);

--- a/slick.formatters.js
+++ b/slick.formatters.js
@@ -9,20 +9,6 @@
  */
 
 (function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "Formatters": {
-        "PercentComplete": PercentCompleteFormatter,
-        "PercentCompleteBar": PercentCompleteBarFormatter,
-        "YesNo": YesNoFormatter,
-        "Checkmark": CheckmarkFormatter,
-        "Checkbox": CheckboxFormatter
-
-      }
-    }
-  });
-
   function PercentCompleteFormatter(row, cell, value, columnDef, dataContext) {
     if (value == null || value === "") {
       return "-";
@@ -62,4 +48,18 @@
   function CheckmarkFormatter(row, cell, value, columnDef, dataContext) {
     return value ? "<img src='../images/tick.png'>" : "";
   }
+
+  // exports
+  $.extend(true, window, {
+    "Slick": {
+      "Formatters": {
+        "PercentComplete": PercentCompleteFormatter,
+        "PercentCompleteBar": PercentCompleteBarFormatter,
+        "YesNo": YesNoFormatter,
+        "Checkmark": CheckmarkFormatter,
+        "Checkbox": CheckboxFormatter
+
+      }
+    }
+  });
 })(jQuery);

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -30,14 +30,6 @@ if (typeof Slick === "undefined") {
 
 (function ($) {
   "use strict";
-
-  // Slick.Grid
-  $.extend(true, window, {
-    Slick: {
-      Grid: SlickGrid
-    }
-  });
-
   // shared across all grids on the page
   var scrollbarDimensions;
   var maxSupportedCssHeight;  // browser's breaking point
@@ -6045,4 +6037,11 @@ if (typeof Slick === "undefined") {
 
     init();
   }
+
+  // exports
+  $.extend(true, window, {
+    Slick: {
+      Grid: SlickGrid
+    }
+  });
 }(jQuery));

--- a/slick.groupitemmetadataprovider.js
+++ b/slick.groupitemmetadataprovider.js
@@ -1,13 +1,4 @@
 (function ($) {
-  $.extend(true, window, {
-    Slick: {
-      Data: {
-        GroupItemMetadataProvider: GroupItemMetadataProvider
-      }
-    }
-  });
-
-
   /***
    * Provides item metadata for group (Slick.Group) and totals (Slick.Totals) rows produced by the DataView.
    * This metadata overrides the default behavior and formatting of those rows so that they appear and function
@@ -182,4 +173,13 @@
       "setOptions": setOptions
     };
   }
+
+  // exports
+  $.extend(true, window, {
+    Slick: {
+      Data: {
+        GroupItemMetadataProvider: GroupItemMetadataProvider
+      }
+    }
+  });
 })(jQuery);

--- a/slick.remotemodel-yahoo.js
+++ b/slick.remotemodel-yahoo.js
@@ -201,6 +201,12 @@
     };
   }
 
-  // Slick.Data.RemoteModel
-  $.extend(true, window, { Slick: { Data: { RemoteModel: RemoteModel }}});
+  // exports
+  $.extend(true, window, { 
+    Slick: { 
+      Data: { 
+        RemoteModel: RemoteModel 
+      }
+    }
+  });
 })(jQuery);

--- a/slick.remotemodel.js
+++ b/slick.remotemodel.js
@@ -164,6 +164,12 @@
     };
   }
 
-  // Slick.Data.RemoteModel
-  $.extend(true, window, { Slick: { Data: { RemoteModel: RemoteModel }}});
+  // exports
+  $.extend(true, window, { 
+    Slick: { 
+      Data: { 
+        RemoteModel: RemoteModel 
+      }
+    }
+  });
 })(jQuery);

--- a/tests/dataview/dataview.js
+++ b/tests/dataview/dataview.js
@@ -161,7 +161,7 @@ test("refresh fires after resume", function() {
     var count = 0;
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[0,1]}, "args");
+        same(args.rows, [0,1], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -243,7 +243,7 @@ test("applied immediately", function() {
     dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[0]}, "args");
+        same(args.rows, [0,1,2], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -277,7 +277,7 @@ test("re-applied on refresh", function() {
 
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[0]}, "args");
+        same(args.rows, [0,1,2], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -321,7 +321,8 @@ test("all", function() {
     var dv = new Slick.Data.DataView();
     dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
     dv.onRowsChanged.subscribe(function(e,args) {
-        ok(false, "onRowsChanged called");
+        ok(true, "onRowsChanged called");
+        same(args.rows, [0,1,2], "args");        
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
         ok(true, "onRowCountChanged called");
@@ -353,7 +354,7 @@ test("all then none", function() {
 
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[0,1,2]}, "args");
+        same(args.rows, [0,1,2], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -420,7 +421,7 @@ test("basic", function() {
 
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[1]}, "args");
+        same(args.rows, [1], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -461,7 +462,7 @@ test("updating an item to pass the filter", function() {
     dv.setFilter(function(o) { return o["val"] !== 1337; });
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[3]}, "args");
+        same(args.rows, [3], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -489,8 +490,9 @@ test("updating an item to not pass the filter", function() {
     dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2},{id:3,val:3}]);
     dv.setFilter(function(o) { return o["val"] !== 1337; });
     dv.onRowsChanged.subscribe(function(e,args) {
-        console.log(args);
-        ok(false, "onRowsChanged called");
+        ok(true, "onRowsChanged called");
+        same(args.rows, [3], "args");
+        count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
         ok(true, "onRowCountChanged called");
@@ -506,7 +508,7 @@ test("updating an item to not pass the filter", function() {
         count++;
     });
     dv.updateItem(3,{id:3,val:1337});
-    equal(count, 2, "events fired");
+    equal(count, 3, "events fired");
     same(dv.getItems()[3], {id:3,val:1337}, "item updated");
     assertConsistency(dv);
 });
@@ -520,7 +522,7 @@ test("basic", function() {
 
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[1,2]}, "args");
+        same(args.rows, [1,2], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -529,7 +531,7 @@ test("basic", function() {
     dv.onPagingInfoChanged.subscribe(function(e,args) {
         ok(false, "onPagingInfoChanged called");
     });
-    var newItems = [{id:1,val:1337},{id:1,val:4711}];
+    var newItems = [{id:1,val:1337},{id:2,val:4711}];
     dv.updateItems([1,2], newItems);
     equal(count, 1, "events fired");
     same(dv.getItem(1), newItems[0], "item updated");
@@ -561,7 +563,7 @@ test("updating an item not passing the filter", function() {
     dv.onPagingInfoChanged.subscribe(function(e,args) {
         ok(false, "onPagingInfoChanged called");
     });
-    var newItems = [{id:3,val:1337},{id:3,val:4711}];
+    var newItems = [{id:3,val:1337},{id:4,val:4711}];
     dv.updateItems([3,4], newItems);
     same(dv.getItems()[3], newItems[0], "item updated");
     same(dv.getItems()[4], newItems[1], "item updated");
@@ -575,7 +577,7 @@ test("updating an item to pass the filter", function() {
     dv.setFilter(function(o) { return o["val"] !== 1337 && o["val"] !== 4711; });
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[3,4]}, "args");
+        same(args.rows, [3,4,5], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -605,8 +607,9 @@ test("updating an item to not pass the filter", function() {
     dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2},{id:3,val:3},{id:4,val:4},{id:5,val:5}]);
     dv.setFilter(function(o) { return o["val"] !== 1337 && o["val"] !== 4711; });
     dv.onRowsChanged.subscribe(function(e,args) {
-        console.log(args);
-        ok(false, "onRowsChanged called");
+        ok(true, "onRowsChanged called");
+        same(args.rows, [3,4,5], "args");
+        count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
         ok(true, "onRowCountChanged called");
@@ -623,7 +626,7 @@ test("updating an item to not pass the filter", function() {
     });
     var newItems = [{id:3,val:1337},{id:4,val:4711}];
     dv.updateItems([3,4],newItems);
-    equal(count, 2, "events fired");
+    equal(count, 3, "events fired");
     same(dv.getItems()[3], newItems[0], "item updated");
     same(dv.getItems()[4], newItems[1], "item updated");
     assertConsistency(dv);
@@ -659,7 +662,7 @@ test("basic", function() {
     dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[3]}, "args");
+        same(args.rows, [3], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -730,7 +733,7 @@ test("basic", function() {
     dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[3,4,5]}, "args");
+        same(args.rows, [3,4,5], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -749,12 +752,12 @@ test("basic", function() {
     var newItems = [{id:3,val:1337},{id:4,val:4711},{id:5,val:8080}];
     dv.addItems(newItems);
     equal(count, 3, "events fired");
-    same(dv.getItems()[3], newItems[3], "item updated");
-    same(dv.getItems()[4], newItems[4], "item updated");
-    same(dv.getItems()[5], newItems[5], "item updated");
-    same(dv.getItem(3), newItems[3], "item updated");
-    same(dv.getItem(4), newItems[4], "item updated");
-    same(dv.getItem(5), newItems[5], "item updated");
+    same(dv.getItems()[3], newItems[0], "item updated");
+    same(dv.getItems()[4], newItems[1], "item updated");
+    same(dv.getItems()[5], newItems[2], "item updated");
+    same(dv.getItem(3), newItems[0], "item updated");
+    same(dv.getItem(4), newItems[1], "item updated");
+    same(dv.getItem(5), newItems[2], "item updated");
     assertConsistency(dv);
 });
 
@@ -788,7 +791,7 @@ test("insert at the beginning", function() {
     dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[0,1,2,3]}, "args");
+        same(args.rows, [0,1,2,3], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -818,7 +821,7 @@ test("insert in the middle", function() {
     dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[2,3]}, "args");
+        same(args.rows, [2,3], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -848,7 +851,7 @@ test("insert at the end", function() {
     dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[3]}, "args");
+        same(args.rows, [3], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -902,7 +905,7 @@ test("insert at the beginning", function() {
     dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[0,1,2,3,4,5]}, "args");
+        same(args.rows, [0,1,2,3,4,5], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -935,7 +938,7 @@ test("insert in the middle", function() {
     dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[2,3,4,5]}, "args");
+        same(args.rows, [2,3,4,5], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -969,7 +972,7 @@ test("insert at the end", function() {
     dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[3,4,5]}, "args");
+        same(args.rows, [3,4,5], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -1056,7 +1059,7 @@ test("delete at the beginning", function() {
     dv.setItems([{id:05,val:0},{id:15,val:1},{id:25,val:2}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[0,1]}, "args");
+        same(args.rows, [0,1,2], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -1085,7 +1088,7 @@ test("delete in the middle", function() {
     dv.setItems([{id:05,val:0},{id:15,val:1},{id:25,val:2}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[1]}, "args");
+        same(args.rows, [1, 2], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -1113,7 +1116,9 @@ test("delete at the end", function() {
     var dv = new Slick.Data.DataView();
     dv.setItems([{id:05,val:0},{id:15,val:1},{id:25,val:2}]);
     dv.onRowsChanged.subscribe(function(e,args) {
-        ok(false, "onRowsChanged called");
+        ok(true, "onRowsChanged called");
+        same(args.rows, [2], "args");
+        count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
         ok(true, "onRowCountChanged called");
@@ -1129,7 +1134,7 @@ test("delete at the end", function() {
         count++;
     });
     dv.deleteItem(25);
-    equal(count, 2, "events fired");
+    equal(count, 3, "events fired");
     equal(dv.getItems().length, 2, "items updated");
     equal(dv.getLength(), 2, "rows updated");
     assertConsistency(dv);
@@ -1195,7 +1200,7 @@ test("delete at the beginning", function() {
     dv.setItems([{id:05,val:0},{id:15,val:1},{id:25,val:2},{id:35,val:3},{id:45,val:4}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[0,1]}, "args");
+        same(args.rows, [0,1,2,3,4], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -1213,7 +1218,7 @@ test("delete at the beginning", function() {
     });
     dv.deleteItems([05,15]);
     equal(count, 3, "events fired");
-    equal(dv.getItems().length, 2, "items updated");
+    equal(dv.getItems().length, 3, "items updated");
     equal(dv.getLength(), 3, "rows updated");
     assertConsistency(dv);
 });
@@ -1224,7 +1229,7 @@ test("delete in the middle", function() {
     dv.setItems([{id:05,val:0},{id:15,val:1},{id:25,val:2},{id:35,val:3},{id:45,val:4}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[1,2]}, "args");
+        same(args.rows, [1,2,3,4], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -1253,7 +1258,7 @@ test("delete in the middle mixed", function() {
     dv.setItems([{id:05,val:0},{id:15,val:1},{id:25,val:2},{id:35,val:3},{id:45,val:4}]);
     dv.onRowsChanged.subscribe(function(e,args) {
         ok(true, "onRowsChanged called");
-        same(args, {rows:[1,3]}, "args");
+        same(args.rows, [1,2,3,4], "args");
         count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
@@ -1281,7 +1286,9 @@ test("delete at the end", function() {
     var dv = new Slick.Data.DataView();
     dv.setItems([{id:05,val:0},{id:15,val:1},{id:25,val:2},{id:35,val:3},{id:45,val:4}]);
     dv.onRowsChanged.subscribe(function(e,args) {
-        ok(false, "onRowsChanged called");
+        ok(true, "onRowsChanged called");
+        same(args.rows, [3,4], "args");
+        count++;
     });
     dv.onRowCountChanged.subscribe(function(e,args) {
         ok(true, "onRowCountChanged called");
@@ -1296,8 +1303,8 @@ test("delete at the end", function() {
         equal(args.totalRows, 3, "totalRows arg");
         count++;
     });
-    dv.deleteItem(25);
-    equal(count, 2, "events fired");
+    dv.deleteItems([35,45]);
+    equal(count, 3, "events fired");
     equal(dv.getItems().length, 3, "items updated");
     equal(dv.getLength(), 3, "rows updated");
     assertConsistency(dv);

--- a/tests/dataview/dataview.js
+++ b/tests/dataview/dataview.js
@@ -511,6 +511,123 @@ test("updating an item to not pass the filter", function() {
     assertConsistency(dv);
 });
 
+module("updateItems");
+
+test("basic", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2},{id:3,val:3},{id:4,val:4}]);
+
+    dv.onRowsChanged.subscribe(function(e,args) {
+        ok(true, "onRowsChanged called");
+        same(args, {rows:[1,2]}, "args");
+        count++;
+    });
+    dv.onRowCountChanged.subscribe(function(e,args) {
+        ok(false, "onRowCountChanged called");
+    });
+    dv.onPagingInfoChanged.subscribe(function(e,args) {
+        ok(false, "onPagingInfoChanged called");
+    });
+    var newItems = [{id:1,val:1337},{id:1,val:4711}];
+    dv.updateItems([1,2], newItems);
+    equal(count, 1, "events fired");
+    same(dv.getItem(1), newItems[0], "item updated");
+    same(dv.getItem(2), newItems[1], "item updated");
+    assertConsistency(dv);
+});
+
+test("length mismatch", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2},{id:3,val:3},{id:4,val:4}]);
+    try {
+        dv.updateItems([1], [{id:1,val:1337},{id:1,val:4711}]);
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+});
+
+test("updating an item not passing the filter", function() {
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2},{id:3,val:1337},{id:4,val:4711},{id:5,val:5}]);
+    dv.setFilter(function(o) { return o["val"] !== 1337 && o["val"] !== 4711; });
+    dv.onRowsChanged.subscribe(function(e,args) {
+        ok(false, "onRowsChanged called");
+    });
+    dv.onRowCountChanged.subscribe(function(e,args) {
+        ok(false, "onRowCountChanged called");
+    });
+    dv.onPagingInfoChanged.subscribe(function(e,args) {
+        ok(false, "onPagingInfoChanged called");
+    });
+    var newItems = [{id:3,val:1337},{id:3,val:4711}];
+    dv.updateItems([3,4], newItems);
+    same(dv.getItems()[3], newItems[0], "item updated");
+    same(dv.getItems()[4], newItems[1], "item updated");
+    assertConsistency(dv);
+});
+
+test("updating an item to pass the filter", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2},{id:3,val:1337},{id:4,val:4711},{id:5,val:5}]);
+    dv.setFilter(function(o) { return o["val"] !== 1337 && o["val"] !== 4711; });
+    dv.onRowsChanged.subscribe(function(e,args) {
+        ok(true, "onRowsChanged called");
+        same(args, {rows:[3,4]}, "args");
+        count++;
+    });
+    dv.onRowCountChanged.subscribe(function(e,args) {
+        ok(true, "onRowCountChanged called");
+        equal(args.previous, 4, "previous arg");
+        equal(args.current, 6, "current arg");
+        count++;
+    });
+    dv.onPagingInfoChanged.subscribe(function(e,args) {
+        ok(true, "onPagingInfoChanged called");
+        same(args.pageSize, 0, "pageSize arg");
+        same(args.pageNum, 0, "pageNum arg");
+        same(args.totalRows, 6, "totalRows arg");
+        count++;        
+    });
+    var newItems = [{id:3,val:3},{id:4,val:4}];
+    dv.updateItems([3,4],newItems);
+    equal(count, 3, "events fired");
+    same(dv.getItems()[3], newItems[0], "item updated");
+    same(dv.getItems()[4], newItems[1], "item updated");
+    assertConsistency(dv);
+});
+
+test("updating an item to not pass the filter", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2},{id:3,val:3},{id:4,val:4},{id:5,val:5}]);
+    dv.setFilter(function(o) { return o["val"] !== 1337 && o["val"] !== 4711; });
+    dv.onRowsChanged.subscribe(function(e,args) {
+        console.log(args);
+        ok(false, "onRowsChanged called");
+    });
+    dv.onRowCountChanged.subscribe(function(e,args) {
+        ok(true, "onRowCountChanged called");
+        equal(args.previous, 6, "previous arg");
+        equal(args.current, 4, "current arg");
+        count++;
+    });
+    dv.onPagingInfoChanged.subscribe(function(e,args) {
+        ok(true, "onPagingInfoChanged called");
+        same(args.pageSize, 0, "pageSize arg");
+        same(args.pageNum, 0, "pageNum arg");
+        same(args.totalRows, 4, "totalRows arg");
+        count++;
+    });
+    var newItems = [{id:3,val:1337},{id:4,val:4711}];
+    dv.updateItems([3,4],newItems);
+    equal(count, 2, "events fired");
+    same(dv.getItems()[3], newItems[0], "item updated");
+    same(dv.getItems()[4], newItems[1], "item updated");
+    assertConsistency(dv);
+});
 
 module("addItem");
 
@@ -580,6 +697,64 @@ test("add an item not passing the filter", function() {
     });
     dv.addItem({id:3,val:1337});
     same(dv.getItems()[3], {id:3,val:1337}, "item updated");
+    assertConsistency(dv);
+});
+
+module("addItems");
+
+test("must have id", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
+    try {
+        dv.addItems([{id:3,val:3}, {val:1337}]);
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+});
+
+test("must have id (custom)", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{uid:0,val:0},{uid:1,val:1},{uid:2,val:2}], "uid");
+    try {
+        dv.addItems([{uid:3,val:3},{id:3,val:1337}]);
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+});
+
+test("basic", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
+    dv.onRowsChanged.subscribe(function(e,args) {
+        ok(true, "onRowsChanged called");
+        same(args, {rows:[3,4,5]}, "args");
+        count++;
+    });
+    dv.onRowCountChanged.subscribe(function(e,args) {
+        ok(true, "onRowCountChanged called");
+        equal(args.previous, 3, "previous arg");
+        equal(args.current, 6, "current arg");
+        count++;
+    });
+    dv.onPagingInfoChanged.subscribe(function(e,args) {
+        ok(true, "onPagingInfoChanged called");
+        equal(args.pageSize, 0, "pageSize arg");
+        equal(args.pageNum, 0, "pageNum arg");
+        equal(args.totalRows, 6, "totalRows arg");
+        count++;
+    });
+    var newItems = [{id:3,val:1337},{id:4,val:4711},{id:5,val:8080}];
+    dv.addItems(newItems);
+    equal(count, 3, "events fired");
+    same(dv.getItems()[3], newItems[3], "item updated");
+    same(dv.getItems()[4], newItems[4], "item updated");
+    same(dv.getItems()[5], newItems[5], "item updated");
+    same(dv.getItem(3), newItems[3], "item updated");
+    same(dv.getItem(4), newItems[4], "item updated");
+    same(dv.getItem(5), newItems[5], "item updated");
     assertConsistency(dv);
 });
 
@@ -694,6 +869,130 @@ test("insert at the end", function() {
     same(dv.getItem(3), {id:3,val:1337}, "item updated");
     equal(dv.getItems().length, 4, "items updated");
     equal(dv.getLength(), 4, "rows updated");
+    assertConsistency(dv);
+});
+
+module("insertItems");
+
+test("must have id", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
+    try {
+        dv.insertItems(0,[{id:3,val:1337},{val:4711}]);
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+});
+
+test("must have id (custom)", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{uid:0,val:0},{uid:1,val:1},{uid:2,val:2}], "uid");
+    try {
+        dv.insertItems(0,[{uid:3,val:1337},{id:4,val:4711}]);
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+});
+
+test("insert at the beginning", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
+    dv.onRowsChanged.subscribe(function(e,args) {
+        ok(true, "onRowsChanged called");
+        same(args, {rows:[0,1,2,3,4,5]}, "args");
+        count++;
+    });
+    dv.onRowCountChanged.subscribe(function(e,args) {
+        ok(true, "onRowCountChanged called");
+        equal(args.previous, 3, "previous arg");
+        equal(args.current, 6, "current arg");
+        count++;
+    });
+    dv.onPagingInfoChanged.subscribe(function(e,args) {
+        ok(true, "onPagingInfoChanged called");
+        equal(args.pageSize, 0, "pageSize arg");
+        equal(args.pageNum, 0, "pageNum arg");
+        equal(args.totalRows, 6, "totalRows arg");
+        count++;
+    });
+    var newItems = [{id:3,val:1337},{id:4,val:4711},{id:5,val:8080}];
+    dv.insertItems(0, newItems);
+    equal(count, 3, "events fired");
+    same(dv.getItem(0), newItems[0], "item updated");
+    same(dv.getItem(1), newItems[1], "item updated");
+    same(dv.getItem(2), newItems[2], "item updated");
+    equal(dv.getItems().length, 6, "items updated");
+    equal(dv.getLength(), 6, "rows updated");
+    assertConsistency(dv);
+});
+
+test("insert in the middle", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
+    dv.onRowsChanged.subscribe(function(e,args) {
+        ok(true, "onRowsChanged called");
+        same(args, {rows:[2,3,4,5]}, "args");
+        count++;
+    });
+    dv.onRowCountChanged.subscribe(function(e,args) {
+        ok(true, "onRowCountChanged called");
+        equal(args.previous, 3, "previous arg");
+        equal(args.current, 6, "current arg");
+        count++;
+    });
+    dv.onPagingInfoChanged.subscribe(function(e,args) {
+        ok(true, "onPagingInfoChanged called");
+        equal(args.pageSize, 0, "pageSize arg");
+        equal(args.pageNum, 0, "pageNum arg");
+        equal(args.totalRows, 6, "totalRows arg");
+        count++;
+    });
+    var newItems = [{id:3,val:1337},{id:4,val:4711},{id:5,val:8080}];
+    dv.insertItems(2, newItems);
+    equal(count, 3, "events fired");
+    same(dv.getItem(2), newItems[0], "item updated");
+    same(dv.getItem(3), newItems[1], "item updated");
+    same(dv.getItem(4), newItems[2], "item updated");
+    same(dv.getItem(5), {id:2,val:2}, "item updated");
+    equal(dv.getItems().length, 6, "items updated");
+    equal(dv.getLength(), 6, "rows updated");
+    assertConsistency(dv);
+});
+
+test("insert at the end", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
+    dv.onRowsChanged.subscribe(function(e,args) {
+        ok(true, "onRowsChanged called");
+        same(args, {rows:[3,4,5]}, "args");
+        count++;
+    });
+    dv.onRowCountChanged.subscribe(function(e,args) {
+        ok(true, "onRowCountChanged called");
+        equal(args.previous, 3, "previous arg");
+        equal(args.current, 6, "current arg");
+        count++;
+    });
+    dv.onPagingInfoChanged.subscribe(function(e,args) {
+        ok(true, "onPagingInfoChanged called");
+        equal(args.pageSize, 0, "pageSize arg");
+        equal(args.pageNum, 0, "pageNum arg");
+        equal(args.totalRows, 6, "totalRows arg");
+        count++;
+    });
+    var newItems = [{id:3,val:1337},{id:4,val:4711},{id:5,val:8080}];
+    dv.insertItems(3, newItems);
+    equal(count, 3, "events fired");
+    same(dv.getItem(3), newItems[0], "item updated");
+    same(dv.getItem(4), newItems[1], "item updated");
+    same(dv.getItem(5), newItems[2], "item updated");
+    equal(dv.getItems().length, 6, "items updated");
+    equal(dv.getLength(), 6, "rows updated");
     assertConsistency(dv);
 });
 
@@ -833,6 +1132,174 @@ test("delete at the end", function() {
     equal(count, 2, "events fired");
     equal(dv.getItems().length, 2, "items updated");
     equal(dv.getLength(), 2, "rows updated");
+    assertConsistency(dv);
+});
+
+module("deleteItems");
+
+test("must have id", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
+    try {
+        dv.deleteItems([0, -1]);
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+    try {
+        dv.deleteItems([undefined]);
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+    try {
+        dv.deleteItems([null]);
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+    try {
+        dv.deleteItems([3]);
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+});
+
+test("must have id (custom)", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{uid:0,id:-1,val:0},{uid:1,id:3,val:1},{uid:2,id:null,val:2}], "uid");
+    try {
+        dv.deleteItems([0, -1]);
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+    try {
+        dv.deleteItems([undefined]);
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+    try {
+        dv.deleteItems([null]);
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+    try {
+        dv.deleteItems([3]);
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+});
+
+test("delete at the beginning", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:05,val:0},{id:15,val:1},{id:25,val:2},{id:35,val:3},{id:45,val:4}]);
+    dv.onRowsChanged.subscribe(function(e,args) {
+        ok(true, "onRowsChanged called");
+        same(args, {rows:[0,1]}, "args");
+        count++;
+    });
+    dv.onRowCountChanged.subscribe(function(e,args) {
+        ok(true, "onRowCountChanged called");
+        equal(args.previous, 5, "previous arg");
+        equal(args.current, 3, "current arg");
+        count++;
+    });
+    dv.onPagingInfoChanged.subscribe(function(e,args) {
+        ok(true, "onPagingInfoChanged called");
+        equal(args.pageSize, 0, "pageSize arg");
+        equal(args.pageNum, 0, "pageNum arg");
+        equal(args.totalRows, 3, "totalRows arg");
+        count++;
+    });
+    dv.deleteItems([05,15]);
+    equal(count, 3, "events fired");
+    equal(dv.getItems().length, 2, "items updated");
+    equal(dv.getLength(), 3, "rows updated");
+    assertConsistency(dv);
+});
+
+test("delete in the middle", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:05,val:0},{id:15,val:1},{id:25,val:2},{id:35,val:3},{id:45,val:4}]);
+    dv.onRowsChanged.subscribe(function(e,args) {
+        ok(true, "onRowsChanged called");
+        same(args, {rows:[1,2]}, "args");
+        count++;
+    });
+    dv.onRowCountChanged.subscribe(function(e,args) {
+        ok(true, "onRowCountChanged called");
+        equal(args.previous, 5, "previous arg");
+        equal(args.current, 3, "current arg");
+        count++;
+    });
+    dv.onPagingInfoChanged.subscribe(function(e,args) {
+        ok(true, "onPagingInfoChanged called");
+        equal(args.pageSize, 0, "pageSize arg");
+        equal(args.pageNum, 0, "pageNum arg");
+        equal(args.totalRows, 3, "totalRows arg");
+        count++;
+    });
+    dv.deleteItems([15,25]);
+    equal(count, 3, "events fired");
+    equal(dv.getItems().length, 3, "items updated");
+    equal(dv.getLength(), 3, "rows updated");
+    assertConsistency(dv);
+});
+
+test("delete in the middle mixed", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:05,val:0},{id:15,val:1},{id:25,val:2},{id:35,val:3},{id:45,val:4}]);
+    dv.onRowsChanged.subscribe(function(e,args) {
+        ok(true, "onRowsChanged called");
+        same(args, {rows:[1,3]}, "args");
+        count++;
+    });
+    dv.onRowCountChanged.subscribe(function(e,args) {
+        ok(true, "onRowCountChanged called");
+        equal(args.previous, 5, "previous arg");
+        equal(args.current, 3, "current arg");
+        count++;
+    });
+    dv.onPagingInfoChanged.subscribe(function(e,args) {
+        ok(true, "onPagingInfoChanged called");
+        equal(args.pageSize, 0, "pageSize arg");
+        equal(args.pageNum, 0, "pageNum arg");
+        equal(args.totalRows, 3, "totalRows arg");
+        count++;
+    });
+    dv.deleteItems([15,35]);
+    equal(count, 3, "events fired");
+    equal(dv.getItems().length, 3, "items updated");
+    equal(dv.getLength(), 3, "rows updated");
+    assertConsistency(dv);
+});
+
+test("delete at the end", function() {
+    var count = 0;
+    var dv = new Slick.Data.DataView();
+    dv.setItems([{id:05,val:0},{id:15,val:1},{id:25,val:2},{id:35,val:3},{id:45,val:4}]);
+    dv.onRowsChanged.subscribe(function(e,args) {
+        ok(false, "onRowsChanged called");
+    });
+    dv.onRowCountChanged.subscribe(function(e,args) {
+        ok(true, "onRowCountChanged called");
+        equal(args.previous, 5, "previous arg");
+        equal(args.current, 3, "current arg");
+        count++;
+    });
+    dv.onPagingInfoChanged.subscribe(function(e,args) {
+        ok(true, "onPagingInfoChanged called");
+        equal(args.pageSize, 0, "pageSize arg");
+        equal(args.pageNum, 0, "pageNum arg");
+        equal(args.totalRows, 3, "totalRows arg");
+        count++;
+    });
+    dv.deleteItem(25);
+    equal(count, 2, "events fired");
+    equal(dv.getItems().length, 3, "items updated");
+    equal(dv.getLength(), 3, "rows updated");
     assertConsistency(dv);
 });
 


### PR DESCRIPTION
Resolves #571 

This PR addresses the proposed changes of #571 to have more efficient bulk update capabilities in the Data View. 

**PR Checklist** 

- [x] Changes implemented
- [x] QUnit Tests Added
- [x] Code Documentation updated
- [x] Cypress Tests Added
- [x] Wiki updated - Grab the updated version from https://github.com/Danielku15/SlickGrid-wiki/blob/feat/bulk-updates/DataView.md

**Proposed Changes**

### 1. Add/Insert/Delete operations which accept multiple items
The first change is to add plural versions of the main modification methods: addItems, updateItems, deleteItems
These operations use more optimized array updates and ensure the related index lookup updates + refresh are only triggered once. 

### 2. Bulk Support for beginUpdate/endUpdate
The second change is to allow devs to indicate that bigger bulk updates are performed on the DataView. Internally this bulk update flag is then used at certain places to delay or optimize certain operations. 

For now it is used to delay the delete operations to the endUpdate call which allows a 1 time reorganization of the internal items array and the index lookup table. 

Alternative API approaches could be: 

- Add a separate `beginBulkUpdate` / `endBulkUpdate` method pair. 
- Accept an object `updateHints` as parameter to `beginUpdate` instead of a simple bool.
- Add a separate `setUpdateHints` comparable to `setRefreshHints` to set the bulk option. 
- Re-use `setRefreshHints` to set the bulkUpdate option. 

### 3. Usage of a Map polyfill for better performance 
SlickGrid tries to be very backwards compatible with old browser. Using a `Map` instead of a simple object for object lookups boosts the performance further. On a basic test on chrome:

With object: 
![image](https://user-images.githubusercontent.com/674916/105363071-f0373180-5bfb-11eb-8cc3-c7485534bb40.png)

With the Map polyfill:
![image](https://user-images.githubusercontent.com/674916/105363132-0218d480-5bfc-11eb-8ede-3318c5390bd3.png) 

### 4. Update of DataView QUnit tests
They were quite outdated in regard of the latest behavior. I adopted the current behavior in the test to make them green. 
In the old days it seems `onRowsChanged` was fired with the `args.rows` filled to the newly created rows after the related update. 
The current version contains in `args.rows`the indexes of the rows **before** the update. e.g. if we had 3 rows before, and delete the last one, it signals now that rows 0,1 **and 2** changed. Row 2 does not exist anymore. As I think the current approach is the desired one, I rather updated the tests than fixing the logic. 

### 5. New Example Page and Cypress test
I added a new example page showing the significant performance difference on using the newly available operations. On top I added a Cypress test which also checks that the efficient version takes maximum 50% of the inefficient one. 
