### PR TITLE
Fix bug in getColContentSize when data is an object

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2465,16 +2465,18 @@ if (typeof Slick === "undefined") {
       }
 
       // select rows to evaluate using rowSelectionMode and rowSelectionCount
-      var rows = getData();
-      if (rows.getItems) { rows = rows.getItems(); }
-
-      if (rows.length === 0) { return headerWidth; }
+      if (getDataLength() === 0) { return headerWidth; }
 
       var rowSelectionMode = (isInit ? autoSize.rowSelectionModeOnInit : undefined) || autoSize.rowSelectionMode;
 
-      if (rowSelectionMode === Slick.RowSelectionMode.FirstRow) { rows = rows.slice(0,1); }
-      if (rowSelectionMode === Slick.RowSelectionMode.LastRow) { rows = rows.slice(rows.length -1, rows.length); }
-      if (rowSelectionMode === Slick.RowSelectionMode.FirstNRows) { rows = rows.slice(0, autoSize.rowSelectionCount); }
+      var rowsStart = 0, rowsEnd = getDataLength();
+      if (rowSelectionMode === Slick.RowSelectionMode.FirstRow) { rowsStart = 0; rowsEnd = 1; }
+      if (rowSelectionMode === Slick.RowSelectionMode.LastRow) { rowsStart = getDataLength() - 1; rowsEnd = getDataLength(); }
+      if (rowSelectionMode === Slick.RowSelectionMode.FirstNRows) { rowsStart = 0; rowsEnd = autoSize.rowSelectionCount; }
+
+      // make a shalow copy of the rows
+      var rows = [];
+      for (i = rowsStart; i < rowsEnd; i++) rows.push(getDataItem(i));
 
       // now use valueFilterMode to further filter selected rows
       if (autoSize.valueFilterMode === Slick.ValueFilterMode.DeDuplicate) {


### PR DESCRIPTION
fix https://github.com/6pac/SlickGrid/issues/688

When the Slick.Grid constructor data is set to a custom object (exposing `getItem(index)` and `getLength()` functions), the code in `getColContentSize()` (https://github.com/6pac/SlickGrid/blob/master/slick.grid.js#L2468-L2477) sets `rows` to an object `{ getItem: .., getLength: .. }` instead of an array and so the following calls to `rows.slice` are invalid and throw `TypeError: rows.slice is not a function`.

Note: with this PR the function works correctly without throwing, however it makes a shallow copy before proceeding . A better solution will change the code below to work directly with `getItem` rather than with `rows[..]`