### PR TITLE
feat: show a shadow element of the row being moved/dragged

### DIFF
--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -266,7 +266,7 @@
         disableRowSelection: true,
         hideRowMoveShadow: false,   // defaults to true
         rowMoveShadowScale: 0.7,    // defaults to 0.75
-        rowMoveShadowOpacity: 0.95, // defaults to 0.95
+        rowMoveShadowOpacity: 0.9, // defaults to 0.95
 
         // make only every 2nd row an a moveable row,
         // you can override it here in the options or externally by calling the method on the plugin instance

--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -264,6 +264,9 @@
         cancelEditOnDrag: true,
         singleRowMove: true,
         disableRowSelection: true,
+        hideRowMoveShadow: false,   // defaults to true
+        rowMoveShadowScale: 0.7,    // defaults to 0.75
+        rowMoveShadowOpacity: 0.95, // defaults to 0.95
 
         // make only every 2nd row an a moveable row,
         // you can override it here in the options or externally by calling the method on the plugin instance

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -33,6 +33,7 @@
       cancelEditOnDrag: false,
       disableRowSelection: false,
       hideRowMoveShadow: true,
+      rowMoveMarginLeft: "-5%",
       rowMoveShadowOpacity: 1,
       rowMoveShadowScale: 0.75,
       singleRowMove: false,
@@ -95,7 +96,7 @@
           dd.clonedSlickRow = $slickRowElm.clone();
           dd.clonedSlickRow.css("position", "absolute")
             .css("zIndex", "999999")
-            .css("marginLeft", "-5%")
+            .css("marginLeft", options.rowMoveMarginLeft || "-5%")
             .css("opacity", options.rowMoveShadowOpacity || 0.95)
             .css("transform", "scale(" + options.rowMoveShadowScale + ")")
             .css("boxShadow", "rgb(0 0 0 / 20%) 8px 2px 8px 4px, rgb(0 0 0 / 19%) 2px 2px 0px 0px")

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -105,9 +105,9 @@
             .appendTo(_canvas);
 
           // add a listener on the canvas whenever the mouse moves, we'll have our shadow row follow the mouse cursor
-          _canvas.addEventListener('mousemove', function (e) {
+          $("body").on('mousemove', function (e) {
             if (dd.clonedSlickRow) {
-              var offsetY = e.clientY - (e.currentTarget).getBoundingClientRect().top;
+              var offsetY = e.pageY - $(_canvas).offset().top;
               dd.clonedSlickRow.css("top", offsetY - 6);
             }
           });

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -1,16 +1,17 @@
 /**
  * Row Move Manager options:
- *    cssClass:             A CSS class to be added to the menu item container.
- *    columnId:             Column definition id (defaults to "_move")
- *    cancelEditOnDrag:     Do we want to cancel any Editing while dragging a row (defaults to false)
- *    disableRowSelection:  Do we want to disable the row selection? (defaults to false)
- *    hideRowMoveShadow:    Do we want to hide the row move shadow clone? (defaults to true)
- *    rowMoveShadowMarginLeft:    When row move shadow is shown, optional margin-left (defaults to -5%)
- *    rowMoveShadowOpacity: When row move shadow is shown, what is its opacity? (defaults to 1)
- *    rowMoveShadowScale:   When row move shadow is shown, what is its size scale? (default to 0.75)
- *    singleRowMove:        Do we want a single row move? Setting this to false means that it's a multple row move (defaults to false)
- *    width:                Width of the column
- *    usabilityOverride:    Callback method that user can override the default behavior of the row being moveable or not
+ *    cssClass:                 A CSS class to be added to the menu item container.
+ *    columnId:                 Column definition id (defaults to "_move")
+ *    cancelEditOnDrag:         Do we want to cancel any Editing while dragging a row (defaults to false)
+ *    disableRowSelection:      Do we want to disable the row selection? (defaults to false)
+ *    hideRowMoveShadow:        Do we want to hide the row move shadow clone? (defaults to true)
+ *    rowMoveShadowMarginTop:   When row move shadow is shown, optional margin-top (defaults to 0)
+ *    rowMoveShadowMarginLeft:  When row move shadow is shown, optional margin-left (defaults to 0)
+ *    rowMoveShadowOpacity:     When row move shadow is shown, what is its opacity? (defaults to 0.95)
+ *    rowMoveShadowScale:       When row move shadow is shown, what is its size scale? (default to 0.75)
+ *    singleRowMove:            Do we want a single row move? Setting this to false means that it's a multple row move (defaults to false)
+ *    width:                    Width of the column
+ *    usabilityOverride:        Callback method that user can override the default behavior of the row being moveable or not
  *
  */
 (function ($) {
@@ -34,8 +35,9 @@
       cancelEditOnDrag: false,
       disableRowSelection: false,
       hideRowMoveShadow: true,
-      rowMoveShadowMarginLeft: "-5%",
-      rowMoveShadowOpacity: 1,
+      rowMoveShadowMarginTop: 0,
+      rowMoveShadowMarginLeft: 0,
+      rowMoveShadowOpacity: 0.95,
       rowMoveShadowScale: 0.75,
       singleRowMove: false,
       width: 40,
@@ -95,12 +97,11 @@
         var $slickRowElm = $(_grid.getCellNode(cell.row, cell.cell)).closest('.slick-row');
         if ($slickRowElm) {
           dd.clonedSlickRow = $slickRowElm.clone();
-          dd.clonedSlickRow.css("position", "absolute")
-            .css("zIndex", "999999")
-            .css("marginLeft", options.rowMoveShadowMarginLeft || "-5%")
+          dd.clonedSlickRow.addClass('slick-reorder-shadow-row')
+            .css("marginTop", options.rowMoveShadowMarginTop || 0)
+            .css("marginLeft", options.rowMoveShadowMarginLeft || 0)
             .css("opacity", options.rowMoveShadowOpacity || 0.95)
             .css("transform", "scale(" + options.rowMoveShadowScale + ")")
-            .css("boxShadow", "rgb(0 0 0 / 20%) 8px 2px 8px 4px, rgb(0 0 0 / 19%) 2px 2px 0px 0px")
             .appendTo(_canvas);
 
           // add a listener on the canvas whenever the mouse moves, we'll have our shadow row follow the mouse cursor

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -61,6 +61,7 @@
 
     function destroy() {
       _handler.unsubscribeAll();
+      $("body").off('mousemove');
     }
 
     function setOptions(newOptions) {

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -61,7 +61,6 @@
 
     function destroy() {
       _handler.unsubscribeAll();
-      $("body").off('mousemove');
     }
 
     function setOptions(newOptions) {
@@ -103,15 +102,8 @@
             .css("marginLeft", options.rowMoveShadowMarginLeft || 0)
             .css("opacity", options.rowMoveShadowOpacity || 0.95)
             .css("transform", "scale(" + options.rowMoveShadowScale + ")")
+            .hide()
             .appendTo(_canvas);
-
-          // add a listener on the canvas whenever the mouse moves, we'll have our shadow row follow the mouse cursor
-          $("body").on('mousemove', function (e) {
-            if (dd.clonedSlickRow) {
-              var offsetY = e.pageY - $(_canvas).offset().top;
-              dd.clonedSlickRow.css("top", offsetY - 6);
-            }
-          });
         }
       }
 
@@ -133,6 +125,7 @@
         .css("zIndex", "99999")
         .css("width", $(_canvas).innerWidth())
         .css("height", rowHeight * selectedRows.length)
+        .hide()
         .appendTo(_canvas);
 
       dd.guide = $("<div class='slick-reorder-guide'/>")
@@ -153,7 +146,13 @@
       e.stopImmediatePropagation();
 
       var top = e.pageY - $(_canvas).offset().top;
-      dd.selectionProxy.css("top", top - 5);
+      dd.selectionProxy.css("top", top - 5).show();
+
+      // if the row move shadow is enabled, we'll also make it follow the mouse cursor
+      if (dd.clonedSlickRow) {
+        var offsetY = e.pageY - $(_canvas).offset().top;
+        dd.clonedSlickRow.css("top", offsetY - 6).show();
+      }
 
       var insertBefore = Math.max(0, Math.min(Math.round(top / _grid.getOptions().rowHeight), _grid.getDataLength()));
       if (insertBefore !== dd.insertBefore) {

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -197,6 +197,7 @@
       dd.selectionProxy.remove();
       if (dd.clonedSlickRow) {
         dd.clonedSlickRow.remove();
+        dd.clonedSlickRow = null;
       }
 
       if (dd.canMove) {

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -5,6 +5,7 @@
  *    cancelEditOnDrag:     Do we want to cancel any Editing while dragging a row (defaults to false)
  *    disableRowSelection:  Do we want to disable the row selection? (defaults to false)
  *    hideRowMoveShadow:    Do we want to hide the row move shadow clone? (defaults to true)
+ *    rowMoveShadowMarginLeft:    When row move shadow is shown, optional margin-left (defaults to -5%)
  *    rowMoveShadowOpacity: When row move shadow is shown, what is its opacity? (defaults to 1)
  *    rowMoveShadowScale:   When row move shadow is shown, what is its size scale? (default to 0.75)
  *    singleRowMove:        Do we want a single row move? Setting this to false means that it's a multple row move (defaults to false)
@@ -33,7 +34,7 @@
       cancelEditOnDrag: false,
       disableRowSelection: false,
       hideRowMoveShadow: true,
-      rowMoveMarginLeft: "-5%",
+      rowMoveShadowMarginLeft: "-5%",
       rowMoveShadowOpacity: 1,
       rowMoveShadowScale: 0.75,
       singleRowMove: false,
@@ -96,7 +97,7 @@
           dd.clonedSlickRow = $slickRowElm.clone();
           dd.clonedSlickRow.css("position", "absolute")
             .css("zIndex", "999999")
-            .css("marginLeft", options.rowMoveMarginLeft || "-5%")
+            .css("marginLeft", options.rowMoveShadowMarginLeft || "-5%")
             .css("opacity", options.rowMoveShadowOpacity || 0.95)
             .css("transform", "scale(" + options.rowMoveShadowScale + ")")
             .css("boxShadow", "rgb(0 0 0 / 20%) 8px 2px 8px 4px, rgb(0 0 0 / 19%) 2px 2px 0px 0px")

--- a/slick.grid.css
+++ b/slick.grid.css
@@ -195,6 +195,12 @@ classes should alter those!
   filter: alpha(opacity = 70);
 }
 
+.slick-reorder-shadow-row {
+  position: absolute;
+  z-index: 999999;
+  box-shadow: rgb(0 0 0 / 20%) 8px 2px 8px 4px, rgb(0 0 0 / 19%) 2px 2px 0px 0px;
+}
+
 .slick-selection {
   z-index: 10;
   position: absolute;


### PR DESCRIPTION
- add option to create a simple clone of the row being moved and show it as a shadow (cloned element) of the row being moved so that we know exactly which row is being dragged (it follow the mouse cursor and once we stop moving it gets destroyed)
- also add options to change this shadow element opacity & scale size
- it's a simple feature but is very helpful to not lose track of exactly which row we're dragging

![Y8rF0Vd4Iz](https://user-images.githubusercontent.com/643976/138313954-094660fc-74d4-43b4-9d75-bd660f503a17.gif)
