### PR TITLE
Fixes for issues with frozen columns,  column reordering, and preheader visibility

### DIFF
--- a/plugins/slick.draggablegrouping.js
+++ b/plugins/slick.draggablegrouping.js
@@ -124,7 +124,15 @@
               $(this).sortable("cancel");
               return;
             }
-            var reorderedIds = $headers.sortable("toArray");
+           var reorderedIds = $headers.sortable("toArray");
+            if($headers.length > 1) {
+              for(var ctr=1,l=$headers.length; ctr < l; ctr+=1) {
+                $header = $($headers[ctr]);
+                for(var ctr2=0,l2=$header.length; ctr2< l2; ctr2+=1) {
+                    reorderedIds.push($header[ctr2]);
+                }                
+              }
+            }
             var reorderedColumns = [];
             for (var i = 0; i < reorderedIds.length; i++) {
               reorderedColumns.push(columns[getColumnIndex(reorderedIds[i].replace(uid, ""))]);

--- a/plugins/slick.draggablegrouping.js
+++ b/plugins/slick.draggablegrouping.js
@@ -128,14 +128,14 @@
             // If frozen columns are used, headers has more than one entry and we need the ids from all of them.
             // though there is only really a left and right header, this will work even if that should change.
             if($headers.length > 1) {
-              for(var ctr=1,l=$headers.length; ctr < l; ctr+=1) {
-                var $header = $($headers[ctr]);
+              for(var headerI=1,l=$headers.length; headerI < l; headerI+=1) {
+                var $header = $($headers[headerI]);
                 var ids = $header.sortable("toArray");
                 // Note: the loop below could be simplified with:
                 // reorderedIds.push.apply(reorderedIds,ids);
                 // However, the loop is more in keeping with way-backward compatibility 
-                for(var ctr2=0,l2=ids.length; ctr2< l2; ctr2+=1) {
-                    reorderedIds.push($header[ctr2]);
+                for(var headerI2=0,l2=ids.length; headerI2< l2; headerI2+=1) {
+                    reorderedIds.push($header[headerI2]);
                 }                
               }
             }

--- a/plugins/slick.draggablegrouping.js
+++ b/plugins/slick.draggablegrouping.js
@@ -134,8 +134,8 @@
                 // Note: the loop below could be simplified with:
                 // reorderedIds.push.apply(reorderedIds,ids);
                 // However, the loop is more in keeping with way-backward compatibility 
-                for(var headerI2=0,l2=ids.length; headerI2< l2; headerI2+=1) {
-                    reorderedIds.push($header[headerI2]);
+                for(var idI=0,idL=ids.length; idI< idL; idI+=1) {
+                    reorderedIds.push(ids[idI]);
                 }                
               }
             }

--- a/plugins/slick.draggablegrouping.js
+++ b/plugins/slick.draggablegrouping.js
@@ -124,11 +124,17 @@
               $(this).sortable("cancel");
               return;
             }
-           var reorderedIds = $headers.sortable("toArray");
+            var reorderedIds = $headers.sortable("toArray");
+            // If frozen columns are used, headers has more than one entry and we need the ids from all of them.
+            // though there is only really a left and right header, this will work even if that should change.
             if($headers.length > 1) {
               for(var ctr=1,l=$headers.length; ctr < l; ctr+=1) {
-                $header = $($headers[ctr]);
-                for(var ctr2=0,l2=$header.length; ctr2< l2; ctr2+=1) {
+                var $header = $($headers[ctr]);
+                var ids = $header.sortable("toArray");
+                // Note: the loop below could be simplified with:
+                // reorderedIds.push.apply(reorderedIds,ids);
+                // However, the loop is more in keeping with way-backward compatibility 
+                for(var ctr2=0,l2=ids.length; ctr2< l2; ctr2+=1) {
                     reorderedIds.push($header[ctr2]);
                 }                
               }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3073,15 +3073,20 @@ if (typeof Slick === "undefined") {
         if (visible) {
           if (animated) {
             $preHeaderPanelScroller.slideDown("fast", resizeCanvas);
+            $preHeaderPanelScrollerR.slideDown("fast", resizeCanvas);
+            
           } else {
             $preHeaderPanelScroller.show();
+            $preHeaderPanelScrollerR.show();
             resizeCanvas();
           }
         } else {
           if (animated) {
             $preHeaderPanelScroller.slideUp("fast", resizeCanvas);
+            $preHeaderPanelScrollerR.slideUp("fast", resizeCanvas);
           } else {
             $preHeaderPanelScroller.hide();
+            $preHeaderPanelScrollerR.slideDown("fast", resizeCanvas);
             resizeCanvas();
           }
         }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -367,7 +367,7 @@ if (typeof Slick === "undefined") {
       $paneTopR = $("<div class='slick-pane slick-pane-top slick-pane-right' tabIndex='0' />").appendTo($container);
       $paneBottomL = $("<div class='slick-pane slick-pane-bottom slick-pane-left' tabIndex='0' />").appendTo($container);
       $paneBottomR = $("<div class='slick-pane slick-pane-bottom slick-pane-right' tabIndex='0' />").appendTo($container);
-
+      
       if (options.createPreHeaderPanel) {
         $preHeaderPanelScroller = $("<div class='slick-preheader-panel ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($paneHeaderL);
         $preHeaderPanel = $("<div />").appendTo($preHeaderPanelScroller);
@@ -3086,7 +3086,7 @@ if (typeof Slick === "undefined") {
             $preHeaderPanelScrollerR.slideUp("fast", resizeCanvas);
           } else {
             $preHeaderPanelScroller.hide();
-            $preHeaderPanelScrollerR.slideDown("fast", resizeCanvas);
+            $preHeaderPanelScrollerR.hide();
             resizeCanvas();
           }
         }


### PR DESCRIPTION
Although I have not reported the issue, I discovered a couple issues when freezing columns while column reordering is enabled.

1) The unfrozen column headers were disappearing  when I froze columns and had the pre-header row collapsed.
2) When columns were frozen dragging a column would make the unfrozen columns dissappear.

The commit message for the changes has details about the bugs and their causes.

These changes should be non-blocking and should improve behavior for frozen column support.