### PR TITLE
`scrollRowIntoView` is now only called if allowed by user

### DIFF
--- a/plugins/slick.state.js
+++ b/plugins/slick.state.js
@@ -41,7 +41,8 @@
 
   var defaults = {
     key_prefix: "slickgrid:",
-    storage: new localStorageWrapper()
+    storage: new localStorageWrapper(),
+    scrollRowIntoView: true
   };
 
   function State(options) {
@@ -104,7 +105,7 @@
               if (state.sortcols) {
                 _grid.setSortColumns(state.sortcols);
               }
-              if (state.viewport) {
+              if (state.viewport && options.scrollRowIntoView) {
                 _grid.scrollRowIntoView(state.viewport.top, true);
               }
               if (state.columns) {


### PR DESCRIPTION
`state` will now only `scrollRowIntoView` if user wishes to

until now, restoring the state automatically brought the previously scrolled row into view (`scrollRowIntoView`) - from now on, the user has control over this function call.

**why?**

well, because this behavior caused issues with rendering the grid if the table was not initiated with any rows.

we have a grid whose lines are added/ updated from an async query, which might or might not change on every call. as the grid is initiated/created, there are initially no rows in it. calling this function when the grid has no rows causes a parameter in `slick.grid.js` (`th`) to be set to `NaN`, which then causes rendering issues - as shown below - when the rows were inserted into the grid.

https://user-images.githubusercontent.com/2896170/134683567-b4c2a063-1e26-457d-848c-1e765aa123ef.mp4

