### PR TITLE
setColumns should update the global treeColumns and columns variable

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2916,13 +2916,8 @@ if (typeof Slick === "undefined") {
     function setColumns(columnDefinitions) {
       trigger(self.onBeforeSetColumns, { previousColumns: columns, newColumns: columnDefinitions, grid: self });
 
-      var _treeColumns = new Slick.TreeColumns(columnDefinitions);
-      if (_treeColumns.hasDepth()) {
-        treeColumns = _treeColumns;
-        columns = treeColumns.extractColumns();
-      } else {
-        columns = columnDefinitions;
-      }
+      treeColumns = new Slick.TreeColumns(columnDefinitions);
+      columns = treeColumns.extractColumns();
 
       updateColumnProps();
       updateColumnCaches();


### PR DESCRIPTION
Calling `setColumns` does not update the global treeColumns and columns variable when there is no tree columns (e.g. flat grid). This causes a bug that the column collection cannot be updated once grid is intialized