### PR TITLE
Fix(slick.grid): Replace jQuery appendTo with js append for renderRows

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -4045,21 +4045,28 @@ if (typeof Slick === "undefined") {
 
       for (var i = 0, ii = rows.length; i < ii; i++) {
         if (( hasFrozenRows ) && ( rows[i] >= actualFrozenRow )) {
-          if (hasFrozenColumns()) {
-            rowsCache[rows[i]].rowNode = $()
-              .add($(x.firstChild).appendTo($canvasBottomL))
-              .add($(xRight.firstChild).appendTo($canvasBottomR));
-          } else {
-            rowsCache[rows[i]].rowNode = $()
-              .add($(x.firstChild).appendTo($canvasBottomL));
-          }
+            if ((hasFrozenRows) && (rows[i] >= actualFrozenRow)) {
+            if (hasFrozenColumns()) {
+                $canvasBottomL.append(x.firstChild);
+                $canvasBottomR.append(xRight.firstChild);
+                rowsCache[rows[i]].rowNode = $()
+                    .add($(x.firstChild))
+                    .add($(xRight.firstChild));
+            } else {
+                $canvasBottomL.append($(x.firstChild))
+                rowsCache[rows[i]].rowNode = $()
+                    .add($(x.firstChild));
+            }
         } else if (hasFrozenColumns()) {
-          rowsCache[rows[i]].rowNode = $()
-            .add($(x.firstChild).appendTo($canvasTopL))
-            .add($(xRight.firstChild).appendTo($canvasTopR));
+            $canvasTopL.append(x.firstChild);
+            $canvasTopR.append(xRight.firstChild);
+            rowsCache[rows[i]].rowNode = $()
+                .add($(x.firstChild))
+                .add($(xRight.firstChild));
         } else {
-          rowsCache[rows[i]].rowNode = $()
-            .add($(x.firstChild).appendTo($canvasTopL));
+            $canvasTopL.append(x.firstChild);
+            rowsCache[rows[i]].rowNode = $()
+                .add($(x.firstChild));
         }
       }
 

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -4045,7 +4045,6 @@ if (typeof Slick === "undefined") {
 
       for (var i = 0, ii = rows.length; i < ii; i++) {
         if (( hasFrozenRows ) && ( rows[i] >= actualFrozenRow )) {
-            if ((hasFrozenRows) && (rows[i] >= actualFrozenRow)) {
             if (hasFrozenColumns()) {
                 $canvasBottomL.append(x.firstChild);
                 $canvasBottomR.append(xRight.firstChild);

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -4046,26 +4046,26 @@ if (typeof Slick === "undefined") {
       for (var i = 0, ii = rows.length; i < ii; i++) {
         if (( hasFrozenRows ) && ( rows[i] >= actualFrozenRow )) {
             if (hasFrozenColumns()) {
-                $canvasBottomL.append(x.firstChild);
-                $canvasBottomR.append(xRight.firstChild);
                 rowsCache[rows[i]].rowNode = $()
                     .add($(x.firstChild))
                     .add($(xRight.firstChild));
+                $canvasBottomL.append(x.firstChild);
+                $canvasBottomR.append(xRight.firstChild);
             } else {
-                $canvasBottomL.append($(x.firstChild))
                 rowsCache[rows[i]].rowNode = $()
                     .add($(x.firstChild));
+                $canvasBottomL.append($(x.firstChild));
             }
         } else if (hasFrozenColumns()) {
-            $canvasTopL.append(x.firstChild);
-            $canvasTopR.append(xRight.firstChild);
             rowsCache[rows[i]].rowNode = $()
                 .add($(x.firstChild))
                 .add($(xRight.firstChild));
-        } else {
             $canvasTopL.append(x.firstChild);
+            $canvasTopR.append(xRight.firstChild);
+        } else {
             rowsCache[rows[i]].rowNode = $()
                 .add($(x.firstChild));
+            $canvasTopL.append(x.firstChild);
         }
       }
 


### PR DESCRIPTION
When my company tested the security of one of our applications, we found that we had missed to sanitize the values we send to Aurelia SlickGrid. We then also discovered that SlickGrid was not protected by the set Content Security Policy in the application, when script tags were run. After further investigation it turns out it's due to the jQuery function AppendTo being used. Which runs script tags automatically when they are appended. 

This PR does not replace all jQuery AppendTo, or for that matter fixes every places where CSP can not protect. It would been too much work for my company to put resources on, instead it only covers the part where we have dynamic data.

More information about this problem: 
https://csp.withgoogle.com/docs/faq.html#caveats
https://docs.wpvip.com/technical-references/security/javascript-security-recommendations/