### PR TITLE
fix: `setOptions` should call `setOverflow` when changing frozenColumns

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2910,7 +2910,7 @@ if (typeof Slick === "undefined") {
       return options;
     }
 
-    function setOptions(args, suppressRender, suppressColumnSet) {
+    function setOptions(args, suppressRender, suppressColumnSet, suppressSetOverflow) {
       if (!getEditorLock().commitCurrentEdit()) {
         return;
       }
@@ -2938,6 +2938,9 @@ if (typeof Slick === "undefined") {
 
       setFrozenOptions();
       setScroller();
+      if (!suppressSetOverflow) {
+        setOverflow();
+      }
       zombieRowNodeFromLastMouseWheelEvent = null;
 
       if (!suppressColumnSet) {


### PR DESCRIPTION
- if we change from a regular grid to a frozen grid dynamically by calling `setOptions({ frozenColumn: 2 })` then it should call `setOverflow` to redo the associated css overflow. This PR does just that and prior to this PR the overflow was just reset and sometime the scrolling was showing up on the left section when it shouldn't

@6pac after merging this PR, could you please do another version release since this bug has been affecting our users and I wish to close it once and for all. Thanks a lot 🍻 