### PR TITLE
fix: use tooltip from header menu options is the correct location

### DIFF
--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -180,8 +180,8 @@
           $el.css("background-image", "url(" + options.buttonImage + ")");
         }
 
-        if (menu.tooltip) {
-          $el.attr("title", menu.tooltip);
+        if (options.tooltip) {
+          $el.attr("title", options.tooltip);
         }
 
         $el


### PR DESCRIPTION
- the `menu` variable can only have `items` since it comes from the column definition