### PR TITLE
Feature: Reset State

### DIFF
--- a/plugins/slick.state.js
+++ b/plugins/slick.state.js
@@ -139,6 +139,9 @@
       return sortCols;
     }
 
+    function reset(){
+      _store.set(options.key_prefix + _cid, {});
+    }
     /*
      *  API
      */
@@ -147,7 +150,8 @@
       "destroy": destroy,
       "save": save,
       "restore": restore,
-      "onStateChanged": onStateChanged
+      "onStateChanged": onStateChanged,
+      "reset": reset
     });
   }
 })(jQuery);


### PR DESCRIPTION
until now it was not possible to reset the state. by adding the `reset` function to the `State` plugin, it's possible to reset the state by storing an empty object into `localStorage`.