### PR TITLE
fixed rgba in box-shadow that causes scss error

### DIFF
--- a/slick.grid.css
+++ b/slick.grid.css
@@ -198,7 +198,7 @@ classes should alter those!
 .slick-reorder-shadow-row {
   position: absolute;
   z-index: 999999;
-  box-shadow: rgb(0 0 0 / 20%) 8px 2px 8px 4px, rgb(0 0 0 / 19%) 2px 2px 0px 0px;
+  box-shadow: rgba(0, 0, 0, 0.2) 8px 2px 8px 4px, rgba(0, 0, 0, 0.19) 2px 2px 0px 0px;
 }
 
 .slick-selection {


### PR DESCRIPTION
fixing this scss error
```
Fatal error: Error: Function rgb is missing argument $green.
        on line 39 of my_project/css/style.scss
        from line 1 of my_project/css/app.scss
>>   box-shadow: rgb(0 0 0 / 20%) 8px 2px 8px 4px, rgb(0 0 0 / 19%) 2px 2px 0px
   --------------^
```