### PR TITLE
fix: grid with Grouping, Row Select All shouldn't include grouping rows

### DIFF
--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -221,8 +221,8 @@
           var rows = [];
           for (var i = 0; i < _grid.getDataLength(); i++) {
             // Get the row and check it's a selectable row before pushing it onto the stack
-            var rowItem = _grid.getDataItem(i);            
-            if (checkSelectableOverride(i, rowItem, _grid)) {
+            var rowItem = _grid.getDataItem(i);
+            if (!rowItem.__group && !rowItem.__groupTotals && checkSelectableOverride(i, rowItem, _grid)) {
               rows.push(i);
             }
           }


### PR DESCRIPTION
- if we use Row Selection with a grid that also has Grouping/Draggable Grouping, clicking on the "Select All" button would also include grouping rows and when calling DataView `getAllSelectedIds()` it would includes some `undefined` Ids which were found to be the grouping rows. So we should fix the issue at the source, which is to NOT include the grouping rows.
- the issue was reported in Slickgrid-Universal in this [comment](https://github.com/ghiscoding/slickgrid-universal/issues/469#issuecomment-913808526)

![image](https://user-images.githubusercontent.com/44271732/132253149-f901f453-a69c-4a4f-8740-44f82ebc853b.png)