### PR TITLE
Allow multiple rows toggle

### DIFF
--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -183,7 +183,10 @@
       } else {
         _grid.setSelectedRows(_grid.getSelectedRows().concat(row), "click.toggle");
       }
-      _grid.setActiveCell(row, getCheckboxColumnCellIndex());
+      
+      if (_options.setActiveCellOnToggle !== false) {
+        _grid.setActiveCell(row, getCheckboxColumnCellIndex());
+      }
     }
 
     function selectRows(rowArray) {


### PR DESCRIPTION
The PR adds option `setActiveCellOnToggle`, which if set to false the plugin will not call `setActiveCell` after a checkbox is toggled.

`setActiveCell` when called end up triggering `onSelectedRowsChanged` which calls `handleSelectedRowsChanged` which deselects all other rows.

By using `setActiveCellOnToggle: false` option to prevent calling `setActiveCell`, multiple rows can be toggled