### PR TITLE
feat: add `command` (execute/undo) to `onCellChange` event

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -5787,6 +5787,7 @@ if (typeof Slick === "undefined") {
                   this.editor.applyValue(item, this.serializedValue);
                   updateRow(this.row);
                   trigger(self.onCellChange, {
+                    command: 'execute',
                     row: this.row,
                     cell: this.cell,
                     item: item,
@@ -5797,6 +5798,7 @@ if (typeof Slick === "undefined") {
                   this.editor.applyValue(item, this.prevSerializedValue);
                   updateRow(this.row);
                   trigger(self.onCellChange, {
+                    command: 'undo',
                     row: this.row,
                     cell: this.cell,
                     item: item,


### PR DESCRIPTION
- in our use case, we call a backend save but if the backend throws an error we want to undo the cell change, however there are no way to currently determine if the event is triggered by the execute or the undo. Simply put, the undo was also triggering a backend save which we of course don't want (especially so if the undo was because of a backend error thrown)