### PR TITLE
fix: use Header Menu width (instead of minWidth) to align right

### DIFF
--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -302,8 +302,8 @@
       // to simulate an align left, we actually need to know the width of the drop menu
       if (options.autoAlign) {
         var gridPos = _grid.getGridPosition();
-        if ((leftPos + options.minWidth) >= gridPos.width) {
-          leftPos = leftPos - options.minWidth + options.autoAlignOffset;
+        if ((leftPos + $menu.width()) >= gridPos.width) {
+          leftPos = leftPos + $menuButton.outerWidth() - $menu.outerWidth() + options.autoAlignOffset;
         }
       }
 


### PR DESCRIPTION
- when the header menu is aligned to the right (instead of default to left), the menu was a bit offset because we were using the wrong width. 

now perfectly aligned to the right 
![image](https://user-images.githubusercontent.com/643976/131176865-7f3cecef-ada6-4fda-93fa-35d8d3323716.png)
