### PR TITLE
jquery.event.drag check for data

### DIFF
--- a/lib/jquery.event.drag-2.3.0.js
+++ b/lib/jquery.event.drag-2.3.0.js
@@ -66,7 +66,9 @@
 
             // forget unbound related events
             remove: function(){
-                $.data( this, drag.datakey ).related -= 1;
+                var data = $.data( this, drag.datakey );
+                if(data)
+                    data.related -= 1;
             },
 
             // configure interaction, capture settings


### PR DESCRIPTION
Check for data before setting the related property. This fixes an issue when using native DND in other components of our application. The error at the bottom is thrown at this line in `jquery.event.drag-2.3.0.js`:

```
remove: function(){
  $.data( this, drag.datakey ).related -= 1;
},

```

![image](https://user-images.githubusercontent.com/11670864/141206575-d372a798-dfc6-4671-98db-1410d82507f4.png)
