### PR TITLE
fix: broken UI when loading grid from hidden div/tab

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3618,7 +3618,8 @@ if (typeof Slick === "undefined") {
       }
 
       $paneTopL.css({
-        'top': $paneHeaderL.height(), 'height': paneTopH
+        'top': $paneHeaderL.height() || (options.showHeaderRow ? options.headerRowHeight : 0) + (options.showPreHeaderPanel ? options.preHeaderPanelHeight : 0),
+        'height': paneTopH
       });
 
       var paneBottomTop = $paneTopL.position().top


### PR DESCRIPTION
- this bug is visible to the user when we try to build/load a grid from an hidden div (or a tab that is not active like below), what happens is that the Header Titles (header column) is shown behind the filter bar (header row) and to the user this seems broken. What happens is that the header height will be 0 and when that happens we can simply calculate it ourselves to avoid ever showing header without a height

see below, we load the page with active tab being the 1st tab, then if we go to 2nd tab (without the fix) we won't see the header titles... on the other end, with the fix, the header title bar will show up correctly

#### without the fix (header bar is height 0 and ends up in behind the filter bar)
![image](https://user-images.githubusercontent.com/643976/123334299-e26e3b00-d510-11eb-8484-1460f3b2a859.png)

#### after the fix
![image](https://user-images.githubusercontent.com/643976/123334325-edc16680-d510-11eb-9843-4b51bac97a17.png)
