### PR TITLE
export Slick.Controls.GridMenu.hideMenu()

### DIFF
--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -667,6 +667,7 @@
       "showGridMenu": showGridMenu,
       "setOptions": setOptions,
       "updateAllTitles": updateAllTitles,
+      "hideMenu": hideMenu,
 
       "onAfterMenuShow": new Slick.Event(),
       "onBeforeMenuShow": new Slick.Event(),


### PR DESCRIPTION
So that menu can be hidden when user clicks somewhere else