### PR TITLE
feat: add new Custom Tooltip plugin

### DIFF
--- a/cypress/integration/example-composite-editor-modal-dialog.spec.js
+++ b/cypress/integration/example-composite-editor-modal-dialog.spec.js
@@ -325,7 +325,7 @@ describe('Example - Composite Editor Modal with Create/Edit/Mass-Update/Mass-Sel
     cy.get(`[style="top:12500px"] > .slick-cell:nth(3)`).should('contain', '9 days');
     cy.get(`[style="top:12500px"] > .slick-cell:nth(4)`).each($cell => {
       const htmlText = $cell.html();
-      expect(htmlText).to.eq('<span class="percent-complete-bar" style="background:silver;width:44%"></span>');
+      expect(htmlText).to.eq('<span class="percent-complete-bar" style="background:silver;width:44%" title="44%"></span>');
     });
     cy.get(`[style="top:12500px"] > .slick-cell:nth(5)`).should('contain', '02/01/2020');
     cy.get(`[style="top:12500px"] > .slick-cell:nth(6)`).should('contain', '');

--- a/cypress/integration/example-plugin-custom-tooltip.spec.js
+++ b/cypress/integration/example-plugin-custom-tooltip.spec.js
@@ -121,6 +121,17 @@ describe('Example - Custom Tooltip', () => {
     cy.get('@duration5-cell').trigger('mouseleave');
   });
 
+  it('should mouse over % Complete cell of Task 5 and expect regular tooltip to show with content "x %" where x is a number', () => {
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 5}px"] > .slick-cell:nth(5)`).as('percentage-cell')
+    cy.get('@percentage-cell').find('.percent-complete-bar').should('exist');
+    cy.get('@percentage-cell').trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip').contains(/\d+\%$/);
+
+    cy.get('@percentage-cell').trigger('mouseleave');
+  });
+
   it('should mouse over header-row (filter) 1st column checkbox and NOT expect any tooltip to show since it is disabled on that column', () => {
     cy.get(`.slick-headerrow-columns .slick-headerrow-column:nth(0)`).as('checkbox0-filter')
     cy.get('@checkbox0-filter').trigger('mouseover');

--- a/cypress/integration/example-plugin-custom-tooltip.spec.js
+++ b/cypress/integration/example-plugin-custom-tooltip.spec.js
@@ -1,0 +1,169 @@
+/// <reference types="cypress" />
+
+describe('Example - Custom Tooltip', () => {
+  const GRID_ROW_HEIGHT = 25;
+  const titles = ['', 'Title', 'Description', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
+
+  beforeEach(() => {
+    // create a console.log spy for later use
+    cy.window().then((win) => {
+      cy.spy(win.console, "log");
+    });
+  });
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example-plugin-custom-tooltip.html`);
+    cy.get('h2').contains('Demonstrates: Slick.Plugins.CustomTooltip');
+  });
+
+  it('should have exact Column Titles in the grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(titles[index]));
+  });
+
+  it('should change server delay to 10ms for faster testing', () => {
+    cy.get('#server-delay').type('{backspace}{backspace}{backspace}10');
+    cy.get('#set-delay-btn').click();
+  });
+
+  it('should mouse over 1st row checkbox column and NOT expect any tooltip to show since it is disabled on that column', () => {
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(0)`).as('checkbox0-cell')
+    cy.get('@checkbox0-cell').trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('not.exist');
+    cy.get('@checkbox0-cell').trigger('mouseleave');
+  });
+
+  it('should mouse over Task 1 cell and expect async tooltip to show', () => {
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(1)`).as('task1-cell')
+    cy.get('@task1-cell').should('contain', 'Task 1');
+    cy.get('@task1-cell').trigger('mouseover');
+    cy.get('.slick-custom-tooltip').contains('loading...');
+
+    cy.wait(10);
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip').contains('Task 1 - (async tooltip)');
+
+    cy.get('.tooltip-2cols-row:nth(1)').find('div:nth(0)').contains('Lifespan:');
+    cy.get('.tooltip-2cols-row:nth(1)').find('div:nth(1)').contains(/\d+$/); // use regexp to make sure it's a number
+
+    cy.get('.tooltip-2cols-row:nth(2)').find('div:nth(0)').contains('Ratio:');
+    cy.get('.tooltip-2cols-row:nth(2)').find('div:nth(1)').contains(/\d+$/); // use regexp to make sure it's a number
+
+    cy.get('@task1-cell').trigger('mouseleave');
+  });
+
+  it('should mouse over Task 5 cell and expect async tooltip to show', () => {
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 5}px"] > .slick-cell:nth(1)`).as('task5-cell')
+    cy.get('@task5-cell').should('contain', 'Task 5');
+    cy.get('@task5-cell').trigger('mouseover');
+    cy.get('.slick-custom-tooltip').contains('loading...');
+
+    cy.wait(10);
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip').contains('Task 5 - (async tooltip)');
+
+    cy.get('.tooltip-2cols-row:nth(1)').find('div:nth(0)').contains('Lifespan:');
+    cy.get('.tooltip-2cols-row:nth(1)').find('div:nth(1)').contains(/\d+$/); // use regexp to make sure it's a number
+
+    cy.get('.tooltip-2cols-row:nth(2)').find('div:nth(0)').contains('Ratio:');
+    cy.get('.tooltip-2cols-row:nth(2)').find('div:nth(1)').contains(/\d+$/); // use regexp to make sure it's a number
+
+    cy.get('@task5-cell').trigger('mouseleave');
+  });
+
+  it('should mouse over 6th row Description and expect full cell content to show in a tooltip because cell has ellipsis and is too long for the cell itself', () => {
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 5}px"] > .slick-cell:nth(2)`).as('desc5-cell')
+    cy.get('@desc5-cell').should('contain', 'This is a sample task description.');
+    cy.get('@desc5-cell').trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip').should('contain', `This is a sample task description.\nIt can be multiline\n\nAnother line...`);
+
+    cy.get('@desc5-cell').trigger('mouseleave');
+  });
+
+  it('should mouse over 6th row Duration and expect a custom tooltip shown with 4 label/value pairs displayed', () => {
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 5}px"] > .slick-cell:nth(3)`).as('duration5-cell')
+    cy.get('@duration5-cell').should('contain', '5 days');
+    cy.get('@duration5-cell').trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip').contains('Custom Tooltip');
+
+    cy.get('.tooltip-2cols-row:nth(0)').find('div:nth(0)').contains('Id:');
+    cy.get('.tooltip-2cols-row:nth(0)').find('div:nth(1)').contains('5');
+
+    cy.get('.tooltip-2cols-row:nth(1)').find('div:nth(0)').contains('Title:');
+    cy.get('.tooltip-2cols-row:nth(1)').find('div:nth(1)').contains('Task 5');
+
+    cy.get('.tooltip-2cols-row:nth(2)').find('div:nth(0)').contains('Completion:');
+    cy.get('.tooltip-2cols-row:nth(2)').find('div:nth(1)').find('.percent-complete-bar').should('exist');
+
+    cy.get('.tooltip-2cols-row:nth(3)').find('div:nth(0)').contains('Effort Driven:');
+    cy.get('.tooltip-2cols-row:nth(3)').find('div:nth(1)')
+      .find('img').invoke('attr', 'src').then(src => expect(src).to.contain('tick.png'));
+
+    cy.get('@duration5-cell').trigger('mouseleave');
+  });
+
+  it('should mouse over header-row (filter) 1st column checkbox and NOT expect any tooltip to show since it is disabled on that column', () => {
+    cy.get(`.slick-headerrow-columns .slick-headerrow-column:nth(0)`).as('checkbox0-filter')
+    cy.get('@checkbox0-filter').trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('not.exist');
+    cy.get('@checkbox0-filter').trigger('mouseleave');
+  });
+
+  it('should mouse over header-row (filter) 2nd column Title and expect a tooltip to show rendered from an headerRowFormatter', () => {
+    cy.get(`.slick-headerrow-columns .slick-headerrow-column:nth(1)`).as('checkbox0-filter')
+    cy.get('@checkbox0-filter').trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip').contains('Custom Tooltip - Header Row (filter)');
+
+    cy.get('.tooltip-2cols-row:nth(0)').find('div:nth(0)').contains('Column:');
+    cy.get('.tooltip-2cols-row:nth(0)').find('div:nth(1)').contains('title');
+
+    cy.get('@checkbox0-filter').trigger('mouseleave');
+  });
+
+  it('should mouse over header-row (filter) Finish column and NOT expect any tooltip to show since it is disabled on that column', () => {
+    cy.get(`.slick-headerrow-columns .slick-headerrow-column:nth(6)`).as('finish-filter')
+    cy.get('@finish-filter').trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('not.exist');
+    cy.get('@finish-filter').trigger('mouseleave');
+  });
+
+  it('should mouse over header title on 1st column with checkbox and NOT expect any tooltip to show since it is disabled on that column', () => {
+    cy.get(`.slick-header-columns .slick-header-column:nth(0)`).as('checkbox-header')
+    cy.get('@checkbox-header').trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('not.exist');
+    cy.get('@checkbox-header').trigger('mouseleave');
+  });
+
+  it('should mouse over header title on 2nd column with Title name and expect a tooltip to show rendered from an headerFormatter', () => {
+    cy.get(`.slick-header-columns .slick-header-column:nth(1)`).as('checkbox0-header')
+    cy.get('@checkbox0-header').trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip').contains('Custom Tooltip - Header');
+
+    cy.get('.tooltip-2cols-row:nth(0)').find('div:nth(0)').contains('Column:');
+    cy.get('.tooltip-2cols-row:nth(0)').find('div:nth(1)').contains('Title');
+
+    cy.get('@checkbox0-header').trigger('mouseleave');
+  });
+
+  it('should mouse over header title on 2nd column with Finish name and NOT expect any tooltip to show since it is disabled on that column', () => {
+    cy.get(`.slick-header-columns .slick-header-column:nth(6)`).as('finish-header')
+    cy.get('@finish-header').trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('not.exist');
+    cy.get('@finish-header').trigger('mouseleave');
+  });
+});

--- a/cypress/integration/example-plugin-custom-tooltip.spec.js
+++ b/cypress/integration/example-plugin-custom-tooltip.spec.js
@@ -2,7 +2,7 @@
 
 describe('Example - Custom Tooltip', () => {
   const GRID_ROW_HEIGHT = 25;
-  const titles = ['', 'Title', 'Description', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
+  const titles = ['', 'Title', 'Description', 'Description 2', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
 
   beforeEach(() => {
     // create a console.log spy for later use
@@ -80,13 +80,25 @@ describe('Example - Custom Tooltip', () => {
     cy.get('@desc5-cell').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip').should('not.contain', `regular tooltip (from title attribute)\nTask 5 cell value:\nThis is a sample task description.\nIt can be multiline\n\nAnother line...`);
     cy.get('.slick-custom-tooltip').should('contain', `This is a sample task description.\nIt can be multiline\n\nAnother line...`);
 
     cy.get('@desc5-cell').trigger('mouseleave');
   });
 
+  it('should mouse over 6th row Description 2 and expect regular tooltip title + concatenated full cell content when using "useRegularTooltipFromFormatterOnly: true"', () => {
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 5}px"] > .slick-cell:nth(3)`).as('desc2-5-cell')
+    cy.get('@desc2-5-cell').should('contain', 'This is a sample task description.');
+    cy.get('@desc2-5-cell').trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip').should('contain', `regular tooltip (from title attribute)\nTask 5 cell value:\nThis is a sample task description.\nIt can be multiline\n\nAnother line...`);
+
+    cy.get('@desc2-5-cell').trigger('mouseleave');
+  });
+
   it('should mouse over 6th row Duration and expect a custom tooltip shown with 4 label/value pairs displayed', () => {
-    cy.get(`[style="top:${GRID_ROW_HEIGHT * 5}px"] > .slick-cell:nth(3)`).as('duration5-cell')
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 5}px"] > .slick-cell:nth(4)`).as('duration5-cell')
     cy.get('@duration5-cell').should('contain', '5 days');
     cy.get('@duration5-cell').trigger('mouseover');
 
@@ -131,7 +143,7 @@ describe('Example - Custom Tooltip', () => {
   });
 
   it('should mouse over header-row (filter) Finish column and NOT expect any tooltip to show since it is disabled on that column', () => {
-    cy.get(`.slick-headerrow-columns .slick-headerrow-column:nth(6)`).as('finish-filter')
+    cy.get(`.slick-headerrow-columns .slick-headerrow-column:nth(7)`).as('finish-filter')
     cy.get('@finish-filter').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('not.exist');
@@ -160,7 +172,7 @@ describe('Example - Custom Tooltip', () => {
   });
 
   it('should mouse over header title on 2nd column with Finish name and NOT expect any tooltip to show since it is disabled on that column', () => {
-    cy.get(`.slick-header-columns .slick-header-column:nth(6)`).as('finish-header')
+    cy.get(`.slick-header-columns .slick-header-column:nth(7)`).as('finish-header')
     cy.get('@finish-header').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('not.exist');

--- a/examples/example-plugin-custom-tooltip.html
+++ b/examples/example-plugin-custom-tooltip.html
@@ -25,12 +25,31 @@
       column-gap: 5px;
       line-height: 20px;
     }
+
+    /* change css of 3rd column (l2 r2) */
+    .l2.slick-custom-tooltip {
+      background-color: #363636;
+      color: #ffffff;
+      border: 2px solid #252525;
+      /* overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2; */
+    }
+    .l2.slick-custom-tooltip.tooltip-arrow.arrow-up::before {
+      border-bottom: 7px solid #252525;
+    }
+    .l2.slick-custom-tooltip.tooltip-arrow.arrow-down::after {
+      border-top: 7px solid #252525;
+    }
   </style>
 </head>
 
 <body>
   <div style="position:relative">
-    <div style="width:600px;">
+    <div style="width:618px;">
       <div id="myGrid" style="width:100%;height:500px;"></div>
     </div>
 
@@ -38,17 +57,24 @@
       <h2>Demonstrates:</h2>
       <ul>
         <li>Custom Tooltip Plugin</li>
-        <li>First column shows an async tooltip (could be an API with Promise), it demos a formatter which itself has a
+        <li>1st column shows an async tooltip (could be an API with Promise), it demos a formatter which itself has a
           formatter displaying percent complete bar
         </li>
+        <li>2nd column is with "useRegularTooltip" which will parse your cell formatters in search of a "title" attribute to use as tooltip</li>
         <li>Every other columns will show other info of the item data context</li>
         <li>Tooltip gets auto-position depending on its available space</li>
+        <li>You can disable a tooltip via "usabilityOverride"</li>
       </ul>
 
       <h2>Options:</h2>
       <button onclick="customTooltipPlugin.setOptions({hideArrow:true})">Hide Tooltip Arrow ON</button>
       &nbsp;
       <button onclick="customTooltipPlugin.setOptions({hideArrow:false})">Hide Tooltip Arrow OFF</button>
+      <br/>
+      <br/>
+      <button onclick="disableTooltip(true)">Disable Tooltip ON</button>
+      &nbsp;
+      <button onclick="disableTooltip(false)">Disable Tooltip OFF</button>
       <h2>View Source:</h2>
       <ul>
         <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-plugin-custom-tooltip.html"
@@ -83,6 +109,17 @@
       }
     }
 
+    function disableTooltip(disable) {
+      if (disable) {
+        isTooltipDisabled = true;
+        // customTooltipPlugin.setOptions({ usabilityOverride: function (args) { return false;}});
+      } else {
+        isTooltipDisabled = false;
+        // customTooltipPlugin.setOptions({ usabilityOverride: function (args) { return args.cell !== 0;}});
+      }
+    }
+
+    var isTooltipDisabled = false;
     var grid;
     var data = [];
     var customTooltipPlugin;
@@ -110,11 +147,13 @@
       },
       { 
         id: "desc", name: "Description", field: "description", width: 100, editor: Slick.Editors.LongText,  
-        formatter: (row, cell, value) => `<span title="regular tooltip (from title attribute) - cell value: ${value || ''}">${value || ''}</span>`,
+        formatter: (row, cell, value, column, dataContext) => `<span title="<b>regular tooltip</b> (from title attribute) \r${dataContext.title} cell value:\r ${value || ''}">${value || ''}</span>`,
+        // define tooltip options here OR for the entire grid via the grid options (cell tooltip options will have precedence over grid options)
         customTooltip: {
-          useRegularTooltip: true,
-          // maxWidth: 200,
-          // maxHeight: 40,
+          useRegularTooltip: true, // note regular tooltip will try to find a "title" attribute in the cell formatter (it won't work without a cell formatter)
+          renderRegularTooltipAsHtml: true, // defaults to false, regular "title" tooltip won't be rendered as html unless specified via this flag (also "\r\n" will be replaced by <br>)
+          // maxWidth: 100,
+          // maxHeight: 30,
         },
       },
       { id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Text },
@@ -133,26 +172,30 @@
       // Custom Tooltip options can be defined in a Column or Grid Options or a mixed of both (first options found wins)
       customTooltip: {
         formatter: tooltipFormatter,
-        usabilityOverride: (args) => (args.cell !== 0), // don't show on first column
+        usabilityOverride: function (args) {
+         return !isTooltipDisabled && args.cell !== 0; // don't show on first column (row selection column)
+        }
         // hideArrow: true, // defaults to False
       },
     };
 
     function tooltipFormatter(row, cell, value, column, dataContext) {
       const tooltipTitle = 'Custom Tooltip';
+      const effortDrivenHtml = Slick.Formatters.Checkmark(row, cell, dataContext.percentComplete, column, dataContext);
+      const completionBarHtml = Slick.Formatters.PercentCompleteBar(row, cell, dataContext.percentComplete, column, dataContext);
       return '<div class="color-sf-primary-dark" style="font-weight: bold">' + tooltipTitle + '</div>'
         + '<div class="tooltip-2cols-row"><div>Id:</div> <div>' + dataContext.id + '</div></div>'
         + '<div class="tooltip-2cols-row"><div>Title:</div> <div>' + dataContext.title + '</div></div>'
-        + '<div class="tooltip-2cols-row"><div>Completion:</div> <div>' + dataContext.percentComplete + '%</div>'
-        + '</div>';
+        + '<div class="tooltip-2cols-row"><div>Completion:</div> <div>' + completionBarHtml + '</div></div>'
+        + '<div class="tooltip-2cols-row"><div>Effort Driven:</div> <div>' + effortDrivenHtml + '</div></div>';
     }
 
     function tooltipTaskFormatter(row, cell, value, column, dataContext, grid) {
       const tooltipTitle = 'Task ' + dataContext.id + ' - (async tooltip)';
 
       // use a 2nd Formatter to get the percent completion
-      // any p                  ies provided from the `asyncPost` will end up in the `__params` property (unless a different prop name is provided via `asyncParamsPropName`)
-      const completionBar = Slick.Formatters.PercentCompleteBar(row, cell, dataContext.percentComplete, column, dataContext, grid);
+      // any properies provided from the `asyncPost` will end up in the `__params` property (unless a different prop name is provided via `asyncParamsPropName`)
+      const completionBar = Slick.Formatters.PercentCompleteBar(row, cell, dataContext.percentComplete, column, dataContext);
       const out = '<div class="color-se-danger" style="font-weight: bold">' + tooltipTitle + '</div>'
         + '<div class="tooltip-2cols-row"><div>Completion:</div> <div>' + completionBar + '</div></div>'
         + '<div class="tooltip-2cols-row"><div>Lifespan:</div> <div>' + dataContext.__params.lifespan.toFixed(2) + '</div></div>'

--- a/examples/example-plugin-custom-tooltip.html
+++ b/examples/example-plugin-custom-tooltip.html
@@ -152,11 +152,11 @@
       },
       { 
         id: "desc", name: '<span title="custom title tooltip text">Description</span>', field: "description", width: 100, editor: Slick.Editors.LongText,  
-        formatter: (row, cell, value, column, dataContext) => `<span title="<b>regular tooltip</b> (from title attribute) \r${dataContext.title} cell value:\r ${value || ''}">${value || ''}</span>`,
+        formatter: (row, cell, value, column, dataContext) => `<span title="regular tooltip (from title attribute)\r${dataContext.title} cell value:\r${value || ''}">${value || ''}</span>`,
         // define tooltip options here OR for the entire grid via the grid options (cell tooltip options will have precedence over grid options)
         customTooltip: {
           useRegularTooltip: true, // note regular tooltip will try to find a "title" attribute in the cell formatter (it won't work without a cell formatter)
-          renderRegularTooltipAsHtml: true, // defaults to false, regular "title" tooltip won't be rendered as html unless specified via this flag (also "\r\n" will be replaced by <br>)
+          // renderRegularTooltipAsHtml: true, // defaults to false, regular "title" tooltip won't be rendered as html unless specified via this flag (also "\r\n" will be replaced by <br>)
           // maxWidth: 100,
           // maxHeight: 30,
         },
@@ -178,6 +178,7 @@
       customTooltip: {
         formatter: tooltipFormatter,
         headerFormatter: headerFormatter,
+        // tooltipDelay: 250,
         usabilityOverride: function (args) {
          return !isTooltipDisabled && args.cell !== 0; // don't show on first column (row selection column)
         }
@@ -221,7 +222,7 @@
 
         d["id"] = i;
         d["title"] = "Task " + i;
-        d["description"] = "This is a sample task description.\n  It can be multiline";
+        d["description"] = "This is a sample task description.\nIt can be multiline\r\rAnother line...";
         d["duration"] = "5 days";
         d["percentComplete"] = Math.round(Math.random() * 100);
         d["start"] = "01/01/2009";

--- a/examples/example-plugin-custom-tooltip.html
+++ b/examples/example-plugin-custom-tooltip.html
@@ -42,7 +42,7 @@
       font-style: italic;
       font-size: 13px;
     }
-    .l2 .headerrow-tooltip-title {
+    .l3 .headerrow-tooltip-title {
       color: #ffffff;
     }
     .tooltip-2cols-row {
@@ -53,28 +53,46 @@
       line-height: 20px;
     }
 
-    /* change css of 3rd column (l2 r2) */
-    .l2.slick-custom-tooltip {
+    /* change css of 3rd column (l3) */
+    .l3 .header-tooltip-title,
+    .l3 .headerrow-tooltip-title {
+      color: #ffffff;
+    }
+    .l3.slick-custom-tooltip {
       background-color: #363636;
       color: #ffffff;
       border: 2px solid #252525;
     }
-    .l2.slick-custom-tooltip.tooltip-arrow.arrow-up::before {
-      border-bottom: 7px solid #252525;
+    .l3.slick-custom-tooltip.tooltip-arrow.arrow-down::after,
+    .l3.slick-custom-tooltip.tooltip-arrow.arrow-up::after {
+      border-width: 10px; /* arrow size */
     }
-    .l2.slick-custom-tooltip.tooltip-arrow.arrow-down::after {
-      border-top: 7px solid #252525;
+    .l3.slick-custom-tooltip.tooltip-arrow.arrow-down::after {
+      border-top-color: #252525; /* arrow down color */
+    }
+    .l3.slick-custom-tooltip.tooltip-arrow.arrow-up::after {
+      top: -20px; /* arrow size * 2 */
+      border-bottom-color: #252525; /* arrow up color */
+    }
+    .l3.slick-custom-tooltip.tooltip-arrow.arrow-left-align::after {
+      margin-left: 15px;
+    }
+    .l3.slick-custom-tooltip.tooltip-arrow.arrow-right-align::after {
+      margin-left: calc(100% - 20px - 15px); /* 20px is (arrow size * 2), 15px is your extra side margin */
+    }
+    .l5.slick-custom-tooltip.arrow-left-align::after {
+      margin-left: 5%;
     }
   </style>
 </head>
 
 <body>
   <div style="position:relative">
-    <div style="width:618px;">
+    <div style="width:718px;">
       <div id="myGrid" style="width:100%;height:500px;"></div>
     </div>
 
-    <div class="options-panel">
+    <div class="options-panel" style="margin-left: 100px">
       <h2>Demonstrates: <code>Slick.Plugins.CustomTooltip</code></h2>
       <ul>
         <li>Custom Tooltip Plugin</li>
@@ -145,7 +163,7 @@
     }
 
     function changeServerDelay(delay) {
-      serverApiDelay = delay;
+      serverApiDelay = $('#server-delay').val();
     }
 
     function filter(item) {
@@ -218,7 +236,12 @@
         },
       },
       { id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Text },
-      { id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete },
+      { 
+        id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, 
+        formatter: Slick.Formatters.PercentCompleteBar, 
+        editor: Slick.Editors.PercentComplete,
+        customTooltip: { useRegularTooltip: true },
+      },
       { id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date },
       { 
         id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date,
@@ -246,7 +269,6 @@
         formatter: tooltipFormatter,
         headerFormatter: headerFormatter,
         headerRowFormatter: headerRowFormatter,
-        // tooltipDelay: 250,
         usabilityOverride: function (args) {
          return !isTooltipDisabled && args.cell !== 0; // don't show on first column (row selection column)
         }

--- a/examples/example-plugin-custom-tooltip.html
+++ b/examples/example-plugin-custom-tooltip.html
@@ -75,7 +75,7 @@
     </div>
 
     <div class="options-panel">
-      <h2>Demonstrates:</h2>
+      <h2>Demonstrates: <code>Slick.Plugins.CustomTooltip</code></h2>
       <ul>
         <li>Custom Tooltip Plugin</li>
         <li>1st column shows an async tooltip (could be an API with Promise), it demos a formatter which itself has a
@@ -101,6 +101,9 @@
         <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-plugin-custom-tooltip.html"
             target="_sourcewindow"> View the source for this example on Github</a></li>
       </ul>
+      <p>
+	      <input type="number" id="server-delay" value="500"/> <button id="set-delay-btn" onclick="changeServerDelay()">Change Server Delay Wait (ms)</button>
+	    </p>
     </div>
   </div>
 
@@ -141,6 +144,10 @@
       }
     }
 
+    function changeServerDelay(delay) {
+      serverApiDelay = delay;
+    }
+
     function filter(item) {
       for (var columnId in columnFilters) {
         if (columnId !== undefined && columnFilters[columnId] !== "") {
@@ -166,6 +173,7 @@
     var data = [];
     var dataView;
     var customTooltipPlugin;
+    var serverApiDelay = 500; // simulate API server call delay
     var columns = [
       {
         id: "title", name: "Title", field: "title", width: 70, cssClass: "cell-title",
@@ -181,7 +189,7 @@
           // you will need to provide an `asyncPost` function returning a Promise and also `asyncPostFormatter` formatter to display the result once the Promise resolves
           formatter: () => `<div>loading...</div>`,
           asyncProcess: () => new Promise(resolve => {
-            setTimeout(() => resolve({ ratio: Math.random() * 10 / 10, lifespan: Math.random() * 100 }), 500);
+            setTimeout(() => resolve({ ratio: Math.random() * 10 / 10, lifespan: Math.random() * 100 }), serverApiDelay);
           }),
           asyncPostFormatter: this.tooltipTaskFormatter.bind(this),
 

--- a/examples/example-plugin-custom-tooltip.html
+++ b/examples/example-plugin-custom-tooltip.html
@@ -58,12 +58,6 @@
       background-color: #363636;
       color: #ffffff;
       border: 2px solid #252525;
-      /* overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      display: -webkit-box;
-      -webkit-box-orient: vertical;
-      -webkit-line-clamp: 2; */
     }
     .l2.slick-custom-tooltip.tooltip-arrow.arrow-up::before {
       border-bottom: 7px solid #252525;
@@ -201,15 +195,23 @@
         // define tooltip options here OR for the entire grid via the grid options (cell tooltip options will have precedence over grid options)
         customTooltip: {
           useRegularTooltip: true, // note regular tooltip will try to find a "title" attribute in the cell formatter (it won't work without a cell formatter)
+          // useRegularTooltipFromFormatterOnly: true,
           // renderRegularTooltipAsHtml: true, // defaults to false, regular "title" tooltip won't be rendered as html unless specified via this flag (also "\r\n" will be replaced by <br>)
-          // maxWidth: 100,
+          // maxWidth: 75,
           // maxHeight: 30,
         },
       },
       { id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Text },
       { id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete },
       { id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date },
-      { id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date },
+      { 
+        id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date,
+        // you could disable the custom/regular tooltip via either of the following 2 options
+        disableTooltip: true,
+        // customTooltip: {
+        //   usabilityOverride: (args) => false,
+        // },
+      },
       { id: "effortDriven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark, editor: Slick.Editors.Checkbox }
     ];
 

--- a/examples/example-plugin-custom-tooltip.html
+++ b/examples/example-plugin-custom-tooltip.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="../plugins/slick.customtooltip.css" type="text/css" />
   <link rel="stylesheet" href="examples.css" type="text/css" />
   <style>
-    .cell-title {
+    .cell-title, .bold {
       font-weight: bold;
     }
 
@@ -18,6 +18,10 @@
       text-align: center;
     }
 
+    .header-tooltip-title {
+      font-weight: bold;
+      font-size: 14px;
+    }
     .tooltip-2cols-row {
       display: grid;
       grid-template-columns: 1fr 1fr;
@@ -128,7 +132,7 @@
         id: "title", name: "Title", field: "title", width: 70, cssClass: "cell-title",
         editor: Slick.Editors.Text, validator: requiredFieldValidator,
         customTooltip: {
-          position: 'right', // defaults to "auto", available options are: "auto", "top", "left", "bottom", "right"
+          // position: 'bottom', // defaults to "auto", available options are: "auto", "top", "left", "bottom", "right"
           // you can use the Custom Tooltip in 2 ways (synchronous or asynchronous)
           // example 1 (sync):
           // formatter: this.tooltipTaskFormatter.bind(this),
@@ -147,7 +151,7 @@
         },
       },
       { 
-        id: "desc", name: "Description", field: "description", width: 100, editor: Slick.Editors.LongText,  
+        id: "desc", name: '<span title="custom title tooltip text">Description</span>', field: "description", width: 100, editor: Slick.Editors.LongText,  
         formatter: (row, cell, value, column, dataContext) => `<span title="<b>regular tooltip</b> (from title attribute) \r${dataContext.title} cell value:\r ${value || ''}">${value || ''}</span>`,
         // define tooltip options here OR for the entire grid via the grid options (cell tooltip options will have precedence over grid options)
         customTooltip: {
@@ -161,7 +165,7 @@
       { id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete },
       { id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date },
       { id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date },
-      { id: "effort-driven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark, editor: Slick.Editors.Checkbox }
+      { id: "effortDriven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark, editor: Slick.Editors.Checkbox }
     ];
     var gridOptions = {
       editable: true,
@@ -173,6 +177,7 @@
       // Custom Tooltip options can be defined in a Column or Grid Options or a mixed of both (first options found wins)
       customTooltip: {
         formatter: tooltipFormatter,
+        headerFormatter: headerFormatter,
         usabilityOverride: function (args) {
          return !isTooltipDisabled && args.cell !== 0; // don't show on first column (row selection column)
         }
@@ -180,11 +185,17 @@
       },
     };
 
+    function headerFormatter(row, cell, value, column, dataContext) {
+      const tooltipTitle = 'Custom Tooltip - Header';
+      return '<div class="header-tooltip-title" style="font-weight: bold">' + tooltipTitle + '</div>'
+      + '<div class="tooltip-2cols-row"><div>Column:</div> <div>' + column.name + '</div></div>';
+    }
+
     function tooltipFormatter(row, cell, value, column, dataContext) {
       const tooltipTitle = 'Custom Tooltip';
-      const effortDrivenHtml = Slick.Formatters.Checkmark(row, cell, dataContext.percentComplete, column, dataContext);
+      const effortDrivenHtml = Slick.Formatters.Checkmark(row, cell, dataContext.effortDriven, column, dataContext);
       const completionBarHtml = Slick.Formatters.PercentCompleteBar(row, cell, dataContext.percentComplete, column, dataContext);
-      return '<div class="color-sf-primary-dark" style="font-weight: bold">' + tooltipTitle + '</div>'
+      return '<div class="bold">' + tooltipTitle + '</div>'
         + '<div class="tooltip-2cols-row"><div>Id:</div> <div>' + dataContext.id + '</div></div>'
         + '<div class="tooltip-2cols-row"><div>Title:</div> <div>' + dataContext.title + '</div></div>'
         + '<div class="tooltip-2cols-row"><div>Completion:</div> <div>' + completionBarHtml + '</div></div>'
@@ -197,7 +208,7 @@
       // use a 2nd Formatter to get the percent completion
       // any properies provided from the `asyncPost` will end up in the `__params` property (unless a different prop name is provided via `asyncParamsPropName`)
       const completionBar = Slick.Formatters.PercentCompleteBar(row, cell, dataContext.percentComplete, column, dataContext);
-      const out = '<div class="color-se-danger" style="font-weight: bold">' + tooltipTitle + '</div>'
+      const out = '<div class="bold">' + tooltipTitle + '</div>'
         + '<div class="tooltip-2cols-row"><div>Completion:</div> <div>' + completionBar + '</div></div>'
         + '<div class="tooltip-2cols-row"><div>Lifespan:</div> <div>' + dataContext.__params.lifespan.toFixed(2) + '</div></div>'
         + '<div class="tooltip-2cols-row"><div>Ratio:</div> <div>'+dataContext.__params.ratio.toFixed(2) + '</div></div>';

--- a/examples/example-plugin-custom-tooltip.html
+++ b/examples/example-plugin-custom-tooltip.html
@@ -17,10 +17,33 @@
     .cell-effort-driven {
       text-align: center;
     }
+    .slick-headerrow-column {
+      background: #c4ddc4;
+      text-overflow: clip;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+    }
 
+    .slick-headerrow-column input {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+    }
+    
     .header-tooltip-title {
       font-weight: bold;
       font-size: 14px;
+    }
+    .headerrow-tooltip-title {
+      color: #AD0041;
+      font-style: italic;
+      font-size: 13px;
+    }
+    .l2 .headerrow-tooltip-title {
+      color: #ffffff;
     }
     .tooltip-2cols-row {
       display: grid;
@@ -100,6 +123,7 @@
   <script src="../plugins/slick.cellselectionmodel.js"></script>
   <script src="../plugins/slick.rowselectionmodel.js"></script>
   <script src="../plugins/slick.customtooltip.js"></script>
+  <script src="../slick.dataview.js"></script>
   <script src="../slick.formatters.js"></script>
   <script src="../slick.editors.js"></script>
   <script src="../slick.grid.js"></script>
@@ -123,9 +147,30 @@
       }
     }
 
+    function filter(item) {
+      for (var columnId in columnFilters) {
+        if (columnId !== undefined && columnFilters[columnId] !== "") {
+          var column = grid.getColumns()[grid.getColumnIndex(columnId)];
+
+          if (item[column.field] !== undefined) {
+            var filterResult = typeof item[column.field].indexOf === 'function'
+              ? (item[column.field].indexOf(columnFilters[columnId]) === -1)
+              : (item[column.field] != columnFilters[columnId]);
+
+            if (filterResult) {
+              return false;
+            }
+          }
+        }
+      }
+      return true;
+    }
+
     var isTooltipDisabled = false;
+    var columnFilters = {};
     var grid;
     var data = [];
+    var dataView;
     var customTooltipPlugin;
     var columns = [
       {
@@ -167,17 +212,22 @@
       { id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date },
       { id: "effortDriven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark, editor: Slick.Editors.Checkbox }
     ];
+
     var gridOptions = {
       editable: true,
       enableAddRow: true,
       enableCellNavigation: true,
+      explicitInitialization: true,
       asyncEditorLoading: false,
       autoEdit: false,
+      showHeaderRow: true,
+      headerRowHeight: 30,
       multiSelect: true,
       // Custom Tooltip options can be defined in a Column or Grid Options or a mixed of both (first options found wins)
       customTooltip: {
         formatter: tooltipFormatter,
         headerFormatter: headerFormatter,
+        headerRowFormatter: headerRowFormatter,
         // tooltipDelay: 250,
         usabilityOverride: function (args) {
          return !isTooltipDisabled && args.cell !== 0; // don't show on first column (row selection column)
@@ -190,6 +240,12 @@
       const tooltipTitle = 'Custom Tooltip - Header';
       return '<div class="header-tooltip-title" style="font-weight: bold">' + tooltipTitle + '</div>'
       + '<div class="tooltip-2cols-row"><div>Column:</div> <div>' + column.name + '</div></div>';
+    }
+
+    function headerRowFormatter(row, cell, value, column, dataContext) {
+      const tooltipTitle = 'Custom Tooltip - Header Row (filter)';
+      return '<div class="headerrow-tooltip-title" style="font-weight: bold">' + tooltipTitle + '</div>'
+      + '<div class="tooltip-2cols-row"><div>Column:</div> <div>' + column.field + '</div></div>';
     }
 
     function tooltipFormatter(row, cell, value, column, dataContext) {
@@ -234,21 +290,47 @@
         cssClass: "slick-cell-checkboxsel"
       });
       columns.unshift(checkboxSelector.getColumnDefinition());
-      grid = new Slick.Grid("#myGrid", data, columns, gridOptions);
+      dataView = new Slick.Data.DataView();
+      grid = new Slick.Grid("#myGrid", dataView, columns, gridOptions);
       grid.setSelectionModel(new Slick.RowSelectionModel({ selectActiveRow: false }));
       grid.registerPlugin(checkboxSelector);
 
-       customTooltipPlugin = new Slick.Plugins.CustomTooltip();
+      customTooltipPlugin = new Slick.Plugins.CustomTooltip();
       grid.setSelectionModel(new Slick.CellSelectionModel());
       grid.registerPlugin(customTooltipPlugin);
 
-      grid.onAddNewRow.subscribe(function (e, args) {
-        var item = args.item;
-        grid.invalidateRow(data.length);
-        data.push(item);
+      $(grid.getHeaderRow()).on("change keyup", ":input", function (e) {
+        var columnId = $(this).data("columnId");
+        if (columnId != null) {
+          // keep filter in global variable & filter dataset by calling a refresh
+          columnFilters[columnId] = $.trim($(this).val());
+          dataView.refresh();
+        }
+      });
+
+      grid.onHeaderRowCellRendered.subscribe(function(e, args) {
+        $(args.node).empty();
+        $("<input type='text'>")
+            .data("columnId", args.column.id)
+            .val(columnFilters[args.column.id])
+            .appendTo(args.node);
+      });
+
+      dataView.onRowCountChanged.subscribe(function (e, args) {
         grid.updateRowCount();
         grid.render();
       });
+
+      dataView.onRowsChanged.subscribe(function (e, args) {
+        grid.invalidateRows(args.rows);
+        grid.render();
+      });
+
+      grid.init();
+      dataView.beginUpdate();
+      dataView.setItems(data);
+      dataView.setFilter(filter);
+      dataView.endUpdate();
     })
   </script>
 </body>

--- a/examples/example-plugin-custom-tooltip.html
+++ b/examples/example-plugin-custom-tooltip.html
@@ -1,0 +1,173 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
+  <title>SlickGrid example 3: Editing</title>
+  <link rel="stylesheet" href="../slick.grid.css" type="text/css" />
+  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css" />
+  <link rel="stylesheet" href="../plugins/slick.customtooltip.css" type="text/css" />
+  <link rel="stylesheet" href="examples.css" type="text/css" />
+  <style>
+    .cell-title {
+      font-weight: bold;
+    }
+
+    .cell-effort-driven {
+      text-align: center;
+    }
+
+    .tooltip-2cols-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: 1fr;
+      column-gap: 5px;
+      line-height: 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <div style="position:relative">
+    <div style="width:600px;">
+      <div id="myGrid" style="width:100%;height:500px;"></div>
+    </div>
+
+    <div class="options-panel">
+      <h2>Demonstrates:</h2>
+      <ul>
+        <li>Custom Tooltip Plugin</li>
+        <li>First column shows a tooltip with a formatter which itself has a formatter displaying percent complete bar
+        </li>
+        <li>Every other columns will show other info of the item data context</li>
+      </ul>
+
+      <h2>Options:</h2>
+      <button onclick="grid.setOptions({autoEdit:true})">Auto-edit ON</button>
+      &nbsp;
+      <button onclick="grid.setOptions({autoEdit:false})">Auto-edit OFF</button>
+      <h2>View Source:</h2>
+      <ul>
+        <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-plugin-custom-tooltip.html"
+            target="_sourcewindow"> View the source for this example on Github</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <script src="../lib/firebugx.js"></script>
+
+  <script src="../lib/jquery-1.12.4.min.js"></script>
+  <script src="../lib/jquery-ui.min.js"></script>
+  <script src="../lib/jquery.event.drag-2.3.0.js"></script>
+
+  <script src="../slick.core.js"></script>
+  <script src="../plugins/slick.checkboxselectcolumn.js"></script>
+  <script src="../plugins/slick.cellrangedecorator.js"></script>
+  <script src="../plugins/slick.cellrangeselector.js"></script>
+  <script src="../plugins/slick.cellselectionmodel.js"></script>
+  <script src="../plugins/slick.rowselectionmodel.js"></script>
+  <script src="../plugins/slick.customtooltip.js"></script>
+  <script src="../slick.formatters.js"></script>
+  <script src="../slick.editors.js"></script>
+  <script src="../slick.grid.js"></script>
+
+  <script>
+    function requiredFieldValidator(value) {
+      if (value == null || value == undefined || !value.length) {
+        return { valid: false, msg: "This is a required field" };
+      } else {
+        return { valid: true, msg: null };
+      }
+    }
+
+    var grid;
+    var data = [];
+    var columns = [
+      {
+        id: "title", name: "Title", field: "title", width: 70, cssClass: "cell-title",
+        editor: Slick.Editors.Text, validator: requiredFieldValidator,
+        customTooltip: {
+          formatter: tooltipTaskFormatter,
+          usabilityOverride: (args) => !!(args.dataContext?.id % 2) // show it only every second row
+        },
+      },
+      { id: "desc", name: "Description", field: "description", width: 100, editor: Slick.Editors.LongText },
+      { id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Text },
+      { id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete },
+      { id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date },
+      { id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date },
+      { id: "effort-driven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark, editor: Slick.Editors.Checkbox }
+    ];
+    var gridOptions = {
+      editable: true,
+      enableAddRow: true,
+      enableCellNavigation: true,
+      asyncEditorLoading: false,
+      autoEdit: false,
+      multiSelect: true,
+      // Custom Tooltip options can be defined in a Column or Grid Options or a mixed of both (first options found wins)
+      enableCustomTooltip: true,
+      customTooltip: {
+        formatter: this.tooltipFormatter.bind(this),
+        usabilityOverride: (args) => (args.cell !== 0 && args.cell !== args.grid.getColumns().length - 1), // don't show on first/last columns
+      },
+    };
+
+    function tooltipFormatter(row, cell, value, column, dataContext) {
+      const tooltipTitle = 'Custom Tooltip';
+      return '<div class="color-sf-primary-dark" style="font-weight: bold">' + tooltipTitle + '</div>'
+        + '<div class="tooltip-2cols-row"><div>Id:</div> <div>' + dataContext.id + '</div></div>'
+        + '<div class="tooltip-2cols-row"><div>Title:</div> <div>' + dataContext.title + '</div></div>'
+        + '<div class="tooltip-2cols-row"><div>Completion:</div> <div>' + dataContext.percentComplete + '%</div>'
+        + '</div>';
+    }
+
+    function tooltipTaskFormatter(row, cell, value, column, dataContext, grid) {
+      const tooltipTitle = 'Task ' + dataContext.id + ' - Tooltip';
+
+      // use a 2nd Formatter to get the percent completion
+      const completionBar = Slick.Formatters.PercentCompleteBar(row, cell, dataContext.percentComplete, column, dataContext, grid);
+      const out = '<div class="color-se-danger" style="font-weight: bold">' + tooltipTitle + '</div>'
+        + '<div class="tooltip-2cols-row"><div>Completion:</div> <div>' + completionBar + '</div></div>';
+      return out;
+    }
+
+    $(function () {
+      for (var i = 0; i < 500; i++) {
+        var d = (data[i] = {});
+
+        d["id"] = i;
+        d["title"] = "Task " + i;
+        d["description"] = "This is a sample task description.\n  It can be multiline";
+        d["duration"] = "5 days";
+        d["percentComplete"] = Math.round(Math.random() * 100);
+        d["start"] = "01/01/2009";
+        d["finish"] = "01/05/2009";
+        d["effortDriven"] = (i % 5 == 0);
+      }
+
+      var checkboxSelector = new Slick.CheckboxSelectColumn({
+        cssClass: "slick-cell-checkboxsel"
+      });
+      columns.unshift(checkboxSelector.getColumnDefinition());
+      grid = new Slick.Grid("#myGrid", data, columns, gridOptions);
+      grid.setSelectionModel(new Slick.RowSelectionModel({ selectActiveRow: false }));
+      grid.registerPlugin(checkboxSelector);
+
+      var customTooltipPlugin = new Slick.Plugins.CustomTooltip();
+      grid.setSelectionModel(new Slick.CellSelectionModel());
+      grid.registerPlugin(customTooltipPlugin);
+
+      grid.onAddNewRow.subscribe(function (e, args) {
+        var item = args.item;
+        grid.invalidateRow(data.length);
+        data.push(item);
+        grid.updateRowCount();
+        grid.render();
+      });
+    })
+  </script>
+</body>
+
+</html>

--- a/examples/example-plugin-custom-tooltip.html
+++ b/examples/example-plugin-custom-tooltip.html
@@ -99,7 +99,7 @@
           // when using async, the `formatter` will contain the loading spinner
           // you will need to provide an `asyncPost` function returning a Promise and also `asyncPostFormatter` formatter to display the result once the Promise resolves
           formatter: () => `<div>loading...</div>`,
-          asyncPostProcess: () => new Promise(resolve => {
+          asyncProcess: () => new Promise(resolve => {
             setTimeout(() => resolve({ ratio: Math.random() * 10 / 10, lifespan: Math.random() * 100 }), 500);
           }),
           asyncPostFormatter: this.tooltipTaskFormatter.bind(this),
@@ -108,7 +108,15 @@
           // usabilityOverride: (args) => !!(args.dataContext?.id % 2) // show it only every second row
         },
       },
-      { id: "desc", name: "Description", field: "description", width: 100, editor: Slick.Editors.LongText },
+      { 
+        id: "desc", name: "Description", field: "description", width: 100, editor: Slick.Editors.LongText,  
+        formatter: (row, cell, value) => `<span title="regular tooltip (from title attribute) - cell value: ${value || ''}">${value || ''}</span>`,
+        customTooltip: {
+          useRegularTooltip: true,
+          // maxWidth: 200,
+          // maxHeight: 40,
+        },
+      },
       { id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Text },
       { id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete },
       { id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date },
@@ -140,7 +148,7 @@
     }
 
     function tooltipTaskFormatter(row, cell, value, column, dataContext, grid) {
-      const tooltipTitle = 'Task ' + dataContext.id + ' - Tooltip';
+      const tooltipTitle = 'Task ' + dataContext.id + ' - (async tooltip)';
 
       // use a 2nd Formatter to get the percent completion
       // any p                  ies provided from the `asyncPost` will end up in the `__params` property (unless a different prop name is provided via `asyncParamsPropName`)

--- a/examples/example-plugin-custom-tooltip.html
+++ b/examples/example-plugin-custom-tooltip.html
@@ -128,6 +128,7 @@
         id: "title", name: "Title", field: "title", width: 70, cssClass: "cell-title",
         editor: Slick.Editors.Text, validator: requiredFieldValidator,
         customTooltip: {
+          position: 'right', // defaults to "auto", available options are: "auto", "top", "left", "bottom", "right"
           // you can use the Custom Tooltip in 2 ways (synchronous or asynchronous)
           // example 1 (sync):
           // formatter: this.tooltipTaskFormatter.bind(this),

--- a/examples/example-plugin-custom-tooltip.html
+++ b/examples/example-plugin-custom-tooltip.html
@@ -203,7 +203,15 @@
         // define tooltip options here OR for the entire grid via the grid options (cell tooltip options will have precedence over grid options)
         customTooltip: {
           useRegularTooltip: true, // note regular tooltip will try to find a "title" attribute in the cell formatter (it won't work without a cell formatter)
-          // useRegularTooltipFromFormatterOnly: true,
+        },
+      },
+      { 
+        id: "desc2", name: '<span title="custom title tooltip text">Description 2</span>', field: "description", width: 100, editor: Slick.Editors.LongText,  
+        formatter: (row, cell, value, column, dataContext) => `<span title="regular tooltip (from title attribute)\r${dataContext.title} cell value:\r${value || ''}">${value || ''}</span>`,
+        // define tooltip options here OR for the entire grid via the grid options (cell tooltip options will have precedence over grid options)
+        customTooltip: {
+          useRegularTooltip: true, // note regular tooltip will try to find a "title" attribute in the cell formatter (it won't work without a cell formatter)
+          useRegularTooltipFromFormatterOnly: true,
           // renderRegularTooltipAsHtml: true, // defaults to false, regular "title" tooltip won't be rendered as html unless specified via this flag (also "\r\n" will be replaced by <br>)
           // maxWidth: 75,
           // maxHeight: 30,

--- a/examples/example-plugin-custom-tooltip.html
+++ b/examples/example-plugin-custom-tooltip.html
@@ -38,15 +38,17 @@
       <h2>Demonstrates:</h2>
       <ul>
         <li>Custom Tooltip Plugin</li>
-        <li>First column shows a tooltip with a formatter which itself has a formatter displaying percent complete bar
+        <li>First column shows an async tooltip (could be an API with Promise), it demos a formatter which itself has a
+          formatter displaying percent complete bar
         </li>
         <li>Every other columns will show other info of the item data context</li>
+        <li>Tooltip gets auto-position depending on its available space</li>
       </ul>
 
       <h2>Options:</h2>
-      <button onclick="grid.setOptions({autoEdit:true})">Auto-edit ON</button>
+      <button onclick="customTooltipPlugin.setOptions({hideArrow:true})">Hide Tooltip Arrow ON</button>
       &nbsp;
-      <button onclick="grid.setOptions({autoEdit:false})">Auto-edit OFF</button>
+      <button onclick="customTooltipPlugin.setOptions({hideArrow:false})">Hide Tooltip Arrow OFF</button>
       <h2>View Source:</h2>
       <ul>
         <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-plugin-custom-tooltip.html"
@@ -83,13 +85,27 @@
 
     var grid;
     var data = [];
+    var customTooltipPlugin;
     var columns = [
       {
         id: "title", name: "Title", field: "title", width: 70, cssClass: "cell-title",
         editor: Slick.Editors.Text, validator: requiredFieldValidator,
         customTooltip: {
-          formatter: tooltipTaskFormatter,
-          usabilityOverride: (args) => !!(args.dataContext?.id % 2) // show it only every second row
+          // you can use the Custom Tooltip in 2 ways (synchronous or asynchronous)
+          // example 1 (sync):
+          // formatter: this.tooltipTaskFormatter.bind(this),
+
+          // example 2 (async):
+          // when using async, the `formatter` will contain the loading spinner
+          // you will need to provide an `asyncPost` function returning a Promise and also `asyncPostFormatter` formatter to display the result once the Promise resolves
+          formatter: () => `<div>loading...</div>`,
+          asyncPostProcess: () => new Promise(resolve => {
+            setTimeout(() => resolve({ ratio: Math.random() * 10 / 10, lifespan: Math.random() * 100 }), 500);
+          }),
+          asyncPostFormatter: this.tooltipTaskFormatter.bind(this),
+
+          // optional conditional usability callback
+          // usabilityOverride: (args) => !!(args.dataContext?.id % 2) // show it only every second row
         },
       },
       { id: "desc", name: "Description", field: "description", width: 100, editor: Slick.Editors.LongText },
@@ -107,10 +123,10 @@
       autoEdit: false,
       multiSelect: true,
       // Custom Tooltip options can be defined in a Column or Grid Options or a mixed of both (first options found wins)
-      enableCustomTooltip: true,
       customTooltip: {
-        formatter: this.tooltipFormatter.bind(this),
-        usabilityOverride: (args) => (args.cell !== 0 && args.cell !== args.grid.getColumns().length - 1), // don't show on first/last columns
+        formatter: tooltipFormatter,
+        usabilityOverride: (args) => (args.cell !== 0), // don't show on first column
+        // hideArrow: true, // defaults to False
       },
     };
 
@@ -127,9 +143,12 @@
       const tooltipTitle = 'Task ' + dataContext.id + ' - Tooltip';
 
       // use a 2nd Formatter to get the percent completion
+      // any p                  ies provided from the `asyncPost` will end up in the `__params` property (unless a different prop name is provided via `asyncParamsPropName`)
       const completionBar = Slick.Formatters.PercentCompleteBar(row, cell, dataContext.percentComplete, column, dataContext, grid);
       const out = '<div class="color-se-danger" style="font-weight: bold">' + tooltipTitle + '</div>'
-        + '<div class="tooltip-2cols-row"><div>Completion:</div> <div>' + completionBar + '</div></div>';
+        + '<div class="tooltip-2cols-row"><div>Completion:</div> <div>' + completionBar + '</div></div>'
+        + '<div class="tooltip-2cols-row"><div>Lifespan:</div> <div>' + dataContext.__params.lifespan.toFixed(2) + '</div></div>'
+        + '<div class="tooltip-2cols-row"><div>Ratio:</div> <div>'+dataContext.__params.ratio.toFixed(2) + '</div></div>';
       return out;
     }
 
@@ -155,7 +174,7 @@
       grid.setSelectionModel(new Slick.RowSelectionModel({ selectActiveRow: false }));
       grid.registerPlugin(checkboxSelector);
 
-      var customTooltipPlugin = new Slick.Plugins.CustomTooltip();
+       customTooltipPlugin = new Slick.Plugins.CustomTooltip();
       grid.setSelectionModel(new Slick.CellSelectionModel());
       grid.registerPlugin(customTooltipPlugin);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slickgrid",
-  "version": "2.4.41",
+  "version": "2.4.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "slickgrid",
-      "version": "2.4.41",
+      "version": "2.4.42",
       "license": "MIT",
       "dependencies": {
         "jquery": ">=1.8.0",

--- a/plugins/slick.customTooltip.css
+++ b/plugins/slick.customTooltip.css
@@ -8,40 +8,35 @@
   padding: 7px;
   height: auto;
   width: auto;
-  z-index: 200;
+  z-index: 9999;
   overflow: inherit;
   text-overflow: ellipsis;
   white-space: normal;
 }
-.slick-custom-tooltip::after {
-  content: "";
-  clear: both;
-  display: table;
-}
 
-/* show arrow below tooltip with same color as the border color */
-.slick-custom-tooltip::after,
-.slick-custom-tooltip::before {
+/** 
+ * tooltip arrow styling, arrow styled following this article
+ * https://blog.logrocket.com/creating-beautiful-tooltips-with-only-css/
+ */
+.slick-custom-tooltip.tooltip-arrow::after {
   content: "";
-  height: 0;
+  left: 0px;
   position: absolute;
-  width: 0;
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
+  border: transparent;
+  border-style: solid;
+  border-width: 8px; /* arrow size */
 }
-.slick-custom-tooltip.tooltip-arrow.arrow-up::before {
-  border-bottom: 7px solid #acacac;
-  top: -7px;
+.slick-custom-tooltip.tooltip-arrow.arrow-up::after {
+  top: -16px; /* arrow size, negative(8px * 2) */
+  border-bottom-color: #BFBDBD;
 }
 .slick-custom-tooltip.tooltip-arrow.arrow-down::after {
-  border-top: 7px solid #acacac;
-  bottom: -7px;
+  top: 100%;
+  border-top-color: #BFBDBD;
 }
-.slick-custom-tooltip.tooltip-arrow.arrow-left::after
-.slick-custom-tooltip.tooltip-arrow.arrow-left::before {
-  margin-left: -10%;
+.slick-custom-tooltip.tooltip-arrow.arrow-left-align::after {
+  margin-left: 9px;
 }
-.slick-custom-tooltip.tooltip-arrow.arrow-right::after,
-.slick-custom-tooltip.tooltip-arrow.arrow-right::before {
-  margin-left: 70%;
+.slick-custom-tooltip.tooltip-arrow.arrow-right-align::after {
+  margin-left: calc(100% - 16px - 9px); /* arrow size * 2 => 16px, extra margin of 9px */
 }

--- a/plugins/slick.customTooltip.css
+++ b/plugins/slick.customTooltip.css
@@ -4,6 +4,7 @@
   border: 2px solid #acacac;
   border-radius: 4px;
   color: inherit;
+  font-size: 7.5pt;
   padding: 7px;
   height: auto;
   width: auto;

--- a/plugins/slick.customTooltip.css
+++ b/plugins/slick.customTooltip.css
@@ -7,19 +7,32 @@
   padding: 7px;
   height: auto;
   width: auto;
-  z-index: 10;
+  z-index: 200;
 }
 
 /* show arrow below tooltip with same color as the border color */
-.slick-custom-tooltip::after {
+.slick-custom-tooltip::after,
+.slick-custom-tooltip::before {
   content: "";
   height: 0;
   position: absolute;
   width: 0;
   border-left: 10px solid transparent;
   border-right: 10px solid transparent;
+}
+.slick-custom-tooltip.tooltip-arrow.arrow-up::before {
+  border-bottom: 7px solid #acacac;
+  top: -7px;
+}
+.slick-custom-tooltip.tooltip-arrow.arrow-down::after {
   border-top: 7px solid #acacac;
-  margin-left: -20px;
   bottom: -7px;
-  left: 25px;
+}
+.slick-custom-tooltip.tooltip-arrow.arrow-left::after
+.slick-custom-tooltip.tooltip-arrow.arrow-left::before {
+  margin-left: -10%;
+}
+.slick-custom-tooltip.tooltip-arrow.arrow-right::after,
+.slick-custom-tooltip.tooltip-arrow.arrow-right::before {
+  margin-left: 80%;
 }

--- a/plugins/slick.customTooltip.css
+++ b/plugins/slick.customTooltip.css
@@ -8,6 +8,14 @@
   height: auto;
   width: auto;
   z-index: 200;
+  overflow: initial;
+  text-overflow: ellipsis;
+  white-space: normal;
+}
+.slick-custom-tooltip::after {
+  content: "";
+  clear: both;
+  display: table;
 }
 
 /* show arrow below tooltip with same color as the border color */

--- a/plugins/slick.customTooltip.css
+++ b/plugins/slick.customTooltip.css
@@ -42,5 +42,5 @@
 }
 .slick-custom-tooltip.tooltip-arrow.arrow-right::after,
 .slick-custom-tooltip.tooltip-arrow.arrow-right::before {
-  margin-left: 80%;
+  margin-left: 70%;
 }

--- a/plugins/slick.customTooltip.css
+++ b/plugins/slick.customTooltip.css
@@ -1,0 +1,25 @@
+.slick-custom-tooltip {
+  position: absolute;
+  background-color: #ffffff;
+  border: 2px solid #acacac;
+  border-radius: 4px;
+  color: inherit;
+  padding: 7px;
+  height: auto;
+  width: auto;
+  z-index: 10;
+}
+
+/* show arrow below tooltip with same color as the border color */
+.slick-custom-tooltip::after {
+  content: "";
+  height: 0;
+  position: absolute;
+  width: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-top: 7px solid #acacac;
+  margin-left: -20px;
+  bottom: -7px;
+  left: 25px;
+}

--- a/plugins/slick.customTooltip.css
+++ b/plugins/slick.customTooltip.css
@@ -9,7 +9,7 @@
   height: auto;
   width: auto;
   z-index: 200;
-  overflow: initial;
+  overflow: inherit;
   text-overflow: ellipsis;
   white-space: normal;
 }

--- a/plugins/slick.customtooltip.js
+++ b/plugins/slick.customtooltip.js
@@ -308,18 +308,18 @@
       }
 
       if (tooltipText !== '') {
-        renderTooltipFormatter(formatterOrText, cell, value, columnDef, item, tooltipText /* , _cellTooltipOptions.useRegularTooltipFromFormatterOnly ? null : tmpTitleElm */);
+        renderTooltipFormatter(formatterOrText, cell, value, columnDef, item, tooltipText);
       }
 
       // also clear any "title" attribute to avoid showing a 2nd browser tooltip
-      clearTitleAttribute(tmpTitleElm, tooltipText);
+      swapAndClearTitleAttribute(tmpTitleElm, tooltipText);
     }
 
     /**
-     * clear the "title" attribute from the grid div text content so that it won't show also as a 2nd browser tooltip
-     * note: the reason we can do delete it completely is because we always re-execute the formatter whenever we hover the tooltip and so we have a fresh title attribute each time to use
-     */
-    function clearTitleAttribute(inputTitleElm, tooltipText) {
+   * swap and copy the "title" attribute into a new custom attribute then clear the "title" attribute
+   * from the grid div text content so that it won't show also as a 2nd browser tooltip
+   */
+    function swapAndClearTitleAttribute(inputTitleElm, tooltipText) {
       // the title attribute might be directly on the slick-cell container element (when formatter returns a result object)
       // OR in a child element (most commonly as a custom formatter)
       var titleElm = inputTitleElm || (_cellNodeElm && ((_cellNodeElm.hasAttribute('title') && _cellNodeElm.getAttribute('title')) ? _cellNodeElm : _cellNodeElm.querySelector('[title]')));
@@ -435,11 +435,11 @@
         var position = _cellTooltipOptions.position || 'auto';
         if (position === 'left-align' || (position === 'auto' && (newPositionLeft + calculatedTooltipWidth) > calculatedBodyWidth)) {
           newPositionLeft -= (calculatedTooltipWidth - containerWidth - (_cellTooltipOptions.offsetRight || 0));
-          _tooltipElm.classList.remove('arrow-left');
-          _tooltipElm.classList.add('arrow-right');
+          _tooltipElm.classList.remove('arrow-left-align');
+          _tooltipElm.classList.add('arrow-right-align');
         } else {
-          _tooltipElm.classList.add('arrow-left');
-          _tooltipElm.classList.remove('arrow-right');
+          _tooltipElm.classList.add('arrow-left-align');
+          _tooltipElm.classList.remove('arrow-right-align');
         }
 
         // do the same calculation/reposition with top/bottom (default is top of the cell or in other word starting from the cell going down)
@@ -465,7 +465,7 @@
     function parseFormatterAndSanitize(formatterOrText, cell, value, columnDef, item) {
       if (typeof formatterOrText === 'function') {
         var tooltipText = formatterOrText(cell.row, cell.cell, value, columnDef, item, _grid);
-        var formatterText = ((typeof tooltipText === 'object' && tooltipText.text) ? tooltipText.text : typeof tooltipText === 'string' ? tooltipText : '');
+        var formatterText = (typeof tooltipText === 'object' && tooltipText && tooltipText.text) ? tooltipText.text : (typeof tooltipText === 'string' ? tooltipText : '');
         return sanitizeHtmlString(formatterText);
       } else if (typeof formatterOrText === 'string') {
         return sanitizeHtmlString(formatterOrText);
@@ -511,7 +511,7 @@
       }
 
       // also clear any "title" attribute to avoid showing a 2nd browser tooltip
-      clearTitleAttribute(inputTitleElm, outputText);
+      swapAndClearTitleAttribute(inputTitleElm, outputText);
     }
 
     /**

--- a/plugins/slick.customtooltip.js
+++ b/plugins/slick.customtooltip.js
@@ -17,7 +17,7 @@
  *      id: "action", name: "Action", field: "action", formatter: fakeButtonFormatter,
  *      customTooltip: {
  *        formatter: tooltipTaskFormatter,
- *        usabilityOverride: (args) => !!(args.dataContext?.id % 2) // show it only every second row
+ *        usabilityOverride: (args) => !!(args.dataContext.id % 2) // show it only every second row
  *      }
  *    }
  *  ];
@@ -27,13 +27,13 @@
  *    enableCellNavigation: true,
  *    customTooltip: {
  *      formatter: tooltipTaskFormatter,
- *      usabilityOverride: (args) => !!(args.dataContext?.id % 2) // show it only every second row
+ *      usabilityOverride: (args) => !!(args.dataContext.id % 2) // show it only every second row
  *    },
  *  };
  *
  * @param options {Object} Custom Tooltip Options
  * @class Slick.Plugins.CustomTooltip
- * @constructor
+ * @varructor
  */
 (function ($) {
   // Register namespace
@@ -47,17 +47,22 @@
 
   /**
    * CustomTooltip plugin to show/hide tooltips when columns are too narrow to fit content.
-   * @constructor
+   * @varructor
    * @param {boolean} [options.className="slick-custom-tooltip"]  - custom tooltip class name
    * @param {boolean} [options.offsetTop=5]                       - tooltip offset from the top
    */
   function CustomTooltip(options) {
+    var _cancellablePromise;
     var _dataView;
     var _grid;
     var _gridOptions;
+    var _tooltipElm;
     var _defaults = {
       className: 'slick-custom-tooltip',
-      offsetTop: 5
+      offsetLeft: 0,
+      offsetRight: 0,
+      offsetTopBottom: 4,
+      hideArrow: false,
     };
     var _eventHandler = new Slick.EventHandler();
     var _options;
@@ -66,21 +71,21 @@
      * Initialize plugin.
      */
     function init(grid) {
-      options = $.extend(true, {}, _defaults, options);
+      _options = $.extend(true, {}, _defaults, options);
       _grid = grid;
       var _data = grid && grid.getData() || [];
       _dataView = Array.isArray(_data) ? null : _data;
       _gridOptions = grid.getOptions() || {};
       _eventHandler
         .subscribe(grid.onMouseEnter, handleOnMouseEnter)
-        .subscribe(grid.onMouseLeave, hide);
+        .subscribe(grid.onMouseLeave, hideTooltip);
     }
 
     /**
      * Destroy plugin.
      */
     function destroy() {
-      hide();
+      hideTooltip();
       _eventHandler.unsubscribeAll();
     }
 
@@ -89,13 +94,17 @@
      * @param {jQuery.Event} e - The event
      */
     function handleOnMouseEnter(e, args) {
+      // before doing anything, let's remove any previous tooltip before
+      // and cancel any opened Promise/Observable when using async
+      hideTooltip();
+
       if (_grid && e) {
         var cell = _grid.getCellFromEvent(e);
         if (cell) {
           var item = _dataView ? _dataView.getItem(cell.row) : _grid.getDataItem(cell.row);
           var columnDef = _grid.getColumns()[cell.cell];
           if (item && columnDef) {
-            _options = $.extend(true, {}, _defaults, _gridOptions.customTooltip, columnDef.customTooltip);
+            _options = $.extend(true, {}, _options, _gridOptions.customTooltip, columnDef.customTooltip);
 
             // run the override function (when defined), if the result is false it won't go further
             if (!args) {
@@ -110,24 +119,78 @@
               return;
             }
 
+            var value = item.hasOwnProperty(columnDef.field) ? item[columnDef.field] : null;
             if (typeof _options.formatter === 'function') {
-              var itemValue = item.hasOwnProperty(columnDef.field) ? item[columnDef.field] : null;
-              var tooltipText = _options.formatter(cell.row, cell.cell, itemValue, columnDef, item, _grid);
+              renderTooltipFormatter(value, columnDef, item, _options.formatter, cell);
+            }
+            if (typeof _options.asyncPostProcess === 'function') {
+              var asyncProcess = _options.asyncPostProcess(cell.row, cell.cell, value, columnDef, item, _grid);
+              if (!_options.asyncPostFormatter) {
+                throw new Error('[Slickgrid-Universal] when using "asyncPostProcess", you must also provide an "asyncPostFormatter" formatter');
+              }
 
-              // create the tooltip DOM element with the text returned by the Formatter
-              var tooltipElm = document.createElement('div');
-              tooltipElm.className = _options.className + ' ' + _grid.getUID();
-              tooltipElm.innerHTML = typeof tooltipText === 'object' ? tooltipText.text : tooltipText;
-              document.body.appendChild(tooltipElm);
-
-              // reposition the tooltip on top of the cell that triggered the mouse over event
-              var cellPosition = getHtmlElementOffset(_grid.getCellNode(cell.row, cell.cell));
-              tooltipElm.style.left = cellPosition.left + 'px';
-              tooltipElm.style.top = cellPosition.top - tooltipElm.clientHeight - (_options.offsetTop || 0) + 'px';
+              if (asyncProcess instanceof Promise) {
+                // create a new cancellable promise which will resolve, unless it's cancelled, with the udpated `dataContext` object that includes the `__params`
+                _cancellablePromise = cancellablePromise(asyncProcess);
+                _cancellablePromise.promise
+                  .then(function (asyncResult) {
+                    asyncProcessCallback(asyncResult, cell, value, columnDef, item)
+                  })
+                  .catch(function (error) {
+                    // we will throw back any errors, unless it's a cancelled promise which in that case will be disregarded (thrown by the promise wrapper cancel() call)
+                    if (!(error.isPromiseCancelled)) {
+                      throw error;
+                    }
+                  });
+              }
             }
           }
         }
       }
+    }
+
+    function asyncProcessCallback(asyncResult, cell, value, columnDef, dataContext) {
+      hideTooltip();
+      var itemWithAsyncData = $.extend(true, {}, dataContext, { [_options.asyncParamsPropName || '__params']: asyncResult });
+      renderTooltipFormatter(value, columnDef, itemWithAsyncData, _options.asyncPostFormatter, cell);
+    }
+
+
+    function calculateAvailableSpaceTop(element) {
+      let availableSpace = 0;
+      var pageScrollTop = windowScrollPosition().top;
+      var elmOffset = getHtmlElementOffset(element);
+      if (elmOffset) {
+        var elementOffsetTop = elmOffset.top;
+        availableSpace = elementOffsetTop - pageScrollTop;
+      }
+      return availableSpace;
+    }
+
+    function cancellablePromise(inputPromise) {
+      let hasCancelled = false;
+
+      if (inputPromise instanceof Promise) {
+        return {
+          promise: inputPromise.then(function (result) {
+            if (hasCancelled) {
+              throw { isPromiseCancelled: true };
+            }
+            return result;
+          }),
+          cancel: function () {
+            hasCancelled = true;
+          }
+        };
+      }
+      return inputPromise;
+    }
+
+    function windowScrollPosition() {
+      return {
+        left: window.pageXOffset || document.documentElement.scrollLeft || 0,
+        top: window.pageYOffset || document.documentElement.scrollTop || 0,
+      };
     }
 
     function getHtmlElementOffset(element) {
@@ -150,12 +213,84 @@
     }
 
     /**
-     * Hide (destroy) the tooltip when mouse entering header cell to add/remove tooltip.
+     * hide (remove) tooltip from the DOM,
+     * when using async process, it will also cancel any opened Promise/Observable that might still be opened/pending.
      */
-    function hide() {
+    function hideTooltip() {
+      if (_cancellablePromise && _cancellablePromise.cancel) {
+        _cancellablePromise.cancel();
+      }
       var prevTooltip = document.body.querySelector('.' + _options.className + '.' + _grid.getUID());
       if (prevTooltip && prevTooltip.remove) {
         prevTooltip.remove();
+      }
+    }
+
+    /**
+     * Reposition the Tooltip to be top-left position over the cell.
+     * By default we use an "auto" mode which will allow to position the Tooltip to the best logical position in the window, also when we mention position, we are talking about the relative position against the grid cell.
+     * We can assume that in 80% of the time the default position is top-right, the default is "auto" but we can also override it and use a specific position.
+     * Most of the time positioning of the tooltip will be to the "top-right" of the cell is ok but if our column is completely on the right side then we'll want to change the position to "left" align.
+     * Same goes for the top/bottom position, Most of the time positioning the tooltip to the "top" but if we are hovering a cell at the top of the grid and there's no room to display it then we might need to reposition to "bottom" instead.
+     */
+    function reposition(cell) {
+      if (_tooltipElm) {
+        var cellElm = _grid.getCellNode(cell.row, cell.cell);
+        var cellPosition = getHtmlElementOffset(cellElm);
+        var containerWidth = cellElm.offsetWidth;
+        var calculatedTooltipHeight = _tooltipElm.getBoundingClientRect().height;
+        var calculatedTooltipWidth = _tooltipElm.getBoundingClientRect().width;
+        var calculatedBodyWidth = document.body.offsetWidth || window.innerWidth;
+
+        // first calculate the default (top/left) position
+        let newPositionTop = cellPosition.top - _tooltipElm.offsetHeight - (_options.offsetTopBottom || 0);
+        let newPositionLeft = (cellPosition && cellPosition.left || 0) - (_options.offsetLeft || 0);
+
+        // user could explicitely use a "left" position (when user knows his column is completely on the right)
+        // or when using "auto" and we detect not enough available space then we'll position to the "left" of the cell
+        var position = _options.position || 'auto';
+        if (position === 'left' || (position === 'auto' && (newPositionLeft + calculatedTooltipWidth) > calculatedBodyWidth)) {
+          newPositionLeft -= (calculatedTooltipWidth - containerWidth - (_options.offsetRight || 0));
+          _tooltipElm.classList.remove('arrow-left');
+          _tooltipElm.classList.add('arrow-right');
+        } else {
+          _tooltipElm.classList.add('arrow-left');
+          _tooltipElm.classList.remove('arrow-right');
+        }
+
+        // do the same calculation/reposition with top/bottom (default is top of the cell or in other word starting from the cell going down)
+        if (position === 'top' || (position === 'auto' && calculatedTooltipHeight > calculateAvailableSpaceTop(cellElm))) {
+          newPositionTop = cellPosition.top + (_gridOptions.rowHeight || 0) + (_options.offsetTopBottom || 0);
+          _tooltipElm.classList.remove('arrow-down');
+          _tooltipElm.classList.add('arrow-up');
+        } else {
+          _tooltipElm.classList.add('arrow-down');
+          _tooltipElm.classList.remove('arrow-up');
+        }
+
+        // reposition the editor over the cell (90% of the time this will end up using a position on the "right" of the cell)
+        _tooltipElm.style.top = newPositionTop + 'px';
+        _tooltipElm.style.left = newPositionLeft + 'px';
+      }
+    }
+
+    function renderTooltipFormatter(value, columnDef, item, formatter, cell) {
+      if (typeof formatter === 'function') {
+        var tooltipText = formatter(cell.row, cell.cell, value, columnDef, item, _grid);
+
+        // create the tooltip DOM element with the text returned by the Formatter
+        _tooltipElm = document.createElement('div');
+        _tooltipElm.className = _options.className + ' ' + _grid.getUID();
+        _tooltipElm.innerHTML = typeof tooltipText === 'object' ? tooltipText.text : tooltipText;
+        document.body.appendChild(_tooltipElm);
+
+        // reposition the tooltip on top of the cell that triggered the mouse over event
+        reposition(cell);
+
+        // user could optionally hide the tooltip arrow (we can simply update the CSS variables, that's the only way we have to update CSS pseudo)
+        if (!_options.hideArrow) {
+          _tooltipElm.classList.add('tooltip-arrow');
+        }
       }
     }
 
@@ -172,11 +307,16 @@
       return true;
     }
 
+    function setOptions(newOptions) {
+      _options = $.extend({}, _options, newOptions);
+    }
+
     // Public API
     $.extend(this, {
       "init": init,
       "destroy": destroy,
-      "hide": hide,
+      "hide": hideTooltip,
+      "setOptions": setOptions,
       "pluginName": "CustomTooltip"
     });
   }

--- a/plugins/slick.customtooltip.js
+++ b/plugins/slick.customtooltip.js
@@ -1,0 +1,183 @@
+/**
+ * A plugin to add Custom Tooltip when hovering a cell, it subscribes to the cell "onMouseEnter" and "onMouseLeave" events.
+ * The "customTooltip" is defined in the Column Definition OR Grid Options (the first found will have priority over the second)
+ *
+ * USAGE:
+ *
+ * Add the slick.customTooltip.(js|css) files and register it with the grid.
+ *
+ * To specify a tooltip when hovering a cell, extend the column definition like so:
+ * var customTooltipPlugin = new Slick.Plugins.CustomTooltip(columns, grid options);
+ *
+ * Available plugin options (same options are available in both column definition and/or grid options)
+ *  
+ * Example 1  - via Column Definition
+ *  var columns = [
+ *    {
+ *      id: "action", name: "Action", field: "action", formatter: fakeButtonFormatter,
+ *      customTooltip: {
+ *        formatter: tooltipTaskFormatter,
+ *        usabilityOverride: (args) => !!(args.dataContext?.id % 2) // show it only every second row
+ *      }
+ *    }
+ *  ];
+ * 
+ *  OR Example 2 - via Grid Options (for all columns)
+ *  var gridOptions = {
+ *    enableCellNavigation: true,
+ *    customTooltip: {
+ *      formatter: tooltipTaskFormatter,
+ *      usabilityOverride: (args) => !!(args.dataContext?.id % 2) // show it only every second row
+ *    },
+ *  };
+ *
+ * @param options {Object} Custom Tooltip Options
+ * @class Slick.Plugins.CustomTooltip
+ * @constructor
+ */
+(function ($) {
+  // Register namespace
+  $.extend(true, window, {
+    "Slick": {
+      "Plugins": {
+        "CustomTooltip": CustomTooltip
+      }
+    }
+  });
+
+  /**
+   * CustomTooltip plugin to show/hide tooltips when columns are too narrow to fit content.
+   * @constructor
+   * @param {boolean} [options.className="slick-custom-tooltip"]  - custom tooltip class name
+   * @param {boolean} [options.offsetTop=5]                       - tooltip offset from the top
+   */
+  function CustomTooltip(options) {
+    var _dataView;
+    var _grid;
+    var _gridOptions;
+    var _defaults = {
+      className: 'slick-custom-tooltip',
+      offsetTop: 5
+    };
+    var _eventHandler = new Slick.EventHandler();
+    var _options;
+
+    /**
+     * Initialize plugin.
+     */
+    function init(grid) {
+      options = $.extend(true, {}, _defaults, options);
+      _grid = grid;
+      var _data = grid && grid.getData() || [];
+      _dataView = Array.isArray(_data) ? null : _data;
+      _gridOptions = grid.getOptions() || {};
+      _eventHandler
+        .subscribe(grid.onMouseEnter, handleOnMouseEnter)
+        .subscribe(grid.onMouseLeave, hide);
+    }
+
+    /**
+     * Destroy plugin.
+     */
+    function destroy() {
+      hide();
+      _eventHandler.unsubscribeAll();
+    }
+
+    /**
+     * Handle mouse entering grid cell to show tooltip.
+     * @param {jQuery.Event} e - The event
+     */
+    function handleOnMouseEnter(e, args) {
+      if (_grid && e) {
+        var cell = _grid.getCellFromEvent(e);
+        if (cell) {
+          var item = _dataView ? _dataView.getItem(cell.row) : _grid.getDataItem(cell.row);
+          var columnDef = _grid.getColumns()[cell.cell];
+          if (item && columnDef) {
+            _options = $.extend(true, {}, _defaults, _gridOptions.customTooltip, columnDef.customTooltip);
+
+            // run the override function (when defined), if the result is false it won't go further
+            if (!args) {
+              args = {};
+            }
+            args.cell = cell.cell;
+            args.row = cell.row;
+            args.columnDef = columnDef;
+            args.dataContext = item;
+            args.grid = _grid;
+            if (!runOverrideFunctionWhenExists(_options.usabilityOverride, args)) {
+              return;
+            }
+
+            if (typeof _options.formatter === 'function') {
+              var itemValue = item.hasOwnProperty(columnDef.field) ? item[columnDef.field] : null;
+              var tooltipText = _options.formatter(cell.row, cell.cell, itemValue, columnDef, item, _grid);
+
+              // create the tooltip DOM element with the text returned by the Formatter
+              var tooltipElm = document.createElement('div');
+              tooltipElm.className = _options.className + ' ' + _grid.getUID();
+              tooltipElm.innerHTML = typeof tooltipText === 'object' ? tooltipText.text : tooltipText;
+              document.body.appendChild(tooltipElm);
+
+              // reposition the tooltip on top of the cell that triggered the mouse over event
+              var cellPosition = getHtmlElementOffset(_grid.getCellNode(cell.row, cell.cell));
+              tooltipElm.style.left = cellPosition.left + 'px';
+              tooltipElm.style.top = cellPosition.top - tooltipElm.clientHeight - (_options.offsetTop || 0) + 'px';
+            }
+          }
+        }
+      }
+    }
+
+    function getHtmlElementOffset(element) {
+      if (!element) {
+        return undefined;
+      }
+      var rect = element.getBoundingClientRect();
+      var top = 0;
+      var left = 0;
+      var bottom = 0;
+      var right = 0;
+
+      if (rect.top !== undefined && rect.left !== undefined) {
+        top = rect.top + window.pageYOffset;
+        left = rect.left + window.pageXOffset;
+        right = rect.right;
+        bottom = rect.bottom;
+      }
+      return { top: top, left: left, bottom: bottom, right: right };
+    }
+
+    /**
+     * Hide (destroy) the tooltip when mouse entering header cell to add/remove tooltip.
+     */
+    function hide() {
+      var prevTooltip = document.body.querySelector('.' + _options.className + '.' + _grid.getUID());
+      if (prevTooltip && prevTooltip.remove) {
+        prevTooltip.remove();
+      }
+    }
+
+    /**
+     * Method that user can pass to override the default behavior.
+     * In order word, user can choose or an item is (usable/visible/enable) by providing his own logic.
+     * @param overrideFn: override function callback
+     * @param args: multiple arguments provided to the override (cell, row, columnDef, dataContext, grid)
+     */
+    function runOverrideFunctionWhenExists(overrideFn, args) {
+      if (typeof overrideFn === 'function') {
+        return overrideFn.call(this, args);
+      }
+      return true;
+    }
+
+    // Public API
+    $.extend(this, {
+      "init": init,
+      "destroy": destroy,
+      "hide": hide,
+      "pluginName": "CustomTooltip"
+    });
+  }
+})(jQuery);

--- a/plugins/slick.customtooltip.js
+++ b/plugins/slick.customtooltip.js
@@ -477,7 +477,8 @@
     function renderTooltipFormatter(formatter, cell, value, columnDef, item, tooltipText, inputTitleElm) {
       // create the tooltip DOM element with the text returned by the Formatter
       _tooltipElm = document.createElement('div');
-      _tooltipElm.className = _cellTooltipOptions.className + ' ' + _grid.getUID();
+      _tooltipElm.className = _cellTooltipOptions.className;
+      _tooltipElm.classList.add(_grid.getUID());
       _tooltipElm.classList.add('l' + cell.cell);
       _tooltipElm.classList.add('r' + cell.cell);
       var outputText = tooltipText || parseFormatterAndSanitize(formatter, cell, value, columnDef, item) || '';

--- a/plugins/slick.customtooltip.js
+++ b/plugins/slick.customtooltip.js
@@ -297,7 +297,7 @@
         }
 
         // do the same calculation/reposition with top/bottom (default is top of the cell or in other word starting from the cell going down)
-        if (position === 'top' || (position === 'auto' && calculatedTooltipHeight > calculateAvailableSpaceTop(_cellNodeElm))) {
+        if (position === 'bottom' || (position === 'auto' && calculatedTooltipHeight > calculateAvailableSpaceTop(_cellNodeElm))) {
           newPositionTop = cellPosition.top + (_gridOptions.rowHeight || 0) + (_cellTooltipOptions.offsetTopBottom || 0);
           _tooltipElm.classList.remove('arrow-down');
           _tooltipElm.classList.add('arrow-up');

--- a/plugins/slick.customtooltip.js
+++ b/plugins/slick.customtooltip.js
@@ -234,15 +234,25 @@
     function renderRegulatTooltip(formatterOrText, cell, value, columnDef, item) {
       var tmpDiv = document.createElement('div');
       tmpDiv.innerHTML = sanitizeHtmlString(parseFormatter(formatterOrText, cell, value, columnDef, item));
-      var titleElm = _cellNodeElm.querySelector('[title]');
       var tmpTitleElm = tmpDiv.querySelector('[title]');
       var tooltipText = tmpTitleElm && tmpTitleElm.getAttribute('title') || '';
       if (tooltipText !== '') {
         renderTooltipFormatter(formatterOrText, cell, value, columnDef, item, tooltipText);
       }
-      // clear the "title" attribute from the grid div text content so that it won't show also as a 2nd browser tooltip
-      // note: the reason we can do delete it completely is because we always re-execute the formatter whenever we hover the tooltip and so we have a fresh title attribute each time to use
-      titleElm.setAttribute('title', '');
+
+      // also clear any "title" attribute to avoid showing a 2nd browser tooltip
+      clearTitleAttribute();
+    }
+
+    /**
+     * clear the "title" attribute from the grid div text content so that it won't show also as a 2nd browser tooltip
+     * note: the reason we can do delete it completely is because we always re-execute the formatter whenever we hover the tooltip and so we have a fresh title attribute each time to use
+     */
+    function clearTitleAttribute() {
+      var titleElm = _cellNodeElm.querySelector('[title]');
+      if (titleElm) {
+        titleElm.setAttribute('title', '');
+      }
     }
 
     function asyncProcessCallback(asyncResult, cell, value, columnDef, dataContext) {
@@ -411,6 +421,9 @@
       if (!_cellTooltipOptions.hideArrow) {
         _tooltipElm.classList.add('tooltip-arrow');
       }
+
+      // also clear any "title" attribute to avoid showing a 2nd browser tooltip
+      clearTitleAttribute();
     }
 
     /**

--- a/slick.formatters.js
+++ b/slick.formatters.js
@@ -34,7 +34,7 @@
       color = "green";
     }
 
-    return "<span class='percent-complete-bar' style='background:" + color + ";width:" + value + "%'></span>";
+    return "<span class='percent-complete-bar' style='background:" + color + ";width:" + value + "%' title='" + value + "%'></span>";
   }
 
   function YesNoFormatter(row, cell, value, columnDef, dataContext) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -568,6 +568,12 @@ if (typeof Slick === "undefined") {
         $headerRowScroller
             .on("scroll", handleHeaderRowScroll);
 
+        if (options.showHeaderRow) {
+          $headerRow
+            .on("mouseenter", ".slick-headerrow-column", handleHeaderRowMouseEnter)
+            .on("mouseleave", ".slick-headerrow-column", handleHeaderRowMouseLeave);
+        }
+
         if (options.createFooterRow) {
           $footerRow
             .on("contextmenu", handleFooterContextMenu)
@@ -4720,6 +4726,20 @@ if (typeof Slick === "undefined") {
       }, e);
     }
 
+    function handleHeaderRowMouseEnter(e) {
+      trigger(self.onHeaderRowMouseEnter, {
+        "column": $(this).data("column"),
+        "grid": self
+      }, e);
+    }
+
+    function handleHeaderRowMouseLeave(e) {
+      trigger(self.onHeaderRowMouseLeave, {
+        "column": $(this).data("column"),
+        "grid": self
+      }, e);
+    }
+
     function handleHeaderContextMenu(e) {
       var $header = $(e.target).closest(".slick-header-column", ".slick-header-columns");
       var column = $header && $header.data("column");
@@ -5934,6 +5954,8 @@ if (typeof Slick === "undefined") {
       "onSort": new Slick.Event(),
       "onHeaderMouseEnter": new Slick.Event(),
       "onHeaderMouseLeave": new Slick.Event(),
+      "onHeaderRowMouseEnter": new Slick.Event(),
+      "onHeaderRowMouseLeave": new Slick.Event(),
       "onHeaderContextMenu": new Slick.Event(),
       "onHeaderClick": new Slick.Event(),
       "onHeaderCellRendered": new Slick.Event(),


### PR DESCRIPTION
- display custom tooltip via a custom formatter, subscribes to `onMouseEnter` and `onMouseLeave` to create a Custom Tooltip
- also add 2x new events to work with header-row as well `onHeaderRowMouseEnter` and `onHeaderRowMouseLeave`

### TODOs
- [x] working basic POC
- [x] add optional async tooltip (with Promise)
- [x] tooltip auto-positioning (top, bottom, left-align, right-align)
- [x] optionally read cell `title` (in a regular cell formatter) without even the need to create a `customTooltip` every time
- [x] add custom tooltip for Column Header as well
- [x] add custom tooltip for Header-Row (filters) as well
   - requires to add 2x new events `onHeaderRowMouseEnter` and `onHeaderRowMouseLeave`
- [x] merge and reuse code from `Slick.AutoTooltip` to remove the need for that plugin
- [x] add Cypress E2E tests
- [x] add css ref to create tooltip w/arrow [article](https://blog.logrocket.com/creating-beautiful-tooltips-with-only-css/)

![NgcJIGthF9](https://user-images.githubusercontent.com/643976/138189920-48791bd9-8c1b-4fdb-b80d-c935c5e15c33.gif)
