### PR TITLE
feat: Auto scroll the viewport when dragging to make selection

### DIFF
--- a/cypress/integration/example-auto-scroll-when-dragging.spec.js
+++ b/cypress/integration/example-auto-scroll-when-dragging.spec.js
@@ -1,0 +1,311 @@
+/// <reference types="cypress" />
+
+describe('Example - Frozen Columns & Rows', { retries: 1 }, () => {
+  // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
+  const cellWidth = 80;
+  const cellHeight = 25;
+  const gridWidth = 600;
+  const gridHeight = 350;
+
+  const fullTitles = ['#', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Cost', 'Effort Driven'];
+
+  for (var i = 0; i < 30; i++) {
+    fullTitles.push("Mock" + i);
+  }
+
+  it('should load Example', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example-auto-scroll-when-dragging.html`);
+  });
+
+  it('should have exact column titles on grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+  });
+
+  function dragStart(row, col, canvasClass) {
+    return cy.get(`${canvasClass || ''} [style="top:${row * 25}px"] > .slick-cell:nth(${col})`, )
+      .as('dragStart')
+      .click({force: true})
+      .trigger('mousedown', { which: 1 })
+      .trigger('mousemove', cellWidth/3, cellHeight/3);
+  }
+
+  function drag(addRow, addCell) {
+    cy.get('@dragStart').trigger('mousemove', cellWidth * (addCell + 0.5) , cellHeight * (addRow + 0.5), { force: true })
+  }
+
+  function dragOutside(position, ms, px, selector) {
+    var x = gridWidth / 2;
+    var y = gridHeight / 2;
+    if (position.toLowerCase().indexOf("left") > -1) {
+      x = -px;
+    } else if (position.toLowerCase().indexOf("right") > -1) {
+      x = gridWidth + (px || 0);
+    }
+    if (position.toLowerCase().indexOf("top") > -1) {
+      y = -px;
+    } else if (position.toLowerCase().indexOf("bottom") > -1) {
+      y = gridHeight + (px || 0);
+    }
+    cy.get(`#myGrid ${selector || ''}`).trigger('mousemove', x, y, {force: true});
+    if (ms) {
+      cy.wait(ms);
+    }
+  }
+
+  function dragEnd() {
+    return cy.get('#myGrid').trigger('mouseup', {force: true});
+  }
+
+  it('should decorator shown when dragging', { scrollBehavior: false }, function () {
+    dragStart(0, 1);
+    cy.get('.slick-range-decorator').should('be.exist');
+    drag(0, 5);
+    dragEnd();
+    cy.get('.slick-range-decorator').should('not.be.exist');
+    cy.get('.slick-cell.selected').should('have.length', 6);
+  })
+
+  it('should auto scroll take effect to display the selecting element when dragging', { scrollBehavior: false }, function () {
+    dragStart(0, 1);
+    cy.get('#myGrid .slick-viewport:first').invoke('scrollLeft').then(scrollBefore => {
+      dragOutside('right', 300, 100);
+      cy.get('#myGrid .slick-viewport:first').invoke('scrollLeft').then(scrollAfter => {
+        expect(scrollBefore).to.be.lessThan(scrollAfter);
+        dragEnd();
+      })
+    })
+
+    cy.get('#isAutoScroll').click();
+    cy.get('#setOptions').click();
+    dragStart(0, 1);
+    cy.get('#myGrid .slick-viewport:first').invoke('scrollLeft').then(scrollBefore => {
+      dragOutside('right', 300, 100);
+      cy.get('#myGrid .slick-viewport:first').invoke('scrollLeft').then(scrollAfter => {
+        expect(scrollBefore).to.be.equal(scrollAfter);
+        dragEnd();
+      })
+    })
+
+    cy.get('#setDefaultOption').click();
+    cy.get('#isAutoScroll').should('have.value', 'on')
+  })
+
+  it('should MIN interval take effect when auto scroll: 30ms -> 90ms', { scrollBehavior: false }, function () {
+    let defaultInterval = 0;
+    dragStart(0, 1);
+    cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
+      dragOutside('bottom', 0, 300);
+      const defaultStart = performance.now();
+      cy.get('#myGrid .slick-viewport:first .slick-row > .slick-cell:first-child')
+        .contains('16') // actually #15 will be selected
+        .should('not.be.hidden');
+      cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
+        dragEnd();
+        defaultInterval = performance.now() - defaultStart;
+        expect(scrollBefore).to.be.lessThan(scrollAfter);
+      })
+    })
+
+    cy.get('#minIntervalToShowNextCell').type('{selectall}90'); // 30ms -> 90ms
+    cy.get('#setOptions').click();
+
+    dragStart(0, 1);
+    cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
+      dragOutside('bottom', 0, 300);
+      const newStart = performance.now();
+      cy.get('#myGrid .slick-viewport:first .slick-row > .slick-cell:first-child')
+        .contains('16') // actually #15 will be selected
+        .should('not.be.hidden');
+      cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
+        dragEnd();
+        const newInterval = performance.now() - newStart;
+        expect(scrollBefore).to.be.lessThan(scrollAfter);
+        expect(newInterval).to.be.greaterThan(2 * defaultInterval); // max scrolling speed is slower than before
+      })
+    })
+
+    cy.get('#setDefaultOption').click();
+    cy.get('#minIntervalToShowNextCell').should('have.value', '30')
+  })
+
+  it('should MAX interval take effect when auto scroll: 600ms -> 200ms', { scrollBehavior: false }, function () {
+    let defaultInterval = 0;
+    dragStart(0, 1);
+    cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
+      dragOutside('bottom');
+      const defaultStart = performance.now();
+      cy.get('#myGrid .slick-viewport:first .slick-row > .slick-cell:first-child')
+        .contains('16', { timeout: 10000 }) // actually #15 will be selected
+        .should('not.be.hidden');
+      cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
+        dragEnd();
+        defaultInterval = performance.now() - defaultStart;
+        expect(scrollBefore).to.be.lessThan(scrollAfter);
+      })
+    })
+
+    cy.get('#maxIntervalToShowNextCell').type('{selectall}200'); // 600ms -> 200ms
+    cy.get('#setOptions').click();
+
+    dragStart(0, 1);
+    cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
+      dragOutside('bottom');
+      const newStart = performance.now();
+      cy.get('#myGrid .slick-viewport:first .slick-row > .slick-cell:first-child')
+        .contains('16', { timeout: 10000 }) // actually #15 will be selected
+        .should('not.be.hidden');
+      cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
+        dragEnd();
+        const newInterval = performance.now() - newStart;
+        expect(scrollBefore).to.be.lessThan(scrollAfter);
+        expect(2 * newInterval).to.be.lessThan(defaultInterval, 1000); // min scrolling speed is quicker than before
+      })
+    })
+
+    cy.get('#setDefaultOption').click();
+    cy.get('#maxIntervalToShowNextCell').should('have.value', '600')
+  })
+
+  it('should Delay per Px take effect when auto scroll: 5ms/px -> 50ms/px', { scrollBehavior: false }, function () {
+    let defaultInterval = 0;
+    dragStart(0, 1);
+    cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
+      dragOutside('bottom');
+      const defaultStart = performance.now();
+      cy.get('#myGrid .slick-viewport:first .slick-row > .slick-cell:first-child')
+        .contains('16') // actually #15 will be selected
+        .should('not.be.hidden');
+      cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
+        dragEnd();
+        defaultInterval = performance.now() - defaultStart;
+        expect(scrollBefore).to.be.lessThan(scrollAfter);
+      })
+    })
+
+    cy.get('#accelerateInterval').type('{selectall}50'); // 5ms/px -> 50ms/px
+    cy.get('#setOptions').click();
+
+    dragStart(0, 1);
+    cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
+      dragOutside('bottom');
+      const newStart = performance.now();
+      cy.get('#myGrid .slick-viewport:first .slick-row > .slick-cell:first-child')
+        .contains('16') // actually #15 will be selected
+        .should('not.be.hidden');
+      cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
+        dragEnd();
+        const newInterval = performance.now() - newStart;
+        expect(scrollBefore).to.be.lessThan(scrollAfter);
+        expect(5 * newInterval).to.be.lessThan(defaultInterval, 1000); // scrolling speed is quicker than before
+      })
+    })
+
+    cy.get('#setDefaultOption').click();
+    cy.get('#accelerateInterval').should('have.value', '5')
+  })
+
+  it('should have a frozen grid with 4 containers with 2 columns on the left and 3 rows on the top after click Set/Clear Frozen button', () => {
+    cy.get('[style="top:0px"]').should('have.length', 1);
+
+    cy.get('#toggleFrozen').click();
+
+    cy.get('[style="top:0px"]').should('have.length', 2 * 2);
+    cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 2 * 2);
+    cy.get('.grid-canvas-top').children().should('have.length', 3 * 2);
+  });
+
+  function dragInFrozen(whichViewport, dragDirection, fromRow, fromCol, px) {
+    let x;
+    let y;
+    if (whichViewport.toLowerCase().indexOf("left") > -1) {
+      x = 'left'
+    } else if (whichViewport.toLowerCase().indexOf("right") > -1) {
+      x = 'right';
+    }
+    if (whichViewport.toLowerCase().indexOf("top") > -1) {
+      y = 'top';
+    } else if (whichViewport.toLowerCase().indexOf("bottom") > -1) {
+      y = 'bottom';
+    }
+    dragStart(fromRow, fromCol, `.grid-canvas-${x}.grid-canvas-${y}`);
+    return cy.get(`#myGrid .slick-viewport-${x}.slick-viewport-${y}`).as('viewport').then($viewport => {
+      const scrollTopBefore = $viewport.scrollTop();
+      const scrollLeftBefore = $viewport.scrollLeft();
+      dragOutside(dragDirection, 300, px || 100, `.slick-viewport-${x}.slick-viewport-${y}`);
+      return cy.get('@viewport').then($viewportAfter => {
+        dragEnd();
+        return cy.wrap({
+          scrollTopBefore: scrollTopBefore,
+          scrollLeftBefore: scrollLeftBefore,
+          scrollTopAfter: $viewportAfter.scrollTop(),
+          scrollLeftAfter: $viewportAfter.scrollLeft()
+        })
+      })
+    })
+  }
+
+  it('should auto scroll to display the selecting element when dragging in frozen grid', { scrollBehavior: false }, () => {
+    // top left - to bottomRight
+    dragInFrozen('topLeft', 'bottomRight', 0, 1).then(result => {
+      expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
+      expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
+    });
+
+    // top right - to bottomRight
+    dragInFrozen('topRight', 'bottomRight', 0, 0).then(result => {
+      expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
+      expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
+    });
+
+    // bottom left - to bottomRight
+    dragInFrozen('bottomLeft', 'bottomRight', 0, 1).then(result => {
+      expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
+      expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
+    });
+
+    // bottom right - to bottomRight
+    dragInFrozen('bottomRight', 'bottomRight', 0, 0).then(result => {
+      expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
+      expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
+    });
+
+    cy.get('#myGrid .slick-viewport-bottom.slick-viewport-right').scrollTo(cellWidth*3, cellHeight*3);
+
+    // // bottom right - to topLeft
+    dragInFrozen('bottomRight', 'topLeft', 8, 4, 100).then(result => {
+      expect(result.scrollTopBefore).to.be.greaterThan(result.scrollTopAfter);
+      expect(result.scrollLeftBefore).to.be.greaterThan(result.scrollLeftAfter);
+    });
+
+    cy.get('#myGrid .slick-viewport-bottom.slick-viewport-right').scrollTo(0, 0);
+  });
+
+  it('should have a frozen & grouping by Duration grid after click Set/Clear grouping by Duration button', { scrollBehavior: false }, () => {
+    cy.get('#toggleGroup').trigger('click');
+    cy.get('[style="top:0px"]').should('have.length', 2 * 2);
+    cy.get('.grid-canvas-top.grid-canvas-left').contains('Duration');
+  });
+
+
+  it('should auto scroll to display the selecting element even unselectable cell exist in grouping grid', { scrollBehavior: false }, () => {
+    dragStart(7, 0, '.grid-canvas-right.grid-canvas-bottom');
+    cy.get('#myGrid .slick-viewport:last').invoke('scrollTop').then(scrollBefore => {
+      dragOutside('bottom', 400, 100);
+      cy.get('#myGrid .slick-viewport:last').invoke('scrollTop').then(scrollAfter => {
+        expect(scrollBefore).to.be.lessThan(scrollAfter);
+        dragEnd();
+        cy.get('[style="top:350px"].slick-group').should('not.be.hidden');;
+      })
+    })
+  });
+
+  it('should reset to default grid when click Set/Clear Frozen button and Set/Clear grouping button', () => {
+    cy.get('#toggleFrozen').trigger('click');
+    cy.get('#toggleGroup').trigger('click');
+    cy.get('[style="top:0px"]').should('have.length', 1);
+  });
+
+});

--- a/cypress/integration/example-auto-scroll-when-dragging.spec.js
+++ b/cypress/integration/example-auto-scroll-when-dragging.spec.js
@@ -30,11 +30,11 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
   });
 
   function dragStart(parentClass, row, col) {
-    return cy.get(`${parentClass || ''} [style="top:${row * 25}px"] > .slick-cell:nth(${col})`, )
+    cy.get(`${parentClass || ''} [style="top:${row * 25}px"] > .slick-cell:nth(${col})`, )
       .as('dragStart')
       .click({ force: true })
-      .trigger('mousedown', { which: 1, force: true })
-      .trigger('mousemove', cellWidth/3, cellHeight/3, { force: true });
+      .trigger('mousedown', { which: 1 })
+      .trigger('mousemove', cellWidth/3, cellHeight/3);
   }
 
   function drag(addRow, addCell) {
@@ -47,12 +47,12 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
     if (position.toLowerCase().indexOf("left") > -1) {
       x = -px;
     } else if (position.toLowerCase().indexOf("right") > -1) {
-      x = gridWidth - scrollbarDimension + 1 + (px || 0);
+      x = gridWidth - scrollbarDimension + 3 + (px || 0);
     }
     if (position.toLowerCase().indexOf("top") > -1) {
       y = -px;
     } else if (position.toLowerCase().indexOf("bottom") > -1) {
-      y = gridHeight - scrollbarDimension + 1 + (px || 0);
+      y = gridHeight - scrollbarDimension + 3 + (px || 0);
     }
     cy.get(` ${selector || ''}`).trigger('mousemove', x, y, { force: true });
     if (ms) {
@@ -135,35 +135,40 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
 
   function getIntervalUntilRow16Displayed(selector, px) {
     dragStart(selector, 0, 1);
-    return cy.get(selector + ' .slick-viewport:first').as('viewport').invoke('scrollTop').then(scrollBefore => {
+    cy.get(selector + ' .slick-viewport:first').as('viewport').invoke('scrollTop').then(scrollBefore => {
       dragOutside(selector, 'bottom', 0, px);
+
       const start = performance.now();
       cy.get(selector + ' .slick-row:not(.slick-group) >.cell-unselectable')
         .contains('16', { timeout: 10000 }) // actually #15 will be selected
         .should('not.be.hidden');
-      return cy.get('@viewport').invoke('scrollTop').then(scrollAfter => {
+
+      cy.get('@viewport').invoke('scrollTop').then(scrollAfter => {
         dragEnd(selector);
         var interval = performance.now() - start;
         expect(scrollBefore).to.be.lessThan(scrollAfter);
-        return cy.wrap(interval);
+        cy.wrap(interval).as('interval' + selector);
       })
     })
   }
 
-  function testInterval(px) {
-    return getIntervalUntilRow16Displayed("#myGrid", px).then(intervalCell => {
-      return getIntervalUntilRow16Displayed("#myGrid2", px).then(intervalRow => {
-        return cy.wrap({
+  function testInterval(key, px) {
+    getIntervalUntilRow16Displayed("#myGrid", px);
+    getIntervalUntilRow16Displayed("#myGrid2", px);
+    cy.get('@interval#myGrid').then(intervalCell => {
+      cy.get('@interval#myGrid2').then(intervalRow => {
+        cy.wrap({
           cell: intervalCell,
           row: intervalRow
-        })
+        }).as(key)
       });
     });
   }
 
   it('should MIN interval take effect when auto scroll: 30ms -> 90ms', { scrollBehavior: false }, function () {
     // By default the MIN interval to show next cell is 30ms.
-    testInterval(300).then(defaultInterval => {
+    testInterval('default', 300);
+    cy.get('@default').then(defaultInterval => {
 
       resetScroll();
       // Setting the interval to 90ms (3 times of the default).
@@ -172,7 +177,8 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
 
       // Ideally if we scrolling to same row by MIN interval, the used time should be 3 times slower than default.
       // Considering the threshold, 1.5 times slower than default is expected
-      testInterval(300).then(newInterval => {
+      testInterval('after', 300);
+      cy.get('@after').then(newInterval => {
 
         // max scrolling speed is slower than before
         expect(newInterval.cell).to.be.greaterThan(1.5 * defaultInterval.cell);
@@ -187,7 +193,8 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
 
   it('should MAX interval take effect when auto scroll: 600ms -> 200ms', { scrollBehavior: false }, function () {
     // By default the MAX interval to show next cell is 600ms.
-    testInterval(0).then(defaultInterval => {
+    testInterval('default', 0);
+    cy.get('@default').then(defaultInterval => {
 
       resetScroll();
       // Setting the interval to 200ms (1/3 of the default).
@@ -196,7 +203,8 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
 
       // Ideally if we scrolling to same row by MAX interval, the used time should be 3 times faster than default.
       // Considering the threshold, 1.5 times faster than default is expected
-      testInterval(0).then(newInterval => {
+      testInterval('after', 0);
+      cy.get('@after').then(newInterval => {
 
         // min scrolling speed is quicker than before
         expect(1.5 * newInterval.cell).to.be.lessThan(defaultInterval.cell);
@@ -211,7 +219,8 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
 
   it('should Delay per Px take effect when auto scroll: 5ms/px -> 50ms/px', { scrollBehavior: false }, function () {
     // By default the Delay per Px is 5ms/px.
-    testInterval(scrollbarDimension).then(defaultInterval => {
+    testInterval('default', scrollbarDimension);
+    cy.get('@default').then(defaultInterval => {
 
       resetScroll();
       // Setting to 50ms/px (10 times of the default).
@@ -221,7 +230,8 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
       // Ideally if we scrolling to same row, and set cursor to 17px, the new interval will be set to MIN interval (Math.max(30, 600 - 50 * 17) = 30ms),
       // and the used time should be around 17 times faster than default.
       // Considering the threshold, 5 times faster than default is expected
-      testInterval(scrollbarDimension).then(newInterval => {
+      testInterval('after', scrollbarDimension);
+      cy.get('@after').then(newInterval => {
 
          // scrolling speed is quicker than before
         expect(5 * newInterval.cell).to.be.lessThan(defaultInterval.cell);
@@ -262,60 +272,68 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
       y = 'bottom';
     }
     dragStart(`${selector} .grid-canvas-${x}.grid-canvas-${y}`, fromRow, fromCol);
-    return cy.get(`${selector} .slick-viewport-${x}.slick-viewport-${y}`).as('viewport').then($viewport => {
+    cy.get(`${selector} .slick-viewport-${x}.slick-viewport-${y}`).as('viewport').then($viewport => {
       const scrollTopBefore = $viewport.scrollTop();
       const scrollLeftBefore = $viewport.scrollLeft();
       dragOutside(`${selector} .slick-viewport-${x}.slick-viewport-${y}`, dragDirection, 300, px || 100);
-      return cy.get('@viewport').then($viewportAfter => {
+      cy.get('@viewport').then($viewportAfter => {
         dragEnd(selector);
-        return cy.wrap({
+        cy.wrap({
           scrollTopBefore: scrollTopBefore,
           scrollLeftBefore: scrollLeftBefore,
           scrollTopAfter: $viewportAfter.scrollTop(),
           scrollLeftAfter: $viewportAfter.scrollLeft()
-        })
+        }).as('result');
       })
     })
   }
 
   it('should auto scroll to display the selecting element when dragging in frozen grid', { scrollBehavior: false }, () => {
     // top left - to bottomRight
-    dragInFrozen('#myGrid', 'topLeft', 'bottomRight', 0, 1).then(result => {
+    dragInFrozen('#myGrid', 'topLeft', 'bottomRight', 0, 1);
+    cy.get('@result').then(result => {
       expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
     });
-    dragInFrozen('#myGrid2', 'topLeft', 'bottomRight', 0, 1).then(result => {
+    dragInFrozen('#myGrid2', 'topLeft', 'bottomRight', 0, 1);
+    cy.get('@result').then(result => {
       expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
     });
 
     // top right - to bottomRight
-    dragInFrozen('#myGrid', 'topRight', 'bottomRight', 0, 0).then(result => {
+    dragInFrozen('#myGrid', 'topRight', 'bottomRight', 0, 0);
+    cy.get('@result').then(result => {
       expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
     });
-    dragInFrozen('#myGrid2', 'topRight', 'bottomRight', 0, 0).then(result => {
+    dragInFrozen('#myGrid2', 'topRight', 'bottomRight', 0, 0);
+    cy.get('@result').then(result => {
       expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
     });
     resetScroll(true);
 
     // bottom left - to bottomRight
-    dragInFrozen('#myGrid', 'bottomLeft', 'bottomRight', 0, 1).then(result => {
+    dragInFrozen('#myGrid', 'bottomLeft', 'bottomRight', 0, 1);
+    cy.get('@result').then(result => {
       expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
     });
-    dragInFrozen('#myGrid2', 'bottomLeft', 'bottomRight', 0, 1).then(result => {
+    dragInFrozen('#myGrid2', 'bottomLeft', 'bottomRight', 0, 1);
+    cy.get('@result').then(result => {
       expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
     });
 
     // bottom right - to bottomRight
-    dragInFrozen('#myGrid', 'bottomRight', 'bottomRight', 0, 0).then(result => {
+    dragInFrozen('#myGrid', 'bottomRight', 'bottomRight', 0, 0);
+    cy.get('@result').then(result => {
       expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
     });
-    dragInFrozen('#myGrid2', 'bottomRight', 'bottomRight', 0, 0).then(result => {
+    dragInFrozen('#myGrid2', 'bottomRight', 'bottomRight', 0, 0);
+    cy.get('@result').then(result => {
       expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
     });
@@ -324,11 +342,13 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
     cy.get('#myGrid2 .slick-viewport-bottom.slick-viewport-right').scrollTo(cellWidth*3, cellHeight*3);
 
     // bottom right - to topLeft
-    dragInFrozen('#myGrid', 'bottomRight', 'topLeft', 8, 4, 100).then(result => {
+    dragInFrozen('#myGrid', 'bottomRight', 'topLeft', 8, 4, 100);
+    cy.get('@result').then(result => {
       expect(result.scrollTopBefore).to.be.greaterThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.greaterThan(result.scrollLeftAfter);
     });
-    dragInFrozen('#myGrid2', 'bottomRight', 'topLeft', 8, 4, 100).then(result => {
+    dragInFrozen('#myGrid2', 'bottomRight', 'topLeft', 8, 4, 100);
+    cy.get('@result').then(result => {
       expect(result.scrollTopBefore).to.be.greaterThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.greaterThan(result.scrollLeftAfter);
     });

--- a/cypress/integration/example-auto-scroll-when-dragging.spec.js
+++ b/cypress/integration/example-auto-scroll-when-dragging.spec.js
@@ -1,11 +1,11 @@
 /// <reference types="cypress" />
 
+import { getScrollDistanceWhenDragOutsideGrid } from '../support/drag'
+
 describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
   // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
   const cellWidth = 80;
   const cellHeight = 25;
-  const gridWidth = 600;
-  const gridHeight = 350;
   const scrollbarDimension = 17;
 
   const fullTitles = ['#', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Cost', 'Effort Driven'];
@@ -29,156 +29,109 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
-  function dragStart(parentClass, row, col) {
-    cy.get(`${parentClass || ''} [style="top:${row * 25}px"] > .slick-cell:nth(${col})`, )
-      .as('dragStart')
-      .click({ force: true })
-      .trigger('mousedown', { which: 1 })
-      .trigger('mousemove', cellWidth/3, cellHeight/3);
-  }
-
-  function drag(addRow, addCell) {
-    cy.get('@dragStart').trigger('mousemove', cellWidth * (addCell + 0.5) , cellHeight * (addRow + 0.5), { force: true })
-  }
-
-  function dragOutside(selector, position, ms, px) {
-    var x = gridWidth / 2;
-    var y = gridHeight / 2;
-    if (position.toLowerCase().indexOf("left") > -1) {
-      x = -px;
-    } else if (position.toLowerCase().indexOf("right") > -1) {
-      x = gridWidth - scrollbarDimension + 3 + (px || 0);
-    }
-    if (position.toLowerCase().indexOf("top") > -1) {
-      y = -px;
-    } else if (position.toLowerCase().indexOf("bottom") > -1) {
-      y = gridHeight - scrollbarDimension + 3 + (px || 0);
-    }
-    cy.get(` ${selector || ''}`).trigger('mousemove', x, y, { force: true });
-    if (ms) {
-      cy.wait(ms);
-    }
-  }
-
-  function dragEnd(selector) {
-    cy.get(selector).trigger('mouseup', { force: true });
-    cy.get(selector + ' .slick-range-decorator').should('not.be.exist');
-  }
-
-  function resetScroll(isFrozen) {
-    const selector = '.slick-viewport' + (isFrozen ? ":last" : ":first")
-    cy.get('#myGrid ' + selector).scrollTo(0, 0);
-    cy.get('#myGrid2 ' + selector).scrollTo(0, 0);
-  }
-
   it('should select border shown in cell selection model, and hidden in row selection model when dragging', { scrollBehavior: false }, function () {
-    dragStart("#myGrid", 0, 1);
+    cy.getCell(0, 1, '', { parentSelector: "#myGrid" })
+      .as('cell1')
+      .dragStart();
     cy.get('#myGrid .slick-range-decorator').should('be.exist').and('have.css', 'border-color').and('not.equal', 'none');
-    drag(0, 5);
-    dragEnd('#myGrid');
+    cy.get('@cell1')
+      .drag(0, 5)
+      .dragEnd('#myGrid');
+    cy.get('#myGrid .slick-range-decorator').should('not.be.exist');
     cy.get('#myGrid .slick-cell.selected').should('have.length', 6);
 
-    dragStart("#myGrid2", 0, 1);
+    cy.getCell(0, 1, '', { parentSelector: "#myGrid2" })
+      .as('cell2')
+      .dragStart();
     cy.get('#myGrid2 .slick-range-decorator').should('be.exist').and('have.css', 'border-style').and('equal', 'none');
-    drag(5, 1);
-    dragEnd('#myGrid2');
-
+    cy.get('@cell2')
+      .drag(5, 1)
+      .dragEnd('#myGrid2');
+    cy.get('#myGrid2 .slick-range-decorator').should('not.be.exist');
     cy.get('#myGrid2 .slick-row:nth-child(-n+6)')
       .children(':not(.cell-unselectable)')
       .each(($child) => expect($child.attr("class")).to.include('selected'));
   })
 
-  it('should auto scroll take effect to display the selecting element when dragging', { scrollBehavior: false }, function () {
-    dragStart("#myGrid", 0, 1);
-    cy.get('#myGrid .slick-viewport:first').invoke('scrollLeft').then(scrollBefore => {
-      dragOutside('#myGrid', 'right', 300, 100);
-      cy.get('#myGrid .slick-viewport:first').invoke('scrollLeft').then(scrollAfter => {
-        expect(scrollBefore).to.be.lessThan(scrollAfter);
-        dragEnd('#myGrid');
-      })
-    })
+  function testScroll() {
+    return getScrollDistanceWhenDragOutsideGrid("#myGrid", 'topLeft', 'right', 0, 1).then(cellScrollDistance => {
+      return getScrollDistanceWhenDragOutsideGrid("#myGrid2", 'topLeft', 'bottom', 0, 1).then(rowScrollDistance => {
+        return cy.wrap({
+          cell: {
+            scrollBefore: cellScrollDistance.scrollLeftBefore,
+            scrollAfter: cellScrollDistance.scrollLeftAfter
+          },
+          row: {
+            scrollBefore: rowScrollDistance.scrollTopBefore,
+            scrollAfter: rowScrollDistance.scrollTopAfter
+          }
+        });
+      });
+    });
+  }
 
-    dragStart("#myGrid2", 0, 1);
-    cy.get('#myGrid2 .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
-      dragOutside('#myGrid2', 'bottom', 300, 100);
-      cy.get('#myGrid2 .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
-        expect(scrollBefore).to.be.lessThan(scrollAfter);
-        dragEnd('#myGrid2');
-        resetScroll();
-      })
-    })
+  it('should auto scroll take effect to display the selecting element when dragging', { scrollBehavior: false }, function () {
+    testScroll().then(scrollDistance => {
+      expect(scrollDistance.cell.scrollBefore).to.be.lessThan(scrollDistance.cell.scrollAfter);
+      expect(scrollDistance.row.scrollBefore).to.be.lessThan(scrollDistance.row.scrollAfter);
+    });
 
     cy.get('#isAutoScroll').click();
     cy.get('#setOptions').click();
 
-    dragStart("#myGrid", 0, 1);
-    cy.get('#myGrid .slick-viewport:first').invoke('scrollLeft').then(scrollBefore => {
-      dragOutside('#myGrid', 'right', 300, 100);
-      cy.get('#myGrid .slick-viewport:first').invoke('scrollLeft').then(scrollAfter => {
-        expect(scrollBefore).to.be.equal(scrollAfter);
-        dragEnd('#myGrid');
-      })
-    })
+    testScroll().then(scrollDistance => {
+      expect(scrollDistance.cell.scrollBefore).to.be.equal(scrollDistance.cell.scrollAfter);
+      expect(scrollDistance.row.scrollBefore).to.be.equal(scrollDistance.row.scrollAfter);
+    });
 
-    dragStart("#myGrid2", 0, 1);
-    cy.get('#myGrid2 .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
-      dragOutside('#myGrid2', 'bottom', 300, 100);
-      cy.get('#myGrid2 .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
-        expect(scrollBefore).to.be.equal(scrollAfter);
-        dragEnd('#myGrid2');
-        resetScroll();
-      })
-    })
     cy.get('#setDefaultOption').click();
     cy.get('#isAutoScroll').should('have.value', 'on')
   })
 
   function getIntervalUntilRow16Displayed(selector, px) {
-    dragStart(selector, 0, 1);
-    cy.get(selector + ' .slick-viewport:first').as('viewport').invoke('scrollTop').then(scrollBefore => {
-      dragOutside(selector, 'bottom', 0, px);
+    const viewportSelector = (selector + ' .slick-viewport:first');
+    cy.getCell(0, 1, '', { parentSelector: selector })
+      .dragStart();
+    return cy.get(viewportSelector).invoke('scrollTop').then(scrollBefore => {
+      cy.dragOutside('bottom', 0, px, { parentSelector: selector });
 
       const start = performance.now();
       cy.get(selector + ' .slick-row:not(.slick-group) >.cell-unselectable')
         .contains('16', { timeout: 10000 }) // actually #15 will be selected
         .should('not.be.hidden');
 
-      cy.get('@viewport').invoke('scrollTop').then(scrollAfter => {
-        dragEnd(selector);
+      return cy.get(viewportSelector).invoke('scrollTop').then(scrollAfter => {
+        cy.dragEnd(selector);
         var interval = performance.now() - start;
         expect(scrollBefore).to.be.lessThan(scrollAfter);
-        cy.wrap(interval).as('interval' + selector);
-      })
-    })
+        cy.get(viewportSelector).scrollTo(0, 0, { ensureScrollable: false });
+        return cy.wrap(interval);
+      });
+    });
   }
 
-  function testInterval(key, px) {
-    getIntervalUntilRow16Displayed("#myGrid", px);
-    getIntervalUntilRow16Displayed("#myGrid2", px);
-    cy.get('@interval#myGrid').then(intervalCell => {
-      cy.get('@interval#myGrid2').then(intervalRow => {
-        cy.wrap({
+  function testInterval(px) {
+    return getIntervalUntilRow16Displayed("#myGrid", px).then(intervalCell => {
+      return getIntervalUntilRow16Displayed("#myGrid2", px).then(intervalRow => {
+        return cy.wrap({
           cell: intervalCell,
           row: intervalRow
-        }).as(key)
+        });
       });
     });
   }
 
   it('should MIN interval take effect when auto scroll: 30ms -> 90ms', { scrollBehavior: false }, function () {
     // By default the MIN interval to show next cell is 30ms.
-    testInterval('default', 300);
-    cy.get('@default').then(defaultInterval => {
+    testInterval(300).then(defaultInterval => {
 
-      resetScroll();
       // Setting the interval to 90ms (3 times of the default).
       cy.get('#minIntervalToShowNextCell').type('{selectall}90'); // 30ms -> 90ms
       cy.get('#setOptions').click();
 
       // Ideally if we scrolling to same row by MIN interval, the used time should be 3 times slower than default.
       // Considering the threshold, 1.5 times slower than default is expected
-      testInterval('after', 300);
-      cy.get('@after').then(newInterval => {
+      testInterval(300).then(newInterval => {
 
         // max scrolling speed is slower than before
         expect(newInterval.cell).to.be.greaterThan(1.5 * defaultInterval.cell);
@@ -186,25 +139,21 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
 
         cy.get('#setDefaultOption').click();
         cy.get('#minIntervalToShowNextCell').should('have.value', '30');
-        resetScroll();
       })
     })
   })
 
   it('should MAX interval take effect when auto scroll: 600ms -> 200ms', { scrollBehavior: false }, function () {
     // By default the MAX interval to show next cell is 600ms.
-    testInterval('default', 0);
-    cy.get('@default').then(defaultInterval => {
+    testInterval(0).then(defaultInterval => {
 
-      resetScroll();
       // Setting the interval to 200ms (1/3 of the default).
       cy.get('#maxIntervalToShowNextCell').type('{selectall}200'); // 600ms -> 200ms
       cy.get('#setOptions').click();
 
       // Ideally if we scrolling to same row by MAX interval, the used time should be 3 times faster than default.
       // Considering the threshold, 1.5 times faster than default is expected
-      testInterval('after', 0);
-      cy.get('@after').then(newInterval => {
+      testInterval(0).then(newInterval => {
 
         // min scrolling speed is quicker than before
         expect(1.5 * newInterval.cell).to.be.lessThan(defaultInterval.cell);
@@ -212,17 +161,14 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
 
         cy.get('#setDefaultOption').click();
         cy.get('#maxIntervalToShowNextCell').should('have.value', '600');
-        resetScroll();
       })
     })
   })
 
   it('should Delay per Px take effect when auto scroll: 5ms/px -> 50ms/px', { scrollBehavior: false }, function () {
     // By default the Delay per Px is 5ms/px.
-    testInterval('default', scrollbarDimension);
-    cy.get('@default').then(defaultInterval => {
+    testInterval(scrollbarDimension).then(defaultInterval => {
 
-      resetScroll();
       // Setting to 50ms/px (10 times of the default).
       cy.get('#accelerateInterval').type('{selectall}50'); // 5ms/px -> 50ms/px
       cy.get('#setOptions').click();
@@ -230,16 +176,14 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
       // Ideally if we scrolling to same row, and set cursor to 17px, the new interval will be set to MIN interval (Math.max(30, 600 - 50 * 17) = 30ms),
       // and the used time should be around 17 times faster than default.
       // Considering the threshold, 5 times faster than default is expected
-      testInterval('after', scrollbarDimension);
-      cy.get('@after').then(newInterval => {
+      testInterval(scrollbarDimension).then(newInterval => {
 
-         // scrolling speed is quicker than before
+        // scrolling speed is quicker than before
         expect(5 * newInterval.cell).to.be.lessThan(defaultInterval.cell);
         expect(5 * newInterval.row).to.be.lessThan(defaultInterval.row);
 
         cy.get('#setDefaultOption').click();
         cy.get('#accelerateInterval').should('have.value', '5');
-        resetScroll();
       })
     })
   })
@@ -258,101 +202,67 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
     cy.get('#myGrid2 .grid-canvas-top').children().should('have.length', 3 * 2);
   });
 
-  function dragInFrozen(selector, whichViewport, dragDirection, fromRow, fromCol, px) {
-    let x;
-    let y;
-    if (whichViewport.toLowerCase().indexOf("left") > -1) {
-      x = 'left'
-    } else if (whichViewport.toLowerCase().indexOf("right") > -1) {
-      x = 'right';
-    }
-    if (whichViewport.toLowerCase().indexOf("top") > -1) {
-      y = 'top';
-    } else if (whichViewport.toLowerCase().indexOf("bottom") > -1) {
-      y = 'bottom';
-    }
-    dragStart(`${selector} .grid-canvas-${x}.grid-canvas-${y}`, fromRow, fromCol);
-    cy.get(`${selector} .slick-viewport-${x}.slick-viewport-${y}`).as('viewport').then($viewport => {
-      const scrollTopBefore = $viewport.scrollTop();
-      const scrollLeftBefore = $viewport.scrollLeft();
-      dragOutside(`${selector} .slick-viewport-${x}.slick-viewport-${y}`, dragDirection, 300, px || 100);
-      cy.get('@viewport').then($viewportAfter => {
-        dragEnd(selector);
-        cy.wrap({
-          scrollTopBefore: scrollTopBefore,
-          scrollLeftBefore: scrollLeftBefore,
-          scrollTopAfter: $viewportAfter.scrollTop(),
-          scrollLeftAfter: $viewportAfter.scrollLeft()
-        }).as('result');
-      })
-    })
+  function resetScrollInFrozen() {
+    cy.get('#myGrid .slick-viewport:last').scrollTo(0, 0);
+    cy.get('#myGrid2 .slick-viewport:last').scrollTo(0, 0);
   }
 
   it('should auto scroll to display the selecting element when dragging in frozen grid', { scrollBehavior: false }, () => {
     // top left - to bottomRight
-    dragInFrozen('#myGrid', 'topLeft', 'bottomRight', 0, 1);
-    cy.get('@result').then(result => {
+    getScrollDistanceWhenDragOutsideGrid('#myGrid', 'topLeft', 'bottomRight', 0, 1).then(result => {
       expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
     });
-    dragInFrozen('#myGrid2', 'topLeft', 'bottomRight', 0, 1);
-    cy.get('@result').then(result => {
+    getScrollDistanceWhenDragOutsideGrid('#myGrid2', 'topLeft', 'bottomRight', 0, 1).then(result => {
       expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
     });
 
     // top right - to bottomRight
-    dragInFrozen('#myGrid', 'topRight', 'bottomRight', 0, 0);
-    cy.get('@result').then(result => {
+    getScrollDistanceWhenDragOutsideGrid('#myGrid', 'topRight', 'bottomRight', 0, 0).then(result => {
       expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
     });
-    dragInFrozen('#myGrid2', 'topRight', 'bottomRight', 0, 0);
-    cy.get('@result').then(result => {
+    getScrollDistanceWhenDragOutsideGrid('#myGrid2', 'topRight', 'bottomRight', 0, 0).then(result => {
       expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
     });
-    resetScroll(true);
+    resetScrollInFrozen();
 
     // bottom left - to bottomRight
-    dragInFrozen('#myGrid', 'bottomLeft', 'bottomRight', 0, 1);
-    cy.get('@result').then(result => {
+    getScrollDistanceWhenDragOutsideGrid('#myGrid', 'bottomLeft', 'bottomRight', 0, 1).then(result => {
       expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
     });
-    dragInFrozen('#myGrid2', 'bottomLeft', 'bottomRight', 0, 1);
-    cy.get('@result').then(result => {
+    getScrollDistanceWhenDragOutsideGrid('#myGrid2', 'bottomLeft', 'bottomRight', 0, 1).then(result => {
       expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
     });
+    resetScrollInFrozen();
 
     // bottom right - to bottomRight
-    dragInFrozen('#myGrid', 'bottomRight', 'bottomRight', 0, 0);
-    cy.get('@result').then(result => {
+    getScrollDistanceWhenDragOutsideGrid('#myGrid', 'bottomRight', 'bottomRight', 0, 0).then(result => {
       expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
     });
-    dragInFrozen('#myGrid2', 'bottomRight', 'bottomRight', 0, 0);
-    cy.get('@result').then(result => {
+    getScrollDistanceWhenDragOutsideGrid('#myGrid2', 'bottomRight', 'bottomRight', 0, 0).then(result => {
       expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
     });
-    resetScroll(true);
-    cy.get('#myGrid .slick-viewport-bottom.slick-viewport-right').scrollTo(cellWidth*3, cellHeight*3);
-    cy.get('#myGrid2 .slick-viewport-bottom.slick-viewport-right').scrollTo(cellWidth*3, cellHeight*3);
+    resetScrollInFrozen();
+    cy.get('#myGrid .slick-viewport-bottom.slick-viewport-right').scrollTo(cellWidth * 3, cellHeight * 3);
+    cy.get('#myGrid2 .slick-viewport-bottom.slick-viewport-right').scrollTo(cellWidth * 3, cellHeight * 3);
 
     // bottom right - to topLeft
-    dragInFrozen('#myGrid', 'bottomRight', 'topLeft', 8, 4, 100);
-    cy.get('@result').then(result => {
+    getScrollDistanceWhenDragOutsideGrid('#myGrid', 'bottomRight', 'topLeft', 8, 4, 100).then(result => {
       expect(result.scrollTopBefore).to.be.greaterThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.greaterThan(result.scrollLeftAfter);
     });
-    dragInFrozen('#myGrid2', 'bottomRight', 'topLeft', 8, 4, 100);
-    cy.get('@result').then(result => {
+    getScrollDistanceWhenDragOutsideGrid('#myGrid2', 'bottomRight', 'topLeft', 8, 4, 100).then(result => {
       expect(result.scrollTopBefore).to.be.greaterThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.greaterThan(result.scrollLeftAfter);
     });
-    resetScroll(true);
+    resetScrollInFrozen();
   });
 
   it('should have a frozen & grouping by Duration grid after click Set/Clear grouping by Duration button', { scrollBehavior: false }, () => {
@@ -364,12 +274,13 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
   });
 
   function testDragInGrouping(selector) {
-    dragStart(selector + ' .grid-canvas-right.grid-canvas-bottom', 7, 0);
+    cy.getCell(7, 0, 'bottomRight', { parentSelector: selector })
+      .dragStart();
     cy.get(selector + ' .slick-viewport:last').as('viewport').invoke('scrollTop').then(scrollBefore => {
-      dragOutside(selector, 'bottom', 400, 300);
+      cy.dragOutside('bottom', 400, 300, { parentSelector: selector });
       cy.get('@viewport').invoke('scrollTop').then(scrollAfter => {
         expect(scrollBefore).to.be.lessThan(scrollAfter);
-        dragEnd(selector);
+        cy.dragEnd(selector);
         cy.get(selector + ' [style="top:350px"].slick-group').should('not.be.hidden');;
       })
     })

--- a/cypress/integration/example-auto-scroll-when-dragging.spec.js
+++ b/cypress/integration/example-auto-scroll-when-dragging.spec.js
@@ -1,11 +1,12 @@
 /// <reference types="cypress" />
 
-describe('Example - Frozen Columns & Rows', { retries: 1 }, () => {
+describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
   // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
   const cellWidth = 80;
   const cellHeight = 25;
   const gridWidth = 600;
   const gridHeight = 350;
+  const scrollbarDimension = 17;
 
   const fullTitles = ['#', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Cost', 'Effort Driven'];
 
@@ -22,202 +23,232 @@ describe('Example - Frozen Columns & Rows', { retries: 1 }, () => {
       .find('.slick-header-columns')
       .children()
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+    cy.get('#myGrid2')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
-  function dragStart(row, col, canvasClass) {
-    return cy.get(`${canvasClass || ''} [style="top:${row * 25}px"] > .slick-cell:nth(${col})`, )
+  function dragStart(parentClass, row, col) {
+    return cy.get(`${parentClass || ''} [style="top:${row * 25}px"] > .slick-cell:nth(${col})`, )
       .as('dragStart')
-      .click({force: true})
-      .trigger('mousedown', { which: 1 })
-      .trigger('mousemove', cellWidth/3, cellHeight/3);
+      .click({ force: true })
+      .trigger('mousedown', { which: 1, force: true })
+      .trigger('mousemove', cellWidth/3, cellHeight/3, { force: true });
   }
 
   function drag(addRow, addCell) {
     cy.get('@dragStart').trigger('mousemove', cellWidth * (addCell + 0.5) , cellHeight * (addRow + 0.5), { force: true })
   }
 
-  function dragOutside(position, ms, px, selector) {
+  function dragOutside(selector, position, ms, px) {
     var x = gridWidth / 2;
     var y = gridHeight / 2;
     if (position.toLowerCase().indexOf("left") > -1) {
       x = -px;
     } else if (position.toLowerCase().indexOf("right") > -1) {
-      x = gridWidth + (px || 0);
+      x = gridWidth - scrollbarDimension + 1 + (px || 0);
     }
     if (position.toLowerCase().indexOf("top") > -1) {
       y = -px;
     } else if (position.toLowerCase().indexOf("bottom") > -1) {
-      y = gridHeight + (px || 0);
+      y = gridHeight - scrollbarDimension + 1 + (px || 0);
     }
-    cy.get(`#myGrid ${selector || ''}`).trigger('mousemove', x, y, {force: true});
+    cy.get(` ${selector || ''}`).trigger('mousemove', x, y, { force: true });
     if (ms) {
       cy.wait(ms);
     }
   }
 
-  function dragEnd() {
-    return cy.get('#myGrid').trigger('mouseup', {force: true});
+  function dragEnd(selector) {
+    cy.get(selector).trigger('mouseup', { force: true });
+    cy.get(selector + ' .slick-range-decorator').should('not.be.exist');
   }
 
-  it('should decorator shown when dragging', { scrollBehavior: false }, function () {
-    dragStart(0, 1);
-    cy.get('.slick-range-decorator').should('be.exist');
+  function resetScroll(isFrozen) {
+    const selector = '.slick-viewport' + (isFrozen ? ":last" : ":first")
+    cy.get('#myGrid ' + selector).scrollTo(0, 0);
+    cy.get('#myGrid2 ' + selector).scrollTo(0, 0);
+  }
+
+  it('should select border shown in cell selection model, and hidden in row selection model when dragging', { scrollBehavior: false }, function () {
+    dragStart("#myGrid", 0, 1);
+    cy.get('#myGrid .slick-range-decorator').should('be.exist').and('have.css', 'border-color').and('not.equal', 'none');
     drag(0, 5);
-    dragEnd();
-    cy.get('.slick-range-decorator').should('not.be.exist');
-    cy.get('.slick-cell.selected').should('have.length', 6);
+    dragEnd('#myGrid');
+    cy.get('#myGrid .slick-cell.selected').should('have.length', 6);
+
+    dragStart("#myGrid2", 0, 1);
+    cy.get('#myGrid2 .slick-range-decorator').should('be.exist').and('have.css', 'border-style').and('equal', 'none');
+    drag(5, 1);
+    dragEnd('#myGrid2');
+
+    cy.get('#myGrid2 .slick-row:nth-child(-n+6)')
+      .children(':not(.cell-unselectable)')
+      .each(($child) => expect($child.attr("class")).to.include('selected'));
   })
 
   it('should auto scroll take effect to display the selecting element when dragging', { scrollBehavior: false }, function () {
-    dragStart(0, 1);
+    dragStart("#myGrid", 0, 1);
     cy.get('#myGrid .slick-viewport:first').invoke('scrollLeft').then(scrollBefore => {
-      dragOutside('right', 300, 100);
+      dragOutside('#myGrid', 'right', 300, 100);
       cy.get('#myGrid .slick-viewport:first').invoke('scrollLeft').then(scrollAfter => {
         expect(scrollBefore).to.be.lessThan(scrollAfter);
-        dragEnd();
+        dragEnd('#myGrid');
+      })
+    })
+
+    dragStart("#myGrid2", 0, 1);
+    cy.get('#myGrid2 .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
+      dragOutside('#myGrid2', 'bottom', 300, 100);
+      cy.get('#myGrid2 .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
+        expect(scrollBefore).to.be.lessThan(scrollAfter);
+        dragEnd('#myGrid2');
+        resetScroll();
       })
     })
 
     cy.get('#isAutoScroll').click();
     cy.get('#setOptions').click();
-    dragStart(0, 1);
+
+    dragStart("#myGrid", 0, 1);
     cy.get('#myGrid .slick-viewport:first').invoke('scrollLeft').then(scrollBefore => {
-      dragOutside('right', 300, 100);
+      dragOutside('#myGrid', 'right', 300, 100);
       cy.get('#myGrid .slick-viewport:first').invoke('scrollLeft').then(scrollAfter => {
         expect(scrollBefore).to.be.equal(scrollAfter);
-        dragEnd();
+        dragEnd('#myGrid');
       })
     })
 
+    dragStart("#myGrid2", 0, 1);
+    cy.get('#myGrid2 .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
+      dragOutside('#myGrid2', 'bottom', 300, 100);
+      cy.get('#myGrid2 .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
+        expect(scrollBefore).to.be.equal(scrollAfter);
+        dragEnd('#myGrid2');
+        resetScroll();
+      })
+    })
     cy.get('#setDefaultOption').click();
     cy.get('#isAutoScroll').should('have.value', 'on')
   })
 
+  function getIntervalUntilRow16Displayed(selector, px) {
+    dragStart(selector, 0, 1);
+    return cy.get(selector + ' .slick-viewport:first').as('viewport').invoke('scrollTop').then(scrollBefore => {
+      dragOutside(selector, 'bottom', 0, px);
+      const start = performance.now();
+      cy.get(selector + ' .slick-row:not(.slick-group) >.cell-unselectable')
+        .contains('16', { timeout: 10000 }) // actually #15 will be selected
+        .should('not.be.hidden');
+      return cy.get('@viewport').invoke('scrollTop').then(scrollAfter => {
+        dragEnd(selector);
+        var interval = performance.now() - start;
+        expect(scrollBefore).to.be.lessThan(scrollAfter);
+        return cy.wrap(interval);
+      })
+    })
+  }
+
+  function testInterval(px) {
+    return getIntervalUntilRow16Displayed("#myGrid", px).then(intervalCell => {
+      return getIntervalUntilRow16Displayed("#myGrid2", px).then(intervalRow => {
+        return cy.wrap({
+          cell: intervalCell,
+          row: intervalRow
+        })
+      });
+    });
+  }
+
   it('should MIN interval take effect when auto scroll: 30ms -> 90ms', { scrollBehavior: false }, function () {
-    let defaultInterval = 0;
-    dragStart(0, 1);
-    cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
-      dragOutside('bottom', 0, 300);
-      const defaultStart = performance.now();
-      cy.get('#myGrid .slick-viewport:first .slick-row > .slick-cell:first-child')
-        .contains('16') // actually #15 will be selected
-        .should('not.be.hidden');
-      cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
-        dragEnd();
-        defaultInterval = performance.now() - defaultStart;
-        expect(scrollBefore).to.be.lessThan(scrollAfter);
+    // By default the MIN interval to show next cell is 30ms.
+    testInterval(300).then(defaultInterval => {
+
+      resetScroll();
+      // Setting the interval to 90ms (3 times of the default).
+      cy.get('#minIntervalToShowNextCell').type('{selectall}90'); // 30ms -> 90ms
+      cy.get('#setOptions').click();
+
+      // Ideally if we scrolling to same row by MIN interval, the used time should be 3 times slower than default.
+      // Considering the threshold, 1.5 times slower than default is expected
+      testInterval(300).then(newInterval => {
+
+        // max scrolling speed is slower than before
+        expect(newInterval.cell).to.be.greaterThan(1.5 * defaultInterval.cell);
+        expect(newInterval.row).to.be.greaterThan(1.5 * defaultInterval.row);
+
+        cy.get('#setDefaultOption').click();
+        cy.get('#minIntervalToShowNextCell').should('have.value', '30');
+        resetScroll();
       })
     })
-
-    cy.get('#minIntervalToShowNextCell').type('{selectall}90'); // 30ms -> 90ms
-    cy.get('#setOptions').click();
-
-    dragStart(0, 1);
-    cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
-      dragOutside('bottom', 0, 300);
-      const newStart = performance.now();
-      cy.get('#myGrid .slick-viewport:first .slick-row > .slick-cell:first-child')
-        .contains('16') // actually #15 will be selected
-        .should('not.be.hidden');
-      cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
-        dragEnd();
-        const newInterval = performance.now() - newStart;
-        expect(scrollBefore).to.be.lessThan(scrollAfter);
-        expect(newInterval).to.be.greaterThan(2 * defaultInterval); // max scrolling speed is slower than before
-      })
-    })
-
-    cy.get('#setDefaultOption').click();
-    cy.get('#minIntervalToShowNextCell').should('have.value', '30')
   })
 
   it('should MAX interval take effect when auto scroll: 600ms -> 200ms', { scrollBehavior: false }, function () {
-    let defaultInterval = 0;
-    dragStart(0, 1);
-    cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
-      dragOutside('bottom');
-      const defaultStart = performance.now();
-      cy.get('#myGrid .slick-viewport:first .slick-row > .slick-cell:first-child')
-        .contains('16', { timeout: 10000 }) // actually #15 will be selected
-        .should('not.be.hidden');
-      cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
-        dragEnd();
-        defaultInterval = performance.now() - defaultStart;
-        expect(scrollBefore).to.be.lessThan(scrollAfter);
+    // By default the MAX interval to show next cell is 600ms.
+    testInterval(0).then(defaultInterval => {
+
+      resetScroll();
+      // Setting the interval to 200ms (1/3 of the default).
+      cy.get('#maxIntervalToShowNextCell').type('{selectall}200'); // 600ms -> 200ms
+      cy.get('#setOptions').click();
+
+      // Ideally if we scrolling to same row by MAX interval, the used time should be 3 times faster than default.
+      // Considering the threshold, 1.5 times faster than default is expected
+      testInterval(0).then(newInterval => {
+
+        // min scrolling speed is quicker than before
+        expect(1.5 * newInterval.cell).to.be.lessThan(defaultInterval.cell);
+        expect(1.5 * newInterval.row).to.be.lessThan(defaultInterval.row);
+
+        cy.get('#setDefaultOption').click();
+        cy.get('#maxIntervalToShowNextCell').should('have.value', '600');
+        resetScroll();
       })
     })
-
-    cy.get('#maxIntervalToShowNextCell').type('{selectall}200'); // 600ms -> 200ms
-    cy.get('#setOptions').click();
-
-    dragStart(0, 1);
-    cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
-      dragOutside('bottom');
-      const newStart = performance.now();
-      cy.get('#myGrid .slick-viewport:first .slick-row > .slick-cell:first-child')
-        .contains('16', { timeout: 10000 }) // actually #15 will be selected
-        .should('not.be.hidden');
-      cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
-        dragEnd();
-        const newInterval = performance.now() - newStart;
-        expect(scrollBefore).to.be.lessThan(scrollAfter);
-        expect(2 * newInterval).to.be.lessThan(defaultInterval, 1000); // min scrolling speed is quicker than before
-      })
-    })
-
-    cy.get('#setDefaultOption').click();
-    cy.get('#maxIntervalToShowNextCell').should('have.value', '600')
   })
 
   it('should Delay per Px take effect when auto scroll: 5ms/px -> 50ms/px', { scrollBehavior: false }, function () {
-    let defaultInterval = 0;
-    dragStart(0, 1);
-    cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
-      dragOutside('bottom');
-      const defaultStart = performance.now();
-      cy.get('#myGrid .slick-viewport:first .slick-row > .slick-cell:first-child')
-        .contains('16') // actually #15 will be selected
-        .should('not.be.hidden');
-      cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
-        dragEnd();
-        defaultInterval = performance.now() - defaultStart;
-        expect(scrollBefore).to.be.lessThan(scrollAfter);
+    // By default the Delay per Px is 5ms/px.
+    testInterval(scrollbarDimension).then(defaultInterval => {
+
+      resetScroll();
+      // Setting to 50ms/px (10 times of the default).
+      cy.get('#accelerateInterval').type('{selectall}50'); // 5ms/px -> 50ms/px
+      cy.get('#setOptions').click();
+
+      // Ideally if we scrolling to same row, and set cursor to 17px, the new interval will be set to MIN interval (Math.max(30, 600 - 50 * 17) = 30ms),
+      // and the used time should be around 17 times faster than default.
+      // Considering the threshold, 5 times faster than default is expected
+      testInterval(scrollbarDimension).then(newInterval => {
+
+         // scrolling speed is quicker than before
+        expect(5 * newInterval.cell).to.be.lessThan(defaultInterval.cell);
+        expect(5 * newInterval.row).to.be.lessThan(defaultInterval.row);
+
+        cy.get('#setDefaultOption').click();
+        cy.get('#accelerateInterval').should('have.value', '5');
+        resetScroll();
       })
     })
-
-    cy.get('#accelerateInterval').type('{selectall}50'); // 5ms/px -> 50ms/px
-    cy.get('#setOptions').click();
-
-    dragStart(0, 1);
-    cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollBefore => {
-      dragOutside('bottom');
-      const newStart = performance.now();
-      cy.get('#myGrid .slick-viewport:first .slick-row > .slick-cell:first-child')
-        .contains('16') // actually #15 will be selected
-        .should('not.be.hidden');
-      cy.get('#myGrid .slick-viewport:first').invoke('scrollTop').then(scrollAfter => {
-        dragEnd();
-        const newInterval = performance.now() - newStart;
-        expect(scrollBefore).to.be.lessThan(scrollAfter);
-        expect(5 * newInterval).to.be.lessThan(defaultInterval, 1000); // scrolling speed is quicker than before
-      })
-    })
-
-    cy.get('#setDefaultOption').click();
-    cy.get('#accelerateInterval').should('have.value', '5')
   })
 
   it('should have a frozen grid with 4 containers with 2 columns on the left and 3 rows on the top after click Set/Clear Frozen button', () => {
-    cy.get('[style="top:0px"]').should('have.length', 1);
+    cy.get('#myGrid [style="top:0px"]').should('have.length', 1);
+    cy.get('#myGrid2 [style="top:0px"]').should('have.length', 1);
 
     cy.get('#toggleFrozen').click();
 
-    cy.get('[style="top:0px"]').should('have.length', 2 * 2);
-    cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 2 * 2);
-    cy.get('.grid-canvas-top').children().should('have.length', 3 * 2);
+    cy.get('#myGrid [style="top:0px"]').should('have.length', 2 * 2);
+    cy.get('#myGrid2 [style="top:0px"]').should('have.length', 2 * 2);
+    cy.get('#myGrid .grid-canvas-left > [style="top:0px"]').children().should('have.length', 2 * 2);
+    cy.get('#myGrid2 .grid-canvas-left > [style="top:0px"]').children().should('have.length', 2 * 2);
+    cy.get('#myGrid .grid-canvas-top').children().should('have.length', 3 * 2);
+    cy.get('#myGrid2 .grid-canvas-top').children().should('have.length', 3 * 2);
   });
 
-  function dragInFrozen(whichViewport, dragDirection, fromRow, fromCol, px) {
+  function dragInFrozen(selector, whichViewport, dragDirection, fromRow, fromCol, px) {
     let x;
     let y;
     if (whichViewport.toLowerCase().indexOf("left") > -1) {
@@ -230,13 +261,13 @@ describe('Example - Frozen Columns & Rows', { retries: 1 }, () => {
     } else if (whichViewport.toLowerCase().indexOf("bottom") > -1) {
       y = 'bottom';
     }
-    dragStart(fromRow, fromCol, `.grid-canvas-${x}.grid-canvas-${y}`);
-    return cy.get(`#myGrid .slick-viewport-${x}.slick-viewport-${y}`).as('viewport').then($viewport => {
+    dragStart(`${selector} .grid-canvas-${x}.grid-canvas-${y}`, fromRow, fromCol);
+    return cy.get(`${selector} .slick-viewport-${x}.slick-viewport-${y}`).as('viewport').then($viewport => {
       const scrollTopBefore = $viewport.scrollTop();
       const scrollLeftBefore = $viewport.scrollLeft();
-      dragOutside(dragDirection, 300, px || 100, `.slick-viewport-${x}.slick-viewport-${y}`);
+      dragOutside(`${selector} .slick-viewport-${x}.slick-viewport-${y}`, dragDirection, 300, px || 100);
       return cy.get('@viewport').then($viewportAfter => {
-        dragEnd();
+        dragEnd(selector);
         return cy.wrap({
           scrollTopBefore: scrollTopBefore,
           scrollLeftBefore: scrollLeftBefore,
@@ -249,63 +280,91 @@ describe('Example - Frozen Columns & Rows', { retries: 1 }, () => {
 
   it('should auto scroll to display the selecting element when dragging in frozen grid', { scrollBehavior: false }, () => {
     // top left - to bottomRight
-    dragInFrozen('topLeft', 'bottomRight', 0, 1).then(result => {
+    dragInFrozen('#myGrid', 'topLeft', 'bottomRight', 0, 1).then(result => {
+      expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
+      expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
+    });
+    dragInFrozen('#myGrid2', 'topLeft', 'bottomRight', 0, 1).then(result => {
       expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
     });
 
     // top right - to bottomRight
-    dragInFrozen('topRight', 'bottomRight', 0, 0).then(result => {
+    dragInFrozen('#myGrid', 'topRight', 'bottomRight', 0, 0).then(result => {
       expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
     });
+    dragInFrozen('#myGrid2', 'topRight', 'bottomRight', 0, 0).then(result => {
+      expect(result.scrollTopBefore).to.be.equal(result.scrollTopAfter);
+      expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
+    });
+    resetScroll(true);
 
     // bottom left - to bottomRight
-    dragInFrozen('bottomLeft', 'bottomRight', 0, 1).then(result => {
+    dragInFrozen('#myGrid', 'bottomLeft', 'bottomRight', 0, 1).then(result => {
+      expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
+      expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
+    });
+    dragInFrozen('#myGrid2', 'bottomLeft', 'bottomRight', 0, 1).then(result => {
       expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.equal(result.scrollLeftAfter);
     });
 
     // bottom right - to bottomRight
-    dragInFrozen('bottomRight', 'bottomRight', 0, 0).then(result => {
+    dragInFrozen('#myGrid', 'bottomRight', 'bottomRight', 0, 0).then(result => {
       expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
     });
-
+    dragInFrozen('#myGrid2', 'bottomRight', 'bottomRight', 0, 0).then(result => {
+      expect(result.scrollTopBefore).to.be.lessThan(result.scrollTopAfter);
+      expect(result.scrollLeftBefore).to.be.lessThan(result.scrollLeftAfter);
+    });
+    resetScroll(true);
     cy.get('#myGrid .slick-viewport-bottom.slick-viewport-right').scrollTo(cellWidth*3, cellHeight*3);
+    cy.get('#myGrid2 .slick-viewport-bottom.slick-viewport-right').scrollTo(cellWidth*3, cellHeight*3);
 
-    // // bottom right - to topLeft
-    dragInFrozen('bottomRight', 'topLeft', 8, 4, 100).then(result => {
+    // bottom right - to topLeft
+    dragInFrozen('#myGrid', 'bottomRight', 'topLeft', 8, 4, 100).then(result => {
       expect(result.scrollTopBefore).to.be.greaterThan(result.scrollTopAfter);
       expect(result.scrollLeftBefore).to.be.greaterThan(result.scrollLeftAfter);
     });
-
-    cy.get('#myGrid .slick-viewport-bottom.slick-viewport-right').scrollTo(0, 0);
+    dragInFrozen('#myGrid2', 'bottomRight', 'topLeft', 8, 4, 100).then(result => {
+      expect(result.scrollTopBefore).to.be.greaterThan(result.scrollTopAfter);
+      expect(result.scrollLeftBefore).to.be.greaterThan(result.scrollLeftAfter);
+    });
+    resetScroll(true);
   });
 
   it('should have a frozen & grouping by Duration grid after click Set/Clear grouping by Duration button', { scrollBehavior: false }, () => {
     cy.get('#toggleGroup').trigger('click');
-    cy.get('[style="top:0px"]').should('have.length', 2 * 2);
-    cy.get('.grid-canvas-top.grid-canvas-left').contains('Duration');
+    cy.get('#myGrid [style="top:0px"]').should('have.length', 2 * 2);
+    cy.get('#myGrid2 [style="top:0px"]').should('have.length', 2 * 2);
+    cy.get('#myGrid .grid-canvas-top.grid-canvas-left').contains('Duration');
+    cy.get('#myGrid2 .grid-canvas-top.grid-canvas-left').contains('Duration');
   });
 
-
-  it('should auto scroll to display the selecting element even unselectable cell exist in grouping grid', { scrollBehavior: false }, () => {
-    dragStart(7, 0, '.grid-canvas-right.grid-canvas-bottom');
-    cy.get('#myGrid .slick-viewport:last').invoke('scrollTop').then(scrollBefore => {
-      dragOutside('bottom', 400, 100);
-      cy.get('#myGrid .slick-viewport:last').invoke('scrollTop').then(scrollAfter => {
+  function testDragInGrouping(selector) {
+    dragStart(selector + ' .grid-canvas-right.grid-canvas-bottom', 7, 0);
+    cy.get(selector + ' .slick-viewport:last').as('viewport').invoke('scrollTop').then(scrollBefore => {
+      dragOutside(selector, 'bottom', 400, 300);
+      cy.get('@viewport').invoke('scrollTop').then(scrollAfter => {
         expect(scrollBefore).to.be.lessThan(scrollAfter);
-        dragEnd();
-        cy.get('[style="top:350px"].slick-group').should('not.be.hidden');;
+        dragEnd(selector);
+        cy.get(selector + ' [style="top:350px"].slick-group').should('not.be.hidden');;
       })
     })
+  }
+
+  it('should auto scroll to display the selecting element even unselectable cell exist in grouping grid', { scrollBehavior: false }, () => {
+    testDragInGrouping('#myGrid');
+    testDragInGrouping('#myGrid2');
   });
 
   it('should reset to default grid when click Set/Clear Frozen button and Set/Clear grouping button', () => {
     cy.get('#toggleFrozen').trigger('click');
     cy.get('#toggleGroup').trigger('click');
-    cy.get('[style="top:0px"]').should('have.length', 1);
+    cy.get('#myGrid [style="top:0px"]').should('have.length', 1);
+    cy.get('#myGrid2 [style="top:0px"]').should('have.length', 1);
   });
 
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,16 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+import { convertPosition } from './common';
+
+// convert position like 'topLeft' to the object { x: 'left|right', y: 'top|bottom' }
+Cypress.Commands.add("convertPosition", (viewport = 'topLeft') => cy.wrap(convertPosition(viewport)))
+
+Cypress.Commands.add("getCell", (row, col, viewport = 'topLeft', { parentSelector = '', rowHeight = 25 } = {}) => {
+  const position = convertPosition(viewport);
+  const canvasSelectorX = position.x ? `.grid-canvas-${position.x}` : '';
+  const canvasSelectorY = position.y ? `.grid-canvas-${position.y}` : '';
+
+  return cy.get(`${parentSelector} ${canvasSelectorX}${canvasSelectorY} [style="top:${row * rowHeight}px"] > .slick-cell:nth(${col})`);
+})

--- a/cypress/support/common.js
+++ b/cypress/support/common.js
@@ -1,0 +1,47 @@
+/**
+ * @typedef {('left'|'right')} xAllowed
+ * @typedef {('top'|'bottom')} yAllowed
+ *
+ * Define allowed input position
+ * @typedef {(xAllowed|yAllowed|'topLeft'|'topRight'|'bottomLeft'|'bottomRight')} AllowedInputPosition
+ *
+ * Define position object
+ * @typedef {Object} Position
+ * @property {xAllowed} x - horizontal
+ * @property {yAllowed} y - vertical
+ */
+
+/**
+ * Enum for position values
+ * @constant
+ * @enum {(xAllowed|yAllowed)}
+ */
+const POSITION = Object.freeze({
+  TOP: 'top',
+  BOTTOM: 'bottom',
+  LEFT: 'left',
+  RIGHT: 'right'
+})
+
+/**
+ * Convert position string to object
+ *
+ * @param {AllowedInputPosition} position
+ * @returns {Position}
+ */
+export function convertPosition(position) {
+  let x = '';
+  let y = '';
+  const _position = position.toLowerCase();
+  if (_position.includes(POSITION.LEFT)) {
+    x = POSITION.LEFT;
+  } else if (_position.includes(POSITION.RIGHT)) {
+    x = POSITION.RIGHT;
+  }
+  if (_position.includes(POSITION.TOP)) {
+    y = POSITION.TOP;
+  } else if (_position.includes(POSITION.BOTTOM)) {
+    y = POSITION.BOTTOM;
+  }
+  return { x, y };
+}

--- a/cypress/support/drag.js
+++ b/cypress/support/drag.js
@@ -1,0 +1,66 @@
+import { convertPosition } from './common';
+
+Cypress.Commands.add("dragStart", { prevSubject: true }, (subject, { cellWidth = 80, cellHeight = 25 } = {}) => {
+  return cy.wrap(subject).click({ force: true })
+    .trigger('mousedown', { which: 1 })
+    .trigger('mousemove', cellWidth / 3, cellHeight / 3);
+})
+
+Cypress.Commands.add("drag", { prevSubject: true }, (subject, addRow, addCell, { cellWidth = 80, cellHeight = 25 } = {}) => {
+  return cy.wrap(subject).trigger('mousemove', cellWidth * (addCell + 0.5), cellHeight * (addRow + 0.5), { force: true });
+})
+
+Cypress.Commands.add("dragOutside", (viewport = 'topLeft', ms = 0, px = 0, { parentSelector = 'div[class^="slickgrid_"]', scrollbarDimension = 17 } = {}) => {
+  const $parent = cy.$$(parentSelector);
+  const gridWidth = $parent.width();
+  const gridHeight = $parent.height();
+  var x = gridWidth / 2;
+  var y = gridHeight / 2;
+  const position = convertPosition(viewport);
+  if (position.x === "left") {
+    x = -px;
+  } else if (position.x === "right") {
+    x = gridWidth - scrollbarDimension + 3 + px;
+  }
+  if (position.y === "top") {
+    y = -px;
+  } else if (position.y === "bottom") {
+    y = gridHeight - scrollbarDimension + 3 + px;
+  }
+
+  cy.get(parentSelector).trigger('mousemove', x, y, { force: true });
+  if (ms) {
+    cy.wait(ms);
+  }
+  return;
+})
+
+Cypress.Commands.add("dragEnd", { prevSubject: 'optional' }, (subject, gridSelector = 'div[class^="slickgrid_"]') => {
+  cy.get(gridSelector).trigger('mouseup', { force: true });
+  return;
+})
+
+export function getScrollDistanceWhenDragOutsideGrid(selector, viewport, dragDirection, fromRow, fromCol, px = 100) {
+  return cy.convertPosition(viewport).then(_viewportPosition => {
+    const viewportSelector = `${selector} .slick-viewport-${_viewportPosition.x}.slick-viewport-${_viewportPosition.y}`
+    cy.getCell(fromRow, fromCol, viewport, { parentSelector: selector })
+      .dragStart();
+    return cy.get(viewportSelector).then($viewport => {
+      const scrollTopBefore = $viewport.scrollTop();
+      const scrollLeftBefore = $viewport.scrollLeft();
+      cy.dragOutside(dragDirection, 300, px, { parentSelector: selector });
+      return cy.get(viewportSelector).then($viewportAfter => {
+        cy.dragEnd(selector);
+        const scrollTopAfter = $viewportAfter.scrollTop();
+        const scrollLeftAfter = $viewportAfter.scrollLeft();
+        cy.get(viewportSelector).scrollTo(0, 0, { ensureScrollable: false });
+        return cy.wrap({
+          scrollTopBefore,
+          scrollLeftBefore,
+          scrollTopAfter,
+          scrollLeftAfter
+        });
+      });
+    });
+  });
+}

--- a/examples/example-auto-scroll-when-dragging.html
+++ b/examples/example-auto-scroll-when-dragging.html
@@ -20,8 +20,11 @@
     .slick-group-title[level='2'] {
       font-style: italic;
     }
-    .slick-row .slick-cell.frozen:last-child, 
-    .slick-header-column.frozen:last-child, 
+    .slick-row:not(.slick-group) >.cell-unselectable {
+      background: #efefef;
+    }
+    .slick-row .slick-cell.frozen:last-child,
+    .slick-header-column.frozen:last-child,
     .slick-headerrow-column.frozen:last-child,
     .slick-footerrow-column.frozen:last-child {
       border-right: 1px solid red;
@@ -38,12 +41,16 @@
 <body>
 <div style="position:relative">
   <div style="width:600px;">
-    <div id="myGrid" style="width:100%;height:350px;"></div>
+    <h1> Using Slick.CellRangeSelector </h1>
+    <div id="myGrid" class="example-grid" style="width:100%;height:350px;"></div>
+    <br>
+    <h1> Using Slick.RowRangeSelector </h1>
+    <div id="myGrid2" class="example-grid" style="width:100%;height:350px;"></div>
   </div>
   <br/>
 
   <div class="options-panel">
-    <h2>Options:</h2>
+    <h2>Options: (Apply to both grid)</h2>
     <div class="option-item">
       <label for='isAutoScroll'>Auto Scroll: (need click Set Options)</label>
       <input type="checkbox" id="isAutoScroll">
@@ -83,7 +90,7 @@
 
     <h2>Demonstrates:</h2>
     <ul>
-      <li>Dragging to make a selection, and the viewport will auto scroll.</li>
+      <li>Dragging from 2nd column to make a selection, and the viewport will auto scroll.</li>
     </ul>
   </div>
 </div>
@@ -98,6 +105,7 @@
 <script src="../plugins/slick.cellrangedecorator.js"></script>
 <script src="../plugins/slick.cellrangeselector.js"></script>
 <script src="../plugins/slick.cellselectionmodel.js"></script>
+<script src="../plugins/slick.rowselectionmodel.js"></script>
 <script src="../slick.editors.js"></script>
 <script src="../slick.formatters.js"></script>
 <script src="../slick.dataview.js"></script>
@@ -106,6 +114,7 @@
 
 <script>
   var grid;
+  var grid2;
   var dataView;
 
   var options = {
@@ -114,11 +123,12 @@
     asyncEditorLoading: false,
     autoEdit: false,
     frozenRow: -1,
+    enableColumnReorder: false,
     frozenColumn: -1
   };
 
   var columns = [
-    {id: "sel", name: "#", field: "num", cssClass: "cell-selection", resizable: false, selectable: false, focusable: false },
+    {id: "sel", name: "#", field: "num", cssClass: "cell-unselectable", resizable: false, selectable: false, focusable: false, width: 40 },
     {id: "title", name: "Title", field: "title", minWidth: 50, cssClass: "cell-title", editor: Slick.Editors.Text},
     {id: "duration", name: "Duration", field: "duration", groupTotalsFormatter: function(totals, columnDef, grid) {
       var val = totals.sum && totals.sum[columnDef.field];
@@ -168,16 +178,22 @@
     var groupItemMetadataProvider = new Slick.Data.GroupItemMetadataProvider();
     loadData(groupItemMetadataProvider);
     grid = new Slick.Grid("#myGrid", dataView, columns, options);
+    grid2 = new Slick.Grid("#myGrid2", dataView, columns, options);
     grid.registerPlugin(groupItemMetadataProvider);
+    grid2.registerPlugin(groupItemMetadataProvider);
     setDefaultOption();
     dataView.onRowCountChanged.subscribe(function (e, args) {
       grid.updateRowCount();
       grid.render();
+      grid2.updateRowCount();
+      grid2.render();
     });
 
     dataView.onRowsChanged.subscribe(function (e, args) {
       grid.invalidateRows(args.rows);
       grid.render();
+      grid2.invalidateRows(args.rows);
+      grid2.render();
     });
   })
 
@@ -198,16 +214,30 @@
         accelerateInterval: Number($('#accelerateInterval').val())
       })
     }));
+
+    grid2.setSelectionModel(new Slick.RowSelectionModel({
+      cellRangeSelector: new Slick.CellRangeSelector({
+        selectionCss: {
+          "border": "none"
+        },
+        autoScroll: $('#isAutoScroll').is(":checked"),
+        minIntervalToShowNextCell: Number($('#minIntervalToShowNextCell').val()),
+        maxIntervalToShowNextCell: Number($('#maxIntervalToShowNextCell').val()),
+        accelerateInterval: Number($('#accelerateInterval').val())
+      })
+  }));
   }
 
   function toggleFrozen() {
     var option = grid.getOptions();
     var frozenRow = option.frozenRow;
     var frozenColumn = option.frozenColumn;
-    grid.setOptions({
+    var newOption = {
       frozenColumn: frozenColumn == -1 ? 1 : -1,
       frozenRow: frozenRow == -1 ? 3 : -1
-    })
+    };
+    grid.setOptions(newOption);
+    grid2.setOptions(newOption);
   }
 
   function toggleGroup() {

--- a/examples/example-auto-scroll-when-dragging.html
+++ b/examples/example-auto-scroll-when-dragging.html
@@ -1,0 +1,233 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
+  <title>SlickGrid example: Spreadsheet with Excel compatible cut and paste</title>
+  <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
+  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
+  <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <style>
+    .cell-effort-driven {
+      text-align: center;
+    }
+    .slick-group-title[level='0'] {
+      font-weight: bold;
+    }
+    .slick-group-title[level='1'] {
+      text-decoration: underline;
+    }
+    .slick-group-title[level='2'] {
+      font-style: italic;
+    }
+    .slick-row .slick-cell.frozen:last-child, 
+    .slick-header-column.frozen:last-child, 
+    .slick-headerrow-column.frozen:last-child,
+    .slick-footerrow-column.frozen:last-child {
+      border-right: 1px solid red;
+    }
+
+    .slick-row.frozen:last-child .slick-cell {
+      border-bottom: 1px solid red;
+    }
+    .option-item {
+      padding: 6px;
+    }
+  </style>
+</head>
+<body>
+<div style="position:relative">
+  <div style="width:600px;">
+    <div id="myGrid" style="width:100%;height:350px;"></div>
+  </div>
+  <br/>
+
+  <div class="options-panel">
+    <h2>Options:</h2>
+    <div class="option-item">
+      <label for='isAutoScroll'>Auto Scroll: (need click Set Options)</label>
+      <input type="checkbox" id="isAutoScroll">
+    </div>
+
+    <div class="option-item">
+      <label for='minIntervalToShowNextCell'>MIN interval to show next cell: </label>
+      <input type='text' id="minIntervalToShowNextCell" style="width:60px;">
+      (ms)
+    </div>
+
+    <div class="option-item">
+      <label for='maxIntervalToShowNextCell'>MAX delay to show next cell (ms): </label>
+      <input type='text' id="maxIntervalToShowNextCell" style="width:60px;">
+      (ms)
+      <div>better to multiple of MIN</div>
+    </div>
+
+
+    <div class="option-item">
+      <label for='accelerateInterval'>Delay when cursor outside 1px (ms): </label>
+      <input type='text' id="accelerateInterval" style="width:60px;">
+      (ms)
+    </div>
+
+    <div class="option-item">
+      <button id='setOptions' onclick="setOptions()">Set Options</button>
+      <button id='setDefaultOption' onclick="setDefaultOption()">Set Default Options</button>
+    </div>
+
+    <hr>
+
+    <div class="option-item">
+      <button id='toggleFrozen' onclick="toggleFrozen()">Set/Clear Frozen</button>
+      <button id='toggleGroup' onclick="toggleGroup()">Set/Clear grouping by Duration</button>
+    </div>
+
+    <h2>Demonstrates:</h2>
+    <ul>
+      <li>Dragging to make a selection, and the viewport will auto scroll.</li>
+    </ul>
+  </div>
+</div>
+
+<script src="../lib/firebugx.js"></script>
+
+<script src="../lib/jquery-1.12.4.min.js"></script>
+<script src="../lib/jquery-ui.min.js"></script>
+<script src="../lib/jquery.event.drag-2.3.0.js"></script>
+
+<script src="../slick.core.js"></script>
+<script src="../plugins/slick.cellrangedecorator.js"></script>
+<script src="../plugins/slick.cellrangeselector.js"></script>
+<script src="../plugins/slick.cellselectionmodel.js"></script>
+<script src="../slick.editors.js"></script>
+<script src="../slick.formatters.js"></script>
+<script src="../slick.dataview.js"></script>
+<script src="../slick.grid.js"></script>
+<script src="../slick.groupitemmetadataprovider.js"></script>
+
+<script>
+  var grid;
+  var dataView;
+
+  var options = {
+    editable: true,
+    enableCellNavigation: true,
+    asyncEditorLoading: false,
+    autoEdit: false,
+    frozenRow: -1,
+    frozenColumn: -1
+  };
+
+  var columns = [
+    {id: "sel", name: "#", field: "num", cssClass: "cell-selection", resizable: false, selectable: false, focusable: false },
+    {id: "title", name: "Title", field: "title", minWidth: 50, cssClass: "cell-title", editor: Slick.Editors.Text},
+    {id: "duration", name: "Duration", field: "duration", groupTotalsFormatter: function(totals, columnDef, grid) {
+      var val = totals.sum && totals.sum[columnDef.field];
+      if (val != null) {
+        return "total: " + ((Math.round(parseFloat(val)*100)/100));
+      }
+      return "";
+    }},
+    {id: "%", name: "% Complete", field: "percentComplete", formatter: Slick.Formatters.PercentCompleteBar},
+    {id: "start", name: "Start", field: "start", minWidth: 60},
+    {id: "finish", name: "Finish", field: "finish", minWidth: 60},
+    {id: "cost", name: "Cost", field: "cost"},
+    {id: "effort-driven", name: "Effort Driven", minWidth: 20, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark}
+  ];
+
+  for (var i = 0; i < 30; i++) {
+    columns.push({id: "mock" + i, name: "Mock" + i, field: "mock" + i});
+  }
+
+  function loadData(groupItemMetadataProvider) {
+    dataView = new Slick.Data.DataView({
+      groupItemMetadataProvider: groupItemMetadataProvider
+    });
+    var someDates = ["01/01/2009", "02/02/2009", "03/03/2009"];
+    var data = [];
+    for (var i = 0; i < 300; i++) {
+      var d = (data[i] = {});
+
+      d["id"] = "id_" + i;
+      d["num"] = i;
+      d["title"] = "Task " + i;
+      d["duration"] = i % 20;
+      d["percentComplete"] = Math.round(Math.random() * 100);
+      d["start"] = someDates[ Math.floor((Math.random()*2)) ];
+      d["finish"] = someDates[ Math.floor((Math.random()*2)) ];
+      d["cost"] = Math.round(Math.random() * 10000) / 100;
+      d["effortDriven"] = (i % 5 == 0);
+
+      for (var j = 0; j < 30; j++) {
+        d["mock" + j] = j
+      }
+    }
+    dataView.setItems(data);
+  }
+
+  $(function () {
+    var groupItemMetadataProvider = new Slick.Data.GroupItemMetadataProvider();
+    loadData(groupItemMetadataProvider);
+    grid = new Slick.Grid("#myGrid", dataView, columns, options);
+    grid.registerPlugin(groupItemMetadataProvider);
+    setDefaultOption();
+    dataView.onRowCountChanged.subscribe(function (e, args) {
+      grid.updateRowCount();
+      grid.render();
+    });
+
+    dataView.onRowsChanged.subscribe(function (e, args) {
+      grid.invalidateRows(args.rows);
+      grid.render();
+    });
+  })
+
+  function setDefaultOption() {
+    $('#isAutoScroll').prop('checked', true);
+    $('#minIntervalToShowNextCell').val('30');
+    $('#maxIntervalToShowNextCell').val('600');
+    $('#accelerateInterval').val('5');
+    setOptions();
+  }
+
+  function setOptions() {
+    grid.setSelectionModel(new Slick.CellSelectionModel({
+      cellRangeSelector: new Slick.CellRangeSelector({
+        autoScroll: $('#isAutoScroll').is(":checked"),
+        minIntervalToShowNextCell: Number($('#minIntervalToShowNextCell').val()),
+        maxIntervalToShowNextCell: Number($('#maxIntervalToShowNextCell').val()),
+        accelerateInterval: Number($('#accelerateInterval').val())
+      })
+    }));
+  }
+
+  function toggleFrozen() {
+    var option = grid.getOptions();
+    var frozenRow = option.frozenRow;
+    var frozenColumn = option.frozenColumn;
+    grid.setOptions({
+      frozenColumn: frozenColumn == -1 ? 1 : -1,
+      frozenRow: frozenRow == -1 ? 3 : -1
+    })
+  }
+
+  function toggleGroup() {
+    (dataView.getGrouping() && dataView.getGrouping().length > 0) ? dataView.setGrouping([]):groupByDuration();
+  }
+
+  function groupByDuration() {
+    dataView.setGrouping({
+      getter: "duration",
+      formatter: function (g) {
+        return "Duration:  " + g.value + "  <span style='color:green'>(" + g.count + " items)</span>";
+      },
+      aggregators: [
+        new Slick.Data.Aggregators.Avg("percentComplete"),
+        new Slick.Data.Aggregators.Sum("cost")
+      ],
+      aggregateCollapsed: false,
+      lazyTotalsCalculation: true
+    });
+  }
+</script>
+</body>
+</html>

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -85,9 +85,9 @@
       _$activeCanvas = $(_grid.getActiveCanvasNode(e));
       _$activeViewport = $(_grid.getActiveViewportNode(e));
 
-      var scrollbarDimensions = _grid.getScrollbarDimensions();
-      _viewportWidth = _$activeViewport.width() - (_grid.isViewportHasVScroll() ? scrollbarDimensions.width : 0);
-      _viewportHeight = _$activeViewport.height() - (_grid.isViewportHasHScroll() ? scrollbarDimensions.height : 0);
+      var scrollbarDimensions = _grid.getDisplayedScrollbarDimensions()
+      _viewportWidth = _$activeViewport.width() - scrollbarDimensions.width;
+      _viewportHeight = _$activeViewport.height() - scrollbarDimensions.height;
       _moveDistanceForOneCell = {
         x: _grid.getAbsoluteColumnMinWidth() / 2,
         y: _grid.getOptions().rowHeight / 2

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -317,7 +317,11 @@
 
       dd.range.end = end;
 
-      _decorator.show(new Slick.Range(dd.range.start.row, dd.range.start.cell, end.row, end.cell));
+      var range = new Slick.Range(dd.range.start.row, dd.range.start.cell, end.row, end.cell);
+      _decorator.show(range);
+      _self.onCellRangeSelecting.notify({
+        range: range
+      });
     }
 
     function handleDragEnd(e, dd) {
@@ -353,7 +357,8 @@
       "getCurrentRange": getCurrentRange,
 
       "onBeforeCellRangeSelected": new Slick.Event(),
-      "onCellRangeSelected": new Slick.Event()
+      "onCellRangeSelected": new Slick.Event(),
+      "onCellRangeSelecting": new Slick.Event()
     });
   }
 })(jQuery);

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -17,6 +17,10 @@
     var _self = this;
     var _handler = new Slick.EventHandler();
     var _defaults = {
+      autoScroll: true,
+      minIntervalToShowNextCell: 30,
+      maxIntervalToShowNextCell: 600, // better to a multiple of minIntervalToShowNextCell
+      accelerateInterval: 5,          // increase 5ms when cursor 1px outside the viewport.
       selectionCss: {
         "border": "2px dashed blue"
       }
@@ -27,6 +31,16 @@
     var _columnOffset;
     var _isRightCanvas;
     var _isBottomCanvas;
+
+    // autoScroll related variables
+    var _$activeViewport;
+    var _viewportWidth;
+    var _viewportHeight;
+    var _draggingMouseOffset;
+    var _moveDistanceForOneCell;
+    var _autoScrollTimerId;
+    var _xDelayForNextCell;
+    var _yDelayForNextCell;
 
     // Scrollings
     var _scrollTop = 0;
@@ -49,6 +63,7 @@
     function destroy() {
       _handler.unsubscribeAll();
       _$activeCanvas = null;
+      _$activeViewport = null;
       _canvas = null;
       if (_decorator && _decorator.destroy) {
         _decorator.destroy();
@@ -68,6 +83,15 @@
       // Set the active canvas node because the decorator needs to append its
       // box to the correct canvas
       _$activeCanvas = $(_grid.getActiveCanvasNode(e));
+      _$activeViewport = $(_grid.getActiveViewportNode(e));
+
+      var scrollbarDimensions = _grid.getScrollbarDimensions();
+      _viewportWidth = _$activeViewport.width() - (_grid.isViewportHasVScroll() ? scrollbarDimensions.width : 0);
+      _viewportHeight = _$activeViewport.height() - (_grid.isViewportHasHScroll() ? scrollbarDimensions.height : 0);
+      _moveDistanceForOneCell = {
+        x: _grid.getAbsoluteColumnMinWidth() / 2,
+        y: _grid.getOptions().rowHeight / 2
+      }
 
       var c = _$activeCanvas.offset();
 
@@ -126,6 +150,138 @@
       }
       e.stopImmediatePropagation();
 
+      if (options.autoScroll) {
+        _draggingMouseOffset = getMouseOffsetViewport(e, dd);
+        if (_draggingMouseOffset.isOutsideViewport) {
+          return handleDragOutsideViewport();
+        }
+      }
+      stopIntervalTimer();
+      handleDragTo(e, dd);
+    }
+
+    function getMouseOffsetViewport(e, dd) {
+      var viewportLeft = _$activeViewport.scrollLeft();
+      var viewportTop = _$activeViewport.scrollTop();
+      var viewportRight = viewportLeft + _viewportWidth;
+      var viewportBottom = viewportTop + _viewportHeight;
+
+      var viewportOffset = _$activeViewport.offset();
+      var viewportOffsetLeft = viewportOffset.left;
+      var viewportOffsetTop = viewportOffset.top;
+      var viewportOffsetRight = viewportOffsetLeft + _viewportWidth;
+      var viewportOffsetBottom = viewportOffsetTop + _viewportHeight;
+
+      var result = {
+        e: e,
+        dd: dd,
+        viewport: {
+          left: viewportLeft,
+          top: viewportTop,
+          right: viewportRight,
+          bottom: viewportBottom,
+          offset: {
+            left: viewportOffsetLeft,
+            top: viewportOffsetTop,
+            right: viewportOffsetRight,
+            bottom: viewportOffsetBottom
+          }
+        },
+        // Consider the viewport as the origin, the `offset` is based on the coordinate system:
+        // the cursor is on the viewport's left/bottom when it is less than 0, and on the right/top when greater than 0.
+        offset: {
+          x: 0,
+          y: 0
+        },
+        isOutsideViewport: false
+      }
+      // ... horizontal
+      if (e.pageX < viewportOffsetLeft) {
+        result.offset.x = e.pageX - viewportOffsetLeft;
+      } else if (e.pageX > viewportOffsetRight) {
+        result.offset.x = e.pageX - viewportOffsetRight;
+      }
+      // ... vertical
+      if (e.pageY < viewportOffsetTop) {
+        result.offset.y = viewportOffsetTop - e.pageY;
+      } else if (e.pageY > viewportOffsetBottom) {
+        result.offset.y = viewportOffsetBottom - e.pageY;
+      }
+      result.isOutsideViewport = !!result.offset.x || !!result.offset.y;
+      return result;
+    }
+
+    function handleDragOutsideViewport() {
+      _xDelayForNextCell = options.maxIntervalToShowNextCell - Math.abs(_draggingMouseOffset.offset.x) * options.accelerateInterval;
+      _yDelayForNextCell = options.maxIntervalToShowNextCell - Math.abs(_draggingMouseOffset.offset.y) * options.accelerateInterval;
+      // only one timer is created to handle the case that cursor outside the viewport
+      if (!_autoScrollTimerId) {
+        var xTotalDelay = 0;
+        var yTotalDelay = 0;
+        _autoScrollTimerId = setInterval(function () {
+          var xNeedUpdate = false;
+          var yNeedUpdate = false;
+          // ... horizontal
+          if (_draggingMouseOffset.offset.x) {
+            xTotalDelay += options.minIntervalToShowNextCell;
+            xNeedUpdate = xTotalDelay >= _xDelayForNextCell;
+          } else {
+            xTotalDelay = 0;
+          }
+          // ... vertical
+          if (_draggingMouseOffset.offset.y) {
+            yTotalDelay += options.minIntervalToShowNextCell;
+            yNeedUpdate = yTotalDelay >= _yDelayForNextCell;
+          } else {
+            yTotalDelay = 0;
+          }
+          if (xNeedUpdate || yNeedUpdate) {
+            if (xNeedUpdate) {
+              xTotalDelay = 0;
+            }
+            if (yNeedUpdate) {
+              yTotalDelay = 0;
+            }
+            handleDragToNewPosition(xNeedUpdate, yNeedUpdate);
+          }
+        }, options.minIntervalToShowNextCell);
+      }
+    }
+
+    function handleDragToNewPosition(xNeedUpdate, yNeedUpdate) {
+      var pageX = _draggingMouseOffset.e.pageX;
+      var pageY = _draggingMouseOffset.e.pageY;
+      var mouseOffsetX = _draggingMouseOffset.offset.x;
+      var mouseOffsetY = _draggingMouseOffset.offset.y;
+      var viewportOffset = _draggingMouseOffset.viewport.offset;
+      // ... horizontal
+      if (xNeedUpdate && mouseOffsetX) {
+        if (mouseOffsetX > 0) {
+          pageX = viewportOffset.right + _moveDistanceForOneCell.x;
+        } else {
+          pageX = viewportOffset.left - _moveDistanceForOneCell.x;
+        }
+      }
+      // ... vertical
+      if (yNeedUpdate && mouseOffsetY) {
+        if (mouseOffsetY > 0) {
+          pageY = viewportOffset.top - _moveDistanceForOneCell.y;
+        } else {
+          pageY = viewportOffset.bottom + _moveDistanceForOneCell.y;
+        }
+      }
+      handleDragTo({
+        pageX: pageX,
+        pageY: pageY
+      }, _draggingMouseOffset.dd);
+    }
+
+    function stopIntervalTimer() {
+      clearInterval(_autoScrollTimerId);
+      _autoScrollTimerId = null;
+    }
+
+    function handleDragTo(e, dd) {
       var end = _grid.getCellFromPoint(
         e.pageX - _$activeCanvas.offset().left + _columnOffset,
         e.pageY - _$activeCanvas.offset().top + _rowOffset
@@ -139,6 +295,19 @@
       // ... or frozen row(s)
       if ( _gridOptions.frozenRow >= 0 && (!_isBottomCanvas && (end.row >= _gridOptions.frozenRow)) || (_isBottomCanvas && (end.row < _gridOptions.frozenRow)) ) {
         return;
+      }
+
+      // scrolling the viewport to display the target `end` cell if it is not fully displayed
+      if (options.autoScroll && _draggingMouseOffset) {
+        var endCellBox = _grid.getCellNodeBox(end.row, end.cell);
+        if (!endCellBox) {
+          return;
+        }
+        var viewport = _draggingMouseOffset.viewport;
+        if (endCellBox.left < viewport.left || endCellBox.right > viewport.right
+          || endCellBox.top < viewport.top || endCellBox.bottom > viewport.bottom) {
+          _grid.scrollCellIntoView(end.row, end.cell);
+        }
       }
 
       // ... or regular grid (without any frozen options)
@@ -159,6 +328,7 @@
       _dragging = false;
       e.stopImmediatePropagation();
 
+      stopIntervalTimer();
       _decorator.hide();
       _self.onCellRangeSelected.notify({
         range: new Slick.Range(

--- a/plugins/slick.rowselectionmodel.js
+++ b/plugins/slick.rowselectionmodel.js
@@ -13,12 +13,15 @@
     var _handler = new Slick.EventHandler();
     var _inHandler;
     var _options;
+    var _selector;
     var _defaults = {
-      selectActiveRow: true
+      selectActiveRow: true,
+      cellRangeSelector: undefined
     };
 
     function init(grid) {
       _options = $.extend(true, {}, _defaults, options);
+      _selector = _options.cellRangeSelector;
       _grid = grid;
       _handler.subscribe(_grid.onActiveCellChanged,
           wrapHandler(handleActiveCellChange));
@@ -26,10 +29,25 @@
           wrapHandler(handleKeyDown));
       _handler.subscribe(_grid.onClick,
           wrapHandler(handleClick));
+      if (_selector) {
+        grid.registerPlugin(_selector);
+        _selector.onCellRangeSelecting.subscribe(handleCellRangeSelected);
+        _selector.onCellRangeSelected.subscribe(handleCellRangeSelected);
+        _selector.onBeforeCellRangeSelected.subscribe(handleBeforeCellRangeSelected);
+      }
     }
 
     function destroy() {
       _handler.unsubscribeAll();
+      if (_selector) {
+        _selector.onCellRangeSelecting.unsubscribe(handleCellRangeSelected);
+        _selector.onCellRangeSelected.unsubscribe(handleCellRangeSelected);
+        _selector.onBeforeCellRangeSelected.unsubscribe(handleBeforeCellRangeSelected);
+        _grid.unregisterPlugin(_selector);
+        if (_selector.destroy) {
+          _selector.destroy();
+        }
+      }
     }
 
     function wrapHandler(handler) {
@@ -173,6 +191,21 @@
       e.stopImmediatePropagation();
 
       return true;
+    }
+
+    function handleBeforeCellRangeSelected(e, cell) {
+      if (_grid.getEditorLock().isActive()) {
+        e.stopPropagation();
+        return false;
+      }
+      _grid.setActiveCell(cell.row, cell.cell);
+    }
+
+    function handleCellRangeSelected(e, args) {
+      if (!_grid.getOptions().multiSelect || !_options.selectActiveRow) {
+        return false;
+      }
+      setSelectedRanges([new Slick.Range(args.range.fromRow, 0, args.range.toRow, _grid.getColumns().length - 1)])
     }
 
     $.extend(this, {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -970,6 +970,18 @@ if (typeof Slick === "undefined") {
       return scrollbarDimensions;
     }
 
+    function isViewportHasHScroll() {
+      return viewportHasHScroll
+    }
+
+    function isViewportHasVScroll() {
+      return viewportHasVScroll;
+    }
+
+    function getAbsoluteColumnMinWidth() {
+      return absoluteColumnMinWidth;
+    }
+
     // TODO:  this is static.  need to handle page mutation.
     function bindAncestorScrollEvents() {
       var elem = (hasFrozenRows && !options.frozenBottom) ? $canvasBottomL[0] : $canvasTopL[0];
@@ -6121,6 +6133,9 @@ if (typeof Slick === "undefined") {
       "getFrozenRowOffset": getFrozenRowOffset,
       "setColumnHeaderVisibility": setColumnHeaderVisibility,
       "sanitizeHtmlString": sanitizeHtmlString,
+      "isViewportHasVScroll": isViewportHasVScroll,
+      "isViewportHasHScroll": isViewportHasHScroll,
+      "getAbsoluteColumnMinWidth": getAbsoluteColumnMinWidth,
 
       "init": finishInitialization,
       "destroy": destroy,

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -970,12 +970,11 @@ if (typeof Slick === "undefined") {
       return scrollbarDimensions;
     }
 
-    function isViewportHasHScroll() {
-      return viewportHasHScroll
-    }
-
-    function isViewportHasVScroll() {
-      return viewportHasVScroll;
+    function getDisplayedScrollbarDimensions() {
+      return {
+        width: viewportHasVScroll ? scrollbarDimensions.width : 0,
+        height: viewportHasHScroll ? scrollbarDimensions.height : 0
+      };
     }
 
     function getAbsoluteColumnMinWidth() {
@@ -4940,7 +4939,7 @@ if (typeof Slick === "undefined") {
     }
 
     function internalScrollColumnIntoView(left, right) {
-      var scrollRight = scrollLeft + $viewportScrollContainerX.width();
+      var scrollRight = scrollLeft + $viewportScrollContainerX.width() - (viewportHasVScroll ? scrollbarDimensions.width : 0);
 
       if (left < scrollLeft) {
         $viewportScrollContainerX.scrollLeft(left);
@@ -6133,8 +6132,7 @@ if (typeof Slick === "undefined") {
       "getFrozenRowOffset": getFrozenRowOffset,
       "setColumnHeaderVisibility": setColumnHeaderVisibility,
       "sanitizeHtmlString": sanitizeHtmlString,
-      "isViewportHasVScroll": isViewportHasVScroll,
-      "isViewportHasHScroll": isViewportHasHScroll,
+      "getDisplayedScrollbarDimensions": getDisplayedScrollbarDimensions,
       "getAbsoluteColumnMinWidth": getAbsoluteColumnMinWidth,
 
       "init": finishInitialization,


### PR DESCRIPTION
(Related: https://github.com/6pac/SlickGrid/issues/114)

This PR allow auto scroll when dragging to make selection using `cellrangeselector`.

[Here is the example page](https://aasdkl.github.io/SlickGrid/examples/example-auto-scroll-when-dragging.html)

The scrolling speed is based on: `Math.max(MIN, MAX - DelayPerPx * cursorPx)`

I'm not sure that setting the option ON by default is appropriate or not.

---

Also, a cypress test is provided. But I'm afraid that these case may failed in some time because they have compared the dragging time interval:

- should MIN interval take effect when auto scroll: 30ms -> 90ms

  - By default the MIN interval to show next cell is `30ms`.
  - In the test I set the interval to `90ms` (3 times of the default).
  - So ideally if we scrolling to same row by MIN interval, the used time should be 3 times slower than default.
  - Considering the threshold, 1.5 times slower than default is passed:
 
  ```js
  expect(newInterval).to.be.greaterThan(1.5 * defaultInterval); // max scrolling speed is slower than before
  ```

- should MAX interval take effect when auto scroll: 600ms -> 200ms

  - By default the MAX interval to show next cell is `600ms`.
  - In the test I set the interval to `200ms` (1/3 of the default).
  - So ideally if we scrolling to same row by MAX interval, the used time should be 3 times faster than default.
  - Considering the threshold, 1.5 times faster than default is passed:

  ```js
  expect(1.5 * newInterval).to.be.lessThan(defaultInterval); // min scrolling speed is quicker than before
  ```

- should Delay per Px take effect when auto scroll: 5ms/px -> 50ms/px'

  - By default the Delay per Px is `5ms/px`.
  - In the test I set it to `50ms/px` (10 times of the default).
  - So ideally if we scrolling to same row, and set cursor to 17px, the new interval will be set to MIN interval (`Math.max(30, 600 - 50 * 17) = 30ms`), and the used time should be more than 10 times faster than default.
  - Considering the threshold, 5 times faster than default is passed:

  ```js
  expect(5 * newInterval).to.be.lessThan(defaultInterval); // scrolling speed is quicker than before
  ```
