### PR TITLE
fix: auto-scroll should work even without jQueryUI

### DIFF
--- a/examples/example-auto-scroll-when-dragging.html
+++ b/examples/example-auto-scroll-when-dragging.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: Spreadsheet with Excel compatible cut and paste</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
     .cell-effort-driven {

--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -5,7 +5,6 @@
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <link rel="stylesheet" href="../slick.grid.css" type="text/css" />
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css" />
   <link rel="stylesheet" href="examples.css" type="text/css" />
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css" />
   <link rel="stylesheet" href="../plugins/slick.rowdetailview.css" type="text/css" />
@@ -121,7 +120,6 @@
   <script src="../lib/firebugx.js"></script>
 
   <script src="../lib/jquery-3.1.0.js"></script>
-  <script src="../lib/jquery-ui.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
   <script src="../slick.core.js"></script>

--- a/slick.grid.css
+++ b/slick.grid.css
@@ -14,8 +14,8 @@ classes should alter those!
 
 .slick-header.ui-state-default {
   overflow: inherit;
+  border-top: 1px solid #d3d3d3;
 }
-
 .slick-header::-webkit-scrollbar,  .slick-headerrow::-webkit-scrollbar, .slick-footerrow::-webkit-scrollbar {
   display: none
 }


### PR DESCRIPTION
- removing jQueryUI CSS from the auto-scroll example made it stopped working, after troubleshooting section by section, it only seem to be caused by an extra border around the slickgrid header. We can copy over the same border from jQueryUI into SlickGrid CSS and auto-scroll works again :)

![brave_7nZgMJ6yJh](https://user-images.githubusercontent.com/643976/197317977-835348f7-634d-4515-ab82-3c8c50f0b9d1.gif)
