### PR TITLE
feat: add onColumnsResizeDblClick event to adding new resize extras

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1845,6 +1845,10 @@ if (typeof Slick === "undefined") {
               render();
               trigger(self.onColumnsResized, { triggeredByColumn: triggeredByColumn });
               setTimeout(function () { columnResizeDragging = false; }, 300);
+            })
+            .on("dblclick", function () {
+              var triggeredByColumn = $(this).parent().attr("id").replace(uid, "");
+              trigger(self.onColumnsResizeDblClick, { triggeredByColumn: triggeredByColumn });
             });
       });
     }
@@ -5913,6 +5917,7 @@ if (typeof Slick === "undefined") {
       "onColumnsReordered": new Slick.Event(),
       "onColumnsDrag": new Slick.Event(),
       "onColumnsResized": new Slick.Event(),
+      "onColumnsResizeDblClick": new Slick.Event(),
       "onBeforeColumnsResize": new Slick.Event(),
       "onCellChange": new Slick.Event(),
       "onCompositeEditorChange": new Slick.Event(),


### PR DESCRIPTION
- this new event will help in implementing a resize by cell content but only for the column that its resize was double-clicked (pretty much the same Excel)
- as shown in the print screen below, the event will trigger when we double-click while the resize icon shows up when hovering between 2 columns

![image](https://user-images.githubusercontent.com/643976/117230604-75c9a080-adeb-11eb-8512-f1c69e6a9e63.png)

![hQ8mk7Gn9N](https://user-images.githubusercontent.com/643976/117231029-55e6ac80-adec-11eb-9ac2-1a1803f7c9df.gif)
 