### PR TITLE
fix: regression introduced by PR #640 and commit f12f4cc

### DIFF
--- a/cypress/integration/example-frozen-columns-and-column-group.spec.js
+++ b/cypress/integration/example-frozen-columns-and-column-group.spec.js
@@ -4,7 +4,7 @@ describe('Example - Row Grouping Titles', () => {
     const fullPreTitles = ['', 'Common Factor', 'Period', 'Analysis'];
     const fullTitles = ['#', 'Title', 'Duration', 'Start', 'Finish', '% Complete', 'Effort Driven'];
 
-    it('should display Example Grid Menu', () => {
+    it('should display Example Frozen Columns & Column Group', () => {
         cy.visit(`${Cypress.config('baseExampleUrl')}/example-frozen-columns-and-column-group.html`);
         cy.get('h2').should('contain', 'Demonstrates:');
         cy.contains('Frozen columns with extra header row grouping columns into categories');

--- a/cypress/integration/example-frozen-columns-and-rows.spec.js
+++ b/cypress/integration/example-frozen-columns-and-rows.spec.js
@@ -1,0 +1,111 @@
+/// <reference types="cypress" />
+
+describe('Example - Frozen Columns & Rows', { retries: 1 }, () => {
+  // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
+
+  const fullTitles = ['#', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven', 'Title1', 'Title2', 'Title3', 'Title4'];
+
+  it('should load Example', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example-frozen-columns-and-rows.html`);
+  });
+
+  it('should have exact column titles on 1st grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+  });
+
+  it('should have exact Column Header Titles in the grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-header-columns:nth(0)')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+  });
+
+  it('should have a frozen grid with 4 containers on page load with 3 columns on the left and 6 columns on the right', () => {
+    cy.get('[style="top:0px"]').should('have.length', 2 * 2);
+    cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 3 * 2);
+    cy.get('.grid-canvas-right > [style="top:0px"]').children().should('have.length', 8 * 2);
+
+    // top-left
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 0');
+
+    // top-right
+    cy.get('.grid-canvas-top.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(1)').should('contain', '01/01/2009');
+    cy.get('.grid-canvas-top.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '01/05/2009');
+    cy.get('.grid-canvas-top.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(4)').should('contain', '0');
+
+    // bottom-left
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 5');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:25px"] > .slick-cell:nth(1)').should('contain', 'Task 6');
+
+    // bottom-right
+    cy.get('.grid-canvas-bottom.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(1)').should('contain', '01/01/2009');
+    cy.get('.grid-canvas-bottom.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '01/05/2009');
+    cy.get('.grid-canvas-bottom.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(4)').should('contain', '5');
+    cy.get('.grid-canvas-bottom.grid-canvas-right > [style="top:25px"] > .slick-cell:nth(4)').should('contain', '6');
+  });
+
+  it('should change frozen row and increment by 1 and expect changes to be reflected in the grid', () => {
+    cy.get('input#frozenRow').type('{backspace}7');
+    cy.get('button#setFrozenRow').click();
+
+    cy.get('[style="top:0px"]').should('have.length', 2 * 2);
+    cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 3 * 2);
+    cy.get('.grid-canvas-right > [style="top:0px"]').children().should('have.length', 8 * 2);
+
+    // top-left
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 0');
+
+    // top-right
+    cy.get('.grid-canvas-top.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(1)').should('contain', '01/01/2009');
+    cy.get('.grid-canvas-top.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '01/05/2009');
+    cy.get('.grid-canvas-top.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(4)').should('contain', '0');
+
+    // bottom-left
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 7');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:25px"] > .slick-cell:nth(1)').should('contain', 'Task 8');
+
+    // bottom-right
+    cy.get('.grid-canvas-bottom.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(1)').should('contain', '01/01/2009');
+    cy.get('.grid-canvas-bottom.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '01/05/2009');
+    cy.get('.grid-canvas-bottom.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(4)').should('contain', '7');
+    cy.get('.grid-canvas-bottom.grid-canvas-right > [style="top:25px"] > .slick-cell:nth(4)').should('contain', '8');
+  });
+
+  it('should change frozen column and increment by 1 and expect changes to be reflected in the grid', () => {
+    cy.get('input#frozenColumn').type('{backspace}3');
+    cy.get('button#setFrozenColumn').click();
+
+    cy.get('[style="top:0px"]').should('have.length', 2 * 2);
+    cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 4 * 2);
+    cy.get('.grid-canvas-right > [style="top:0px"]').children().should('have.length', 7 * 2);
+
+    // top-left
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 0');
+
+    // top-right
+    cy.get('.grid-canvas-top.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '01/01/2009');
+    cy.get('.grid-canvas-top.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(1)').should('contain', '01/05/2009');
+    cy.get('.grid-canvas-top.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(3)').should('contain', '0');
+
+    // bottom-left
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 7');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:25px"] > .slick-cell:nth(1)').should('contain', 'Task 8');
+
+    // bottom-right
+    cy.get('.grid-canvas-bottom.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '01/01/2009');
+    cy.get('.grid-canvas-bottom.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(1)').should('contain', '01/05/2009');
+    cy.get('.grid-canvas-bottom.grid-canvas-right > [style="top:0px"] > .slick-cell:nth(3)').should('contain', '7');
+    cy.get('.grid-canvas-bottom.grid-canvas-right > [style="top:25px"] > .slick-cell:nth(3)').should('contain', '8');
+  });
+
+  it('should click on "Select first 10 rows" button and expect first few rows to be selected', () => {
+    cy.get('button#btnSelectRows').click();
+    cy.get('.selected').should('have.length', 10 * 11); // 10 rows * 11 columns
+  });
+});

--- a/cypress/integration/example-frozen-rows.spec.js
+++ b/cypress/integration/example-frozen-rows.spec.js
@@ -1,0 +1,94 @@
+/// <reference types="cypress" />
+
+describe('Example - Frozen Rows', { retries: 1 }, () => {
+  // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
+
+  const fullTitles = ['#', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven', 'Title1', 'Title2', 'Title3', 'Title4'];
+
+  it('should load Example', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example-frozen-rows.html`);
+  });
+
+  it('should have exact column titles on 1st grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+  });
+
+  it('should have exact Column Header Titles in the grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-header-columns:nth(0)')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+  });
+
+  it('should have a frozen grid with 4 containers on page load with 3 columns on the left and 6 columns on the right', () => {
+    cy.get('[style="top:0px"]').should('have.length', 2); // top + bottom
+    cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 11 * 2);
+
+    // top-left
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 0');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '5 days');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(4)').should('contain', '01/01/2009');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(5)').should('contain', '01/05/2009');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(7)').should('contain', '0');
+
+    // bottom-left
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 49995');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '5 days');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(4)').should('contain', '01/01/2009');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(5)').should('contain', '01/05/2009');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(7)').should('contain', '49995');
+  });
+
+  it('should change frozen row and increment by 1 and expect changes to be reflected in the grid', () => {
+    cy.get('input#frozenRow').type('{backspace}7');
+    cy.get('button#setFrozenRow').click();
+
+    cy.get('[style="top:0px"]').should('have.length', 2); // top + bottom
+    cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 11 * 2);
+
+    // top-left
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 0');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '5 days');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(4)').should('contain', '01/01/2009');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(5)').should('contain', '01/05/2009');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(7)').should('contain', '0');
+
+    // bottom-left
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 49993');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '5 days');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(4)').should('contain', '01/01/2009');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(5)').should('contain', '01/05/2009');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(7)').should('contain', '49993');
+  });
+
+  it('should uncheck "frozen bottom rows" and set it', () => {
+    cy.get('input#frozenBottomRows').uncheck();
+    cy.get('button#setFrozenBottomRows').click();
+
+    cy.get('[style="top:0px"]').should('have.length', 2); // top + bottom
+    cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 11 * 2);
+
+    // top-left
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 0');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '5 days');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(4)').should('contain', '01/01/2009');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(5)').should('contain', '01/05/2009');
+    cy.get('.grid-canvas-top.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(7)').should('contain', '0');
+
+    // bottom-left
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 7');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(2)').should('contain', '5 days');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(4)').should('contain', '01/01/2009');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(5)').should('contain', '01/05/2009');
+    cy.get('.grid-canvas-bottom.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(7)').should('contain', '7');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "slickgrid",
-  "version": "2.4.38",
+  "version": "2.4.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "slickgrid",
-      "version": "2.4.38",
+      "version": "2.4.41",
       "license": "MIT",
       "dependencies": {
         "jquery": ">=1.8.0",
         "jquery-ui": ">=1.8.0"
       },
       "devDependencies": {
-        "cypress": "^8.3.1",
+        "cypress": "^8.5.0",
         "eslint": "^7.32.0",
-        "http-server": "^13.0.1"
+        "http-server": "^13.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -693,9 +693,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.3.1.tgz",
-      "integrity": "sha512-1v6pfx+/5cXhaT5T6QKOvnkawmEHWHLiVzm3MYMoQN1fkX2Ma1C32STd3jBStE9qT5qPSTILjGzypVRxCBi40g==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.5.0.tgz",
+      "integrity": "sha512-MMkXIS+Ro2KETn4gAlG3tIc/7FiljuuCZP0zpd9QsRG6MZSyZW/l1J3D4iQM6WHsVxuX4rFChn5jPFlC2tNSvQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -733,6 +733,7 @@
         "minimist": "^1.2.5",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "proxy-from-env": "1.0.0",
         "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
@@ -1469,9 +1470,9 @@
       }
     },
     "node_modules/http-server": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-13.0.1.tgz",
-      "integrity": "sha512-ke9rphoNuqsOCHy4tA3b3W4Yuxy7VUIXcTHSLz6bkMDAJPQD4twjEatquelJBIPwNhZuC3+FYj/+dSaGHdKTCw==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-13.0.2.tgz",
+      "integrity": "sha512-R8kvPT7qp11AMJWLZsRShvm6heIXdlR/+tL5oAWNG/86A/X+IAFX6q0F9SA2G+dR5aH/759+9PLH0V34Q6j4rg==",
       "dev": true,
       "dependencies": {
         "basic-auth": "^1.0.3",
@@ -2223,6 +2224,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -3375,9 +3382,9 @@
       }
     },
     "cypress": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.3.1.tgz",
-      "integrity": "sha512-1v6pfx+/5cXhaT5T6QKOvnkawmEHWHLiVzm3MYMoQN1fkX2Ma1C32STd3jBStE9qT5qPSTILjGzypVRxCBi40g==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.5.0.tgz",
+      "integrity": "sha512-MMkXIS+Ro2KETn4gAlG3tIc/7FiljuuCZP0zpd9QsRG6MZSyZW/l1J3D4iQM6WHsVxuX4rFChn5jPFlC2tNSvQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.6",
@@ -3414,6 +3421,7 @@
         "minimist": "^1.2.5",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "proxy-from-env": "1.0.0",
         "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
@@ -3982,9 +3990,9 @@
       }
     },
     "http-server": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-13.0.1.tgz",
-      "integrity": "sha512-ke9rphoNuqsOCHy4tA3b3W4Yuxy7VUIXcTHSLz6bkMDAJPQD4twjEatquelJBIPwNhZuC3+FYj/+dSaGHdKTCw==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-13.0.2.tgz",
+      "integrity": "sha512-R8kvPT7qp11AMJWLZsRShvm6heIXdlR/+tL5oAWNG/86A/X+IAFX6q0F9SA2G+dR5aH/759+9PLH0V34Q6j4rg==",
       "dev": true,
       "requires": {
         "basic-auth": "^1.0.3",
@@ -4561,6 +4569,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
       "dev": true
     },
     "psl": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "jquery-ui": ">=1.8.0"
   },
   "devDependencies": {
-    "cypress": "^8.3.1",
+    "cypress": "^8.5.0",
     "eslint": "^7.32.0",
-    "http-server": "^13.0.1"
+    "http-server": "^13.0.2"
   }
 }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3434,7 +3434,9 @@ if (typeof Slick === "undefined") {
         queuePostProcessedRowForCleanup(cacheEntry, postProcessedRows[row], row);
       } else {
         cacheEntry.rowNode.each(function() {
-          this.parentElement.removeChild(this);
+          if (this.parentElement) {
+            this.parentElement.removeChild(this);
+          }
         });
       }
 
@@ -3901,7 +3903,7 @@ if (typeof Slick === "undefined") {
           queuePostProcessedCellForCleanup(cellNode, cellToRemove, row);
         } else {
           cellNode.parentElement.removeChild(cellNode);
-        }       
+        }
 
         delete cacheEntry.cellColSpans[cellToRemove];
         delete cacheEntry.cellNodesByColumnIdx[cellToRemove];
@@ -4053,23 +4055,23 @@ if (typeof Slick === "undefined") {
                 rowsCache[rows[i]].rowNode = $()
                     .add($(x.firstChild))
                     .add($(xRight.firstChild));
-                $canvasBottomL[0].append(x.firstChild);
-                $canvasBottomR[0].append(xRight.firstChild);
+                $canvasBottomL[0].appendChild(x.firstChild);
+                $canvasBottomR[0].appendChild(xRight.firstChild);
             } else {
                 rowsCache[rows[i]].rowNode = $()
                     .add($(x.firstChild));
-                $canvasBottomL[0].append($(x.firstChild));
+                $canvasBottomL[0].appendChild(x.firstChild);
             }
         } else if (hasFrozenColumns()) {
             rowsCache[rows[i]].rowNode = $()
                 .add($(x.firstChild))
                 .add($(xRight.firstChild));
-            $canvasTopL[0].append(x.firstChild);
-            $canvasTopR[0].append(xRight.firstChild);
+            $canvasTopL[0].appendChild(x.firstChild);
+            $canvasTopR[0].appendChild(xRight.firstChild);
         } else {
             rowsCache[rows[i]].rowNode = $()
                 .add($(x.firstChild));
-            $canvasTopL[0].append(x.firstChild);
+            $canvasTopL[0].appendChild(x.firstChild);
         }
       }
 
@@ -5210,7 +5212,7 @@ if (typeof Slick === "undefined") {
     function getActiveCellNode() {
       return activeCellNode;
     }
-	  
+
     //This get/set methods are used for keeping text-selection. These don't consider IE because they don't loose text-selection.
     //Fix for firefox selection. See https://github.com/mleibman/SlickGrid/pull/746/files
     function getTextSelection(){


### PR DESCRIPTION
- this PR fixes 2 issues identified in Frozen Grids and in Slickgrid-Universal lib

the grid shown below has both issues and this PR fixes both of them
1- the top portion of the grid below is broken and throws error shown below and is caused by a regression introduced via commit f12f4cc which is the new Post Async cleanup
2- the bottom portion, which shows `object` everywhere is caused by a regression introduced from previous PR #640
both issues can be seen in this live [Example](http://6pac.github.io/SlickGrid/examples/example-frozen-rows.html), the error thrown is 
```
Uncaught TypeError: Cannot read properties of null (reading 'removeChild')
```
which seems to be caused by `this.parentElement` being null in some cases

#### TODOs
- [x] fix both issues
- [x] add Cypress E2E tests for 2 frozen Examples
   - [example-frozen-rows.html](https://6pac.github.io/SlickGrid/examples/example-frozen-rows.html)
   - [example-frozen-columns-and-rows.html](https://6pac.github.io/SlickGrid/examples/example-frozen-columns-and-rows.html)
- [x] tested in our Salesforce environment and ran all Cypress tests in Slickgrid-Universal & Aurelia-Slickgrid

![image](https://user-images.githubusercontent.com/643976/134962963-055b99c9-4179-46b2-aa96-13a4a2fe94df.png)
