### PR TITLE
fix: adjust the left/right canvas width properly when fullWidthRows is used

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -828,7 +828,18 @@ if (typeof Slick === "undefined") {
         }
       }
       var totalRowWidth = canvasWidthL + canvasWidthR;
-      return options.fullWidthRows ? Math.max(totalRowWidth, availableWidth) : totalRowWidth;
+      if (options.fullWidthRows) {
+        var extraWidth = Math.max(totalRowWidth, availableWidth) - totalRowWidth;
+        if (extraWidth > 0) {
+          totalRowWidth += extraWidth;
+          if (hasFrozenColumns()) {
+            canvasWidthR += extraWidth;
+          } else {
+            canvasWidthL += extraWidth;
+          }
+        }
+      }
+      return totalRowWidth;
     }
 
     function updateCanvasWidth(forceColumnWidthsUpdate) {


### PR DESCRIPTION
When `fullWidthRows: true` is used in options, and when the viewport width is larger than the canvas width, slick grid does not create rows wide enough to fill the viewport.

This happens because although the total canvas width has been calculated to match that of viewport, the total canvas width is not distributed to the left/right canvas.

To illustrate:

 **Without the fix and with this option: `{ fullWidthRows: true }`** , there is an area of white space at the right side of the canvas (selected row is colored in blue to make it more obvious):
<img width="813" alt="current" src="https://user-images.githubusercontent.com/36215332/151564128-dce11837-52e3-4872-a2c9-1f8ee0d5361a.png">

**And with this option: `{ fullWidthRows: true,     frozenColumn: 2 }`**:
<img width="813" alt="current_with_col_freeze" src="https://user-images.githubusercontent.com/36215332/151564690-de8459e5-6d1f-48d8-91d9-d8b6f89265be.png">

Basically visually the fullWidthRows has no effect.

**With the fix and with this option: `{ fullWidthRows: true }`**:
<img width="813" alt="fix" src="https://user-images.githubusercontent.com/36215332/151565017-e48b36e0-8913-461d-84af-03437775ab18.png">
**Same for frozen columns `{ fullWidthRows: true,     frozenColumn: 2 }`**:
<img width="813" alt="fix_with_column_freeze" src="https://user-images.githubusercontent.com/36215332/151565073-6f84b178-a45a-4222-be54-2e8d24f4907e.png">

