### PR TITLE
fix: deactivate edit controller shouldn't throw when active is null

### DIFF
--- a/slick.core.js
+++ b/slick.core.js
@@ -418,6 +418,9 @@
      * @param editController {EditController} edit controller releasing the lock
      */
     this.deactivate = function (editController) {
+      if (!activeEditController) {
+        return;
+      }
       if (activeEditController !== editController) {
         throw new Error("SlickGrid.EditorLock.deactivate: specified editController is not the currently active one");
       }


### PR DESCRIPTION
it had errors thrown when using `autoEdit` and `setActiveCell` which calls `makeActiveCellNormal` which calls `deactivate` which finally throws that error even when the active edit controller is null but that shouldn't matter if it is already null then we shouldn't care and not throw