### PR TITLE
fix: left frozen section shoudn't go over viewport width, fix #473

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -91,6 +91,7 @@ if (typeof Slick === "undefined") {
       frozenBottom: false,
       frozenColumn: -1,
       frozenRow: -1,
+      frozenRightViewportMinWidth: 100,
       fullWidthRows: false,
       multiColumnSort: false,
       numberedMultiColumnSort: false,
@@ -1585,6 +1586,7 @@ if (typeof Slick === "undefined") {
 
     function setupColumnResize() {
       var $col, j, k, c, pageX, columnElements, minPageX, maxPageX, firstResizable, lastResizable;
+      var frozenLeftColMaxWidth = 0;
       columnElements = $headers.children();
       columnElements.find(".slick-resizable-handle").remove();
       columnElements.each(function (i, e) {
@@ -1612,6 +1614,7 @@ if (typeof Slick === "undefined") {
                 return false;
               }
               pageX = e.pageX;
+              frozenLeftColMaxWidth = 0;
               $(this).parent().addClass("slick-header-column-active");
               var shrinkLeewayOnRight = null, stretchLeewayOnRight = null;
               // lock each column's width option to current width
@@ -1671,6 +1674,7 @@ if (typeof Slick === "undefined") {
               columnResizeDragging = true;
               var actualMinWidth, d = Math.min(maxPageX, Math.max(minPageX, e.pageX)) - pageX, x;
               var newCanvasWidthL = 0, newCanvasWidthR = 0;
+              var viewportWidth = viewportHasVScroll ? viewportW - scrollbarDimensions.width : viewportW;
 
               if (d < 0) { // shrink column
                 x = d;
@@ -1759,7 +1763,18 @@ if (typeof Slick === "undefined") {
                       x -= c.maxWidth - c.previousWidth;
                       c.width = c.maxWidth;
                     } else {
-                      c.width = c.previousWidth + x;
+                      var newWidth = c.previousWidth + x;
+                      var resizedCanvasWidthL = canvasWidthL + x;
+
+                      if (hasFrozenColumns() && (j <= options.frozenColumn)) {
+                        // if we're on the left frozen side, we need to make sure that our left section width never goes over the total viewport width
+                        if (newWidth > frozenLeftColMaxWidth && resizedCanvasWidthL < (viewportWidth - options.frozenRightViewportMinWidth)) {
+                          frozenLeftColMaxWidth = newWidth; // keep max column width ref, if we go over the limit this number will stop increasing
+                        }
+                        c.width = ((resizedCanvasWidthL + options.frozenRightViewportMinWidth) > viewportWidth) ? frozenLeftColMaxWidth : newWidth;
+                      } else {
+                        c.width = newWidth;
+                      }
                       x = 0;
                     }
                   }


### PR DESCRIPTION
- fixes #473
- with frozeen grid, we have 2 horizontal scrolling and if any of the column width on the left section goes over the viewport total width then we completely lose the scrolling on the right section (as described in issue #473)
- also note that the PR adds a new grid option `frozenRightViewportMinWidth` which is set to 100 by default and could be customized to a different minimum width for the right section of a frozen grid

#### before
![z1srK4D4NS](https://user-images.githubusercontent.com/643976/118413393-2433d800-b66d-11eb-80a4-fc2900ed8056.gif)

#### after
![k10RN61ukP](https://user-images.githubusercontent.com/643976/118413398-2ac24f80-b66d-11eb-83dc-f09035195f34.gif)
