### PR TITLE
Getlongesttext handles empty rowset

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2480,12 +2480,15 @@ if (typeof Slick === "undefined") {
       if (autoSize.valueFilterMode === Slick.ValueFilterMode.GetLongestText) {
         // get greatest abs value in data
         var tempVal, maxLen = 0, maxIndex = 0;
-        for (i = 0, ii = rows.length; i < ii; i++) {
-          tempVal = rows[i][columnDef.field];
-          if ((tempVal || '').length > maxLen) { maxLen = tempVal.length; maxIndex = i; }
+        if (row.length) {
+          for (i = 0, ii = rows.length; i < ii; i++) {
+            tempVal = rows[i][columnDef.field];
+            if ((tempVal || '').length > maxLen) { maxLen = tempVal.length; maxIndex = i; }
+          }
+          // now substitute a 'c' for all characters
+          tempVal = rows[maxIndex][columnDef.field];
         }
-        // now substitute a 'c' for all characters
-        tempVal = rows[maxIndex][columnDef.field];
+
         rows = [ tempVal ];
       }
 


### PR DESCRIPTION
 - Fixes #642 by not accessing rows' indices/fields if there are no rows.
 - No errors in cypress tests on my machine