### PR TITLE
fix(plugin): only check override if we can move row in first place

### DIFF
--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -137,7 +137,7 @@
         }
 
         // if there's a UsabilityOverride defined, we also need to verify that the condition is valid
-        if (_usabilityOverride) {
+        if (_usabilityOverride && dd.canMove) {
           var insertBeforeDataContext = _grid.getDataItem(insertBefore);
           dd.canMove = checkUsabilityOverride(insertBefore, insertBeforeDataContext, _grid);
         }


### PR DESCRIPTION
- since `canMove` is a private property, we should make sure it's `true` before trying to execute the override, this problem was caught in our implementation because we do use the plugin with the usability override