### PR TITLE
feat: add target to `onBeforeEditCell`

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -367,7 +367,7 @@ if (typeof Slick === "undefined") {
       $paneTopR = $("<div class='slick-pane slick-pane-top slick-pane-right' tabIndex='0' />").appendTo($container);
       $paneBottomL = $("<div class='slick-pane slick-pane-bottom slick-pane-left' tabIndex='0' />").appendTo($container);
       $paneBottomR = $("<div class='slick-pane slick-pane-bottom slick-pane-right' tabIndex='0' />").appendTo($container);
-      
+
       if (options.createPreHeaderPanel) {
         $preHeaderPanelScroller = $("<div class='slick-preheader-panel ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($paneHeaderL);
         $preHeaderPanel = $("<div />").appendTo($preHeaderPanelScroller);
@@ -3074,7 +3074,6 @@ if (typeof Slick === "undefined") {
           if (animated) {
             $preHeaderPanelScroller.slideDown("fast", resizeCanvas);
             $preHeaderPanelScrollerR.slideDown("fast", resizeCanvas);
-            
           } else {
             $preHeaderPanelScroller.show();
             $preHeaderPanelScrollerR.show();
@@ -5033,7 +5032,7 @@ if (typeof Slick === "undefined") {
       var columnDef = columns[activeCell];
       var item = getDataItem(activeRow);
 
-      if (trigger(self.onBeforeEditCell, {row: activeRow, cell: activeCell, item: item, column: columnDef}) === false) {
+      if (trigger(self.onBeforeEditCell, {row: activeRow, cell: activeCell, item: item, column: columnDef, target: 'grid' }) === false) {
         setFocus();
         return;
       }


### PR DESCRIPTION
- the available `target` options will be: "grid" or "composite"
 - since we can also use the `onBeforeEditCell` event within the Composite Editor, I needed a way to make a distinction between a call made with `onBeforeEditCell` from the grid or from the composite component. This `target` will let me know where it was executed from.