### PR TITLE
To Fix the issue specific to drag selection in non-frozen part of grid if there are multiple grids.

### DIFF
--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -71,13 +71,13 @@
       _isBottomCanvas = _$activeCanvas.hasClass('grid-canvas-bottom');
 
       if (_gridOptions.frozenRow > -1 && _isBottomCanvas) {
-        _rowOffset = (_gridOptions.frozenBottom) ? $('.grid-canvas-bottom').height() : $('.grid-canvas-top').height();
+        _rowOffset = (_gridOptions.frozenBottom) ? $(`.${_grid.getUID()} .grid-canvas-bottom`).height() : $(`.${_grid.getUID()} .grid-canvas-top`).height();
       }
 
       _isRightCanvas = _$activeCanvas.hasClass('grid-canvas-right');
 
       if (_gridOptions.frozenColumn > -1 && _isRightCanvas) {
-        _columnOffset = $('.grid-canvas-left').width();
+        _columnOffset = $(`.${_grid.getUID()} .grid-canvas-left`).width();
       }
 
       // prevent the grid from cancelling drag'n'drop by default

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -71,13 +71,13 @@
       _isBottomCanvas = _$activeCanvas.hasClass('grid-canvas-bottom');
 
       if (_gridOptions.frozenRow > -1 && _isBottomCanvas) {
-        _rowOffset = (_gridOptions.frozenBottom) ? $(`.${_grid.getUID()} .grid-canvas-bottom`).height() : $(`.${_grid.getUID()} .grid-canvas-top`).height();
+        _rowOffset = (_gridOptions.frozenBottom) ? $('.'+_grid.getUID()+' .grid-canvas-bottom').height() : $('.'+_grid.getUID()+' .grid-canvas-top').height();
       }
 
       _isRightCanvas = _$activeCanvas.hasClass('grid-canvas-right');
 
       if (_gridOptions.frozenColumn > -1 && _isRightCanvas) {
-        _columnOffset = $(`.${_grid.getUID()} .grid-canvas-left`).width();
+        _columnOffset = $('.'+_grid.getUID()+' .grid-canvas-left').width();
       }
 
       // prevent the grid from cancelling drag'n'drop by default


### PR DESCRIPTION
Issue Description: if we have multiple grids in same page/in the DOM, earlier code looks for  '.grid-canvas-left' width which indeed gets the result of the grid where the event triggered along with the other grids present in the DOM. If the action is done on second grid(which has frozen column) instead of first one, earlier code is getting the width of first grid instead of second one. So made changes to get the width only for the event triggered grid.