### PR TITLE
feat: add filtered item count

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -291,6 +291,9 @@
       return filteredItems;
     }
 
+    function getFilteredItemCount() {
+      return filteredItems.length;
+    }
 
     function getFilter() {
       return filter;
@@ -1375,6 +1378,7 @@
       "setFilter": setFilter,
       "getFilter": getFilter,
       "getFilteredItems": getFilteredItems,
+      "getFilteredItemCount": getFilteredItemCount,
       "sort": sort,
       "fastSort": fastSort,
       "reSort": reSort,


### PR DESCRIPTION
- I need to know the filtered count and currently the only way I was able to do this was to get the entire array of filtered item to get its length which is not at all effective when we can simply add a 1 line function to its length :)