### PR TITLE
bugfix: Apply auto scroll when dragging on RowMoveManager plugin

### DIFF
--- a/examples/example-drag-row-between-grids.html
+++ b/examples/example-drag-row-between-grids.html
@@ -90,6 +90,7 @@
 <script src="../lib/jquery.event.drop-2.3.0.js"></script>
 
 <script src="../slick.core.js"></script>
+<script src="../plugins/slick.cellrangedecorator.js"></script>
 <script src="../plugins/slick.cellrangeselector.js"></script>
 <script src="../plugins/slick.cellselectionmodel.js"></script>
 <script src="../plugins/slick.rowselectionmodel.js"></script>
@@ -187,11 +188,23 @@ $(function () {
   
   grid = new Slick.Grid("#myGrid", data, columns, options);
 
-  grid.setSelectionModel(new Slick.RowSelectionModel());
+  grid.setSelectionModel(new Slick.RowSelectionModel({
+      cellRangeSelector: new Slick.CellRangeSelector({
+        selectionCss: {
+          "border": "none"
+        }
+      })
+  }));
 
   toGrid = new Slick.Grid("#myGrid2", data2, columns2, options);
 
-  toGrid.setSelectionModel(new Slick.RowSelectionModel());
+  toGrid.setSelectionModel(new Slick.RowSelectionModel({
+      cellRangeSelector: new Slick.CellRangeSelector({
+        selectionCss: {
+          "border": "none"
+        }
+      })
+  }));
 
   var moveRowsPlugin = new Slick.CrossGridRowMoveManager({
     cancelEditOnDrag: true,

--- a/examples/example-drag-row-between-grids.html
+++ b/examples/example-drag-row-between-grids.html
@@ -189,21 +189,13 @@ $(function () {
   grid = new Slick.Grid("#myGrid", data, columns, options);
 
   grid.setSelectionModel(new Slick.RowSelectionModel({
-      cellRangeSelector: new Slick.CellRangeSelector({
-        selectionCss: {
-          "border": "none"
-        }
-      })
+    dragToSelect: true
   }));
 
   toGrid = new Slick.Grid("#myGrid2", data2, columns2, options);
 
   toGrid.setSelectionModel(new Slick.RowSelectionModel({
-      cellRangeSelector: new Slick.CellRangeSelector({
-        selectionCss: {
-          "border": "none"
-        }
-      })
+    dragToSelect: true
   }));
 
   var moveRowsPlugin = new Slick.CrossGridRowMoveManager({

--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -126,6 +126,7 @@
 
   <script src="../slick.core.js"></script>
   <script src="../slick.formatters.js"></script>
+  <script src="../plugins/slick.cellrangedecorator.js"></script>
   <script src="../plugins/slick.cellrangeselector.js"></script>
   <script src="../plugins/slick.checkboxselectcolumn.js"></script>
   <script src="../plugins/slick.rowdetailview.js"></script>
@@ -254,7 +255,14 @@
       grid = new Slick.Grid("#myGrid", dataView, columns, options);
 
       // register the Selection Model that will be used for all Plugins 
-      grid.setSelectionModel(new Slick.RowSelectionModel({ selectActiveRow: false }));
+      grid.setSelectionModel(new Slick.RowSelectionModel({
+        selectActiveRow: false,
+        cellRangeSelector: new Slick.CellRangeSelector({
+          selectionCss: {
+            "border": "none"
+          }
+        })
+      }));
 
       // register all Plugins (Row Selection / Row Detail)
       grid.registerPlugin(checkboxSelectorPlugin);

--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -257,11 +257,7 @@
       // register the Selection Model that will be used for all Plugins 
       grid.setSelectionModel(new Slick.RowSelectionModel({
         selectActiveRow: false,
-        cellRangeSelector: new Slick.CellRangeSelector({
-          selectionCss: {
-            "border": "none"
-          }
-        })
+        dragToSelect: true
       }));
 
       // register all Plugins (Row Selection / Row Detail)

--- a/examples/example9-row-reordering-simple.html
+++ b/examples/example9-row-reordering-simple.html
@@ -47,6 +47,7 @@
 <script src="../lib/jquery.event.drop-2.3.0.js"></script>
 
 <script src="../slick.core.js"></script>
+<script src="../plugins/slick.cellrangedecorator.js"></script>
 <script src="../plugins/slick.cellrangeselector.js"></script>
 <script src="../plugins/slick.cellselectionmodel.js"></script>
 <script src="../plugins/slick.rowselectionmodel.js"></script>
@@ -107,7 +108,13 @@ $(function () {
   
   grid = new Slick.Grid("#myGrid", data, columns, options);
 
-  grid.setSelectionModel(new Slick.RowSelectionModel());
+  grid.setSelectionModel(new Slick.RowSelectionModel({
+      cellRangeSelector: new Slick.CellRangeSelector({
+        selectionCss: {
+          "border": "none"
+        },
+      })
+  }));
 
   var moveRowsPlugin = new Slick.RowMoveManager({
     cancelEditOnDrag: true

--- a/examples/example9-row-reordering-simple.html
+++ b/examples/example9-row-reordering-simple.html
@@ -112,7 +112,7 @@ $(function () {
       cellRangeSelector: new Slick.CellRangeSelector({
         selectionCss: {
           "border": "none"
-        },
+        }
       })
   }));
 

--- a/examples/example9-row-reordering-simple.html
+++ b/examples/example9-row-reordering-simple.html
@@ -109,11 +109,7 @@ $(function () {
   grid = new Slick.Grid("#myGrid", data, columns, options);
 
   grid.setSelectionModel(new Slick.RowSelectionModel({
-      cellRangeSelector: new Slick.CellRangeSelector({
-        selectionCss: {
-          "border": "none"
-        }
-      })
+    dragToSelect: true
   }));
 
   var moveRowsPlugin = new Slick.RowMoveManager({

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -41,6 +41,7 @@
     var _autoScrollTimerId;
     var _xDelayForNextCell;
     var _yDelayForNextCell;
+    var _isRowMoveRegistered = false;
 
     // Scrollings
     var _scrollTop = 0;
@@ -92,6 +93,7 @@
         x: _grid.getAbsoluteColumnMinWidth() / 2,
         y: _grid.getOptions().rowHeight / 2
       }
+      _isRowMoveRegistered = hasRowMoveManager();
 
       var c = _$activeCanvas.offset();
 
@@ -145,10 +147,12 @@
     }
 
     function handleDrag(e, dd) {
-      if (!_dragging) {
+      if (!_dragging && !_isRowMoveRegistered) {
         return;
       }
-      e.stopImmediatePropagation();
+      if (!_isRowMoveRegistered) {
+        e.stopImmediatePropagation();
+      }
 
       if (options.autoScroll) {
         _draggingMouseOffset = getMouseOffsetViewport(e, dd);
@@ -315,13 +319,19 @@
         return;
       }
 
-      dd.range.end = end;
+      if (dd && dd.range) {
+        dd.range.end = end;
 
-      var range = new Slick.Range(dd.range.start.row, dd.range.start.cell, end.row, end.cell);
-      _decorator.show(range);
-      _self.onCellRangeSelecting.notify({
-        range: range
-      });
+        var range = new Slick.Range(dd.range.start.row, dd.range.start.cell, end.row, end.cell);
+        _decorator.show(range);
+        _self.onCellRangeSelecting.notify({
+          range: range
+        });
+      }
+    }
+
+    function hasRowMoveManager() {
+      return !!(_grid.getPluginByName('RowMoveManager') || _grid.getPluginByName('CrossGridRowMoveManager'));
     }
 
     function handleDragEnd(e, dd) {

--- a/plugins/slick.crossgridrowmovemanager.js
+++ b/plugins/slick.crossgridrowmovemanager.js
@@ -90,7 +90,7 @@
         _grid.getEditorLock().cancelCurrentEdit();
       }
 
-      if (_grid.getEditorLock().isActive() || !/move|selectAndMove/.test(_grid.getColumns()[cell.cell].behavior)) {
+      if (_grid.getEditorLock().isActive() || !isHandlerColumn(cell.cell)) {
         return false;
       }
 
@@ -260,6 +260,10 @@
       _usabilityOverride = overrideFn;
     }
 
+    function isHandlerColumn(columnIndex) {
+      return /move|selectAndMove/.test(_grid.getColumns()[columnIndex].behavior);
+    }
+
     $.extend(this, {
       "onBeforeMoveRows": new Slick.Event(),
       "onMoveRows": new Slick.Event(),
@@ -269,7 +273,8 @@
       "getColumnDefinition": getColumnDefinition,
       "setOptions": setOptions,
       "usabilityOverride": usabilityOverride,
-      "pluginName": "RowMoveManager"
+      "isHandlerColumn": isHandlerColumn,
+      "pluginName": "CrossGridRowMoveManager"
     });
   }
 })(jQuery);

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -85,7 +85,7 @@
         _grid.getEditorLock().cancelCurrentEdit();
       }
 
-      if (_grid.getEditorLock().isActive() || !/move|selectAndMove/.test(_grid.getColumns()[cell.cell].behavior)) {
+      if (_grid.getEditorLock().isActive() || !isHandlerColumn(cell.cell)) {
         return false;
       }
 
@@ -249,6 +249,10 @@
       _usabilityOverride = overrideFn;
     }
 
+    function isHandlerColumn(columnIndex) {
+      return /move|selectAndMove/.test(_grid.getColumns()[columnIndex].behavior);
+    }
+
     $.extend(this, {
       "onBeforeMoveRows": new Slick.Event(),
       "onMoveRows": new Slick.Event(),
@@ -258,6 +262,7 @@
       "getColumnDefinition": getColumnDefinition,
       "setOptions": setOptions,
       "usabilityOverride": usabilityOverride,
+      "isHandlerColumn": isHandlerColumn,
       "pluginName": "RowMoveManager"
     });
   }

--- a/plugins/slick.rowselectionmodel.js
+++ b/plugins/slick.rowselectionmodel.js
@@ -14,6 +14,7 @@
     var _inHandler;
     var _options;
     var _selector;
+    var _isRowMoveManagerHandler;
     var _defaults = {
       selectActiveRow: true,
       cellRangeSelector: undefined
@@ -204,7 +205,11 @@
     }
 
     function handleBeforeCellRangeSelected(e, cell) {
-      if (_grid.getEditorLock().isActive()) {
+      if (!_isRowMoveManagerHandler) {
+        var rowMoveManager = _grid.getPluginByName('RowMoveManager') || _grid.getPluginByName('CrossGridRowMoveManager');
+        _isRowMoveManagerHandler = rowMoveManager ? rowMoveManager.isHandlerColumn : $.noop;
+      }
+      if (_grid.getEditorLock().isActive() || _isRowMoveManagerHandler(cell.cell)) {
         e.stopPropagation();
         return false;
       }

--- a/plugins/slick.rowselectionmodel.js
+++ b/plugins/slick.rowselectionmodel.js
@@ -17,6 +17,8 @@
     var _isRowMoveManagerHandler;
     var _defaults = {
       selectActiveRow: true,
+      dragToSelect: false,
+      autoScrollWhenDrag: true,
       cellRangeSelector: undefined
     };
 
@@ -24,6 +26,19 @@
       _options = $.extend(true, {}, _defaults, options);
       _selector = _options.cellRangeSelector;
       _grid = grid;
+
+      if (!_selector && _options.dragToSelect) {
+        if (!Slick.CellRangeDecorator) {
+            throw new Error("Slick.CellRangeDecorator is required when option dragToSelect set to true");
+        }
+        _selector = new Slick.CellRangeSelector({
+          selectionCss: {
+            "border": "none"
+          },
+          autoScroll: _options.autoScrollWhenDrag
+        })
+      }
+
       _handler.subscribe(_grid.onActiveCellChanged,
           wrapHandler(handleActiveCellChange));
       _handler.subscribe(_grid.onKeyDown,


### PR DESCRIPTION
The auto scroll behavious is added in this PR: https://github.com/6pac/SlickGrid/pull/656

Since it was modified on the `SelectionModel`,  it should be able to use with plugin `RowMoveManager` by some small fix:

```diff
+<script src="../plugins/slick.cellrangedecorator.js"></script>

-  grid.setSelectionModel(new Slick.RowSelectionModel());
+  grid.setSelectionModel(new Slick.RowSelectionModel({
+      cellRangeSelector: new Slick.CellRangeSelector({
+        selectionCss: {
+          "border": "none"
+        },
+      })
+  }));
```

However, when dragging on the row handler, the `RowSelectionModel` will be called before `RowMoveManager`, and the selected rows will be always be updated by `RowSelectionModel`.

To avoid the update, I extract the method `isHandlerColumn()` in `RowMoveManager`/`CrossGridRowMoveManager`, and add a condition in `RowSelectionModel` on drag start.

---

This 2 examples are updated, and you can drag to select rows now:

- [example-drag-row-between-grids.html](https://aasdkl.github.io/SlickGrid/examples/example-drag-row-between-grids.html)
- [example9-row-reordering-simple.html](https://aasdkl.github.io/SlickGrid/examples/example9-row-reordering-simple.html)

For other files use `RowMoveManager` plugin:

- The drag operation is already for dragging to recycle bin.

  - [example9-row-reordering.html](https://6pac.github.io/SlickGrid/examples/example9-row-reordering.html)
  - [example-frozen-row-reordering.html](https://6pac.github.io/SlickGrid/examples/example-frozen-row-reordering.html)

- The `RowSelectionModel` already contains the option: `selectActiveRow: false`, and I think it would be strange to add the dragToSelect behavious on it.

  - [example-row-detail-selection-and-move.html](https://6pac.github.io/SlickGrid/examples/example-row-detail-selection-and-move.html)

---

**Update:**

After some modification, this file also supports the dragging now

  - [example-row-detail-selection-and-move.html](https://aasdkl.github.io/SlickGrid/examples/example-row-detail-selection-and-move.html)

And the way to add dragging behavious in `RowSelectionModel` is also updated to:

```diff
+<script src="../plugins/slick.cellrangedecorator.js"></script>

-  grid.setSelectionModel(new Slick.RowSelectionModel());
+  grid.setSelectionModel(new Slick.RowSelectionModel({
+    dragToSelect: true
+  }));
```