### PR TITLE
chore: remove jQueryUI from nearly all examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ npm run cypress     # open Cypress tool
 ```
 Once the Cypress UI is open, you can then click on "Run all Specs" to execute all E2E browser tests.
 
-### SlickGrid 3.x drops jQueryUI
+## SlickGrid 3.x drops jQueryUI requirement
 
-Great news we no longer require [jQueryUI](https://jqueryui.com/) in SlickGrid 3.x, we removed all associated code and replaced it with [SortableJS](https://sortablejs.github.io/Sortable/) which is a lot more modern. Please read [SlickGrid 3.0 - Annoucement & Migration](https://github.com/6pac/SlickGrid/wiki/Major-version-3.0----Removal-of-jQueryUI-requirement-(replaced-by-SortableJS)) Wiki for more info.
+Great news we no longer require [jQueryUI](https://jqueryui.com/) in SlickGrid 3.0.0, we removed all associated code and replaced it with [SortableJS](https://sortablejs.github.io/Sortable/) which is a lot more modern and touch friendly. Please read [SlickGrid 3.0 - Annoucement & Migration](https://github.com/6pac/SlickGrid/wiki/Major-version-3.0----Removal-of-jQueryUI-requirement-(replaced-by-SortableJS)) Wiki for more info.

--- a/examples/example-0070-plugin-state.html
+++ b/examples/example-0070-plugin-state.html
@@ -3,7 +3,6 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <title>SlickGrid example: Plugin: State</title>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="../plugins/slick.headerbuttons.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
@@ -45,7 +44,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui-1.11.3.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-autotooltips.html
+++ b/examples/example-autotooltips.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid plugin example: AutoTooltips</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
     .ui-tooltip {
@@ -47,7 +46,6 @@ grid.render();</pre>
 </table>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-bootstrap-3-header.html
+++ b/examples/example-bootstrap-3-header.html
@@ -6,7 +6,6 @@
   <title>SlickGrid example: Basic Grid with Bootstrap 3 css</title>
   <link rel="stylesheet" href="../css/bootstrap.css" type="text/css"/>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
   #myGrid01, #myGrid02 {
@@ -36,7 +35,6 @@
 </table>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -3,7 +3,6 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
@@ -100,7 +99,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../plugins/slick.checkboxselectcolumn.js"></script>

--- a/examples/example-checkbox-row-select.html
+++ b/examples/example-checkbox-row-select.html
@@ -4,7 +4,6 @@
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" crossorigin="anonymous">
@@ -76,7 +75,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-colspan.html
+++ b/examples/example-colspan.html
@@ -3,7 +3,6 @@
 <head>
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
 </head>
 <body>

--- a/examples/example-column-group.html
+++ b/examples/example-column-group.html
@@ -3,7 +3,6 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
@@ -39,7 +38,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-composite-editor-item-details.html
+++ b/examples/example-composite-editor-item-details.html
@@ -5,8 +5,8 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: CompositeEditor</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <style>
     .cell-title {
       font-weight: bold;
@@ -100,9 +100,9 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="../lib/jquery.tmpl.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
 <script src="../slick.interactions.js"></script>
@@ -129,8 +129,8 @@
     {id: "desc", name: "Description", field: "description", width: 100, editor: Slick.Editors.Text},
     {id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Text},
     {id: "percent", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete},
-    {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date},
-    {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date},
+    {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Flatpickr},
+    {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Flatpickr},
     {id: "effort-driven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark, editor: Slick.Editors.Checkbox}
   ];
   var options = {

--- a/examples/example-composite-editor-modal-dialog.html
+++ b/examples/example-composite-editor-modal-dialog.html
@@ -6,8 +6,9 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: CompositeEditor</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css" />
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css" />
+  <link rel="stylesheet" href="examples-unicode-icons.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <style>
     .cell-title {
       font-weight: bold;
@@ -167,7 +168,7 @@
   <script src="../lib/firebugx.js"></script>
 
   <script src="../lib/jquery-3.1.0.js"></script>
-  <script src="../lib/jquery-ui.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
   <script src="../slick.core.js"></script>
@@ -214,8 +215,8 @@
       { id: "desc", name: "Description", field: "description", width: 100, editor: Slick.Editors.LongText, massUpdate: false, },
       { id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Integer, massUpdate: true, validator: durationValidator, formatter: durationFormatter },
       { id: "percent", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete },
-      { id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date, massUpdate: true, },
-      { id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date, massUpdate: false, },
+      { id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Flatpickr, massUpdate: true, },
+      { id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Flatpickr, massUpdate: false, },
       { id: "effort-driven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark, editor: Slick.Editors.Checkbox, massUpdate: true, }
     ];
     var options = {

--- a/examples/example-composite-editor-modal-dialog.html
+++ b/examples/example-composite-editor-modal-dialog.html
@@ -6,9 +6,8 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: CompositeEditor</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css" />
-  <link rel="stylesheet" href="examples-unicode-icons.css" type="text/css"/>
+  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css" />
   <link rel="stylesheet" href="examples.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <style>
     .cell-title {
       font-weight: bold;
@@ -168,7 +167,7 @@
   <script src="../lib/firebugx.js"></script>
 
   <script src="../lib/jquery-3.1.0.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+  <script src="../lib/jquery-ui.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
   <script src="../slick.core.js"></script>
@@ -215,8 +214,8 @@
       { id: "desc", name: "Description", field: "description", width: 100, editor: Slick.Editors.LongText, massUpdate: false, },
       { id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Integer, massUpdate: true, validator: durationValidator, formatter: durationFormatter },
       { id: "percent", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete },
-      { id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Flatpickr, massUpdate: true, },
-      { id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Flatpickr, massUpdate: false, },
+      { id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date, massUpdate: true, },
+      { id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date, massUpdate: false, },
       { id: "effort-driven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark, editor: Slick.Editors.Checkbox, massUpdate: true, }
     ];
     var options = {

--- a/examples/example-custom-column-value-extractor.html
+++ b/examples/example-custom-column-value-extractor.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: Custom column value extractor</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
 </head>
 <body>

--- a/examples/example-drag-row-between-grids.html
+++ b/examples/example-drag-row-between-grids.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: Dragging a row between grids</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
     .cell-effort-driven {
@@ -85,7 +84,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-excel-compatible-spreadsheet-dataview.html
+++ b/examples/example-excel-compatible-spreadsheet-dataview.html
@@ -5,8 +5,9 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: Spreadsheet with Excel compatible cut and paste</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="examples-unicode-icons.css" type="text/css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <style>
     .slick-cell.copied {
       background: blue;
@@ -67,8 +68,8 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
 <script src="../slick.interactions.js"></script>
@@ -186,7 +187,7 @@
   }
   
   columns[4] = {id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete};
-  columns[5] = {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date};
+  columns[5] = {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Flatpickr};
  
 
   $(function () {

--- a/examples/example-excel-compatible-spreadsheet.html
+++ b/examples/example-excel-compatible-spreadsheet.html
@@ -5,8 +5,8 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: Spreadsheet with Excel compatible cut and paste</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="examples-unicode-icons.css" type="text/css"/>
   <style>
     .slick-cell.copied {
       background: blue;
@@ -62,7 +62,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
@@ -186,7 +185,7 @@
   }
   
   columns[4] = {id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete};
-  columns[5] = {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date};
+  columns[5] = {id: "start", name: "Start", field: "start", minWidth: 60};
  
 
   $(function () {

--- a/examples/example-explicit-initialization.html
+++ b/examples/example-explicit-initialization.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: Explicit grid initialization</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
 </head>
 <body>

--- a/examples/example-footer-totals.html
+++ b/examples/example-footer-totals.html
@@ -3,7 +3,6 @@
 <head>
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>Footer Row with Totals</title>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
@@ -36,7 +35,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-frozen-columns-and-column-group.html
+++ b/examples/example-frozen-columns-and-column-group.html
@@ -3,7 +3,6 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
@@ -46,7 +45,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-frozen-columns-and-rows-spreadsheet.html
+++ b/examples/example-frozen-columns-and-rows-spreadsheet.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid Example: Spreadsheet with Frozen Rows and Columns</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
     .slick-cell.copied {
@@ -36,7 +35,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-frozen-columns-autoheight.html
+++ b/examples/example-frozen-columns-autoheight.html
@@ -43,7 +43,6 @@
 </div>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-frozen-columns-large.html
+++ b/examples/example-frozen-columns-large.html
@@ -6,9 +6,10 @@
   <title>SlickGrid example: Frozen Columns</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css" media="screen" charset="utf-8"/>
   <link rel="stylesheet" href="../controls/slick.pager.css" type="text/css" media="screen" charset="utf-8"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css" media="screen" charset="utf-8"/>
+  <link rel="stylesheet" href="examples-unicode-icons.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css" media="screen" charset="utf-8"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <style>
     .cell-title {
       font-weight: bold;
@@ -44,7 +45,7 @@
 <div style="width:2048px;">
   <div class="grid-header" style="width:100%">
     <label>SlickGrid</label>
-    <span style="float:right" class="ui-icon ui-icon-search" title="Toggle search panel"
+    <span style="float:right;margin:0px 4px auto 6px;background:transparent;cursor:pointer;" class="slick-icon-search" title="Toggle search panel"
           onclick="toggleFilterRow()"></span>
   </div>
   <div id="myGrid" style="width:100%;height:1024px;"></div>
@@ -104,7 +105,7 @@
 <script language="JavaScript" src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
@@ -137,9 +138,9 @@ var columns = [
   ,
   {id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentComplete, editor: Slick.Editors.PercentComplete, sortable: true}
   ,
-  {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date, sortable: true}
+  {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Flatpickr, sortable: true}
   ,
-  {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date, sortable: true}
+  {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Flatpickr, sortable: true}
   ,
   {id: "effort-driven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.YesNo, editor: Slick.Editors.YesNoSelect, cannotTriggerInsert: true, sortable: true}
   ,
@@ -757,19 +758,19 @@ $(function () {
   var h_runfilters = null;
 
   // wire up the slider to apply the filter to the model
-  $("#pcSlider,#pcSlider2").slider({
-    "range": "min",
-    "slide": function (event, ui) {
-      Slick.GlobalEditorLock.cancelCurrentEdit();
+  var slider = document.getElementById("pcSlider");
+  var slider2 = document.getElementById("pcSlider2");
+  var sliderCallback = function() {
+    Slick.GlobalEditorLock.cancelCurrentEdit();
 
-      if (percentCompleteThreshold != ui.value) {
-        window.clearTimeout(h_runfilters);
-        h_runfilters = window.setTimeout(dataView.refresh, 10);
-        percentCompleteThreshold = ui.value;
-      }
+    if (percentCompleteThreshold != this.value) {
+      window.clearTimeout(h_runfilters);
+      h_runfilters = window.setTimeout(dataView.refresh, 10);
+      percentCompleteThreshold = this.value;
     }
-  });
-
+  }
+  slider.oninput = sliderCallback;
+  slider2.oninput = sliderCallback;
 
   // wire up the search textbox to apply the filter to the model
   $("#txtSearch,#txtSearch2").keyup(function (e) {
@@ -805,8 +806,6 @@ $(function () {
   dataView.setItems(data);
   dataView.setFilter(myFilter);
   dataView.endUpdate();
-
-  $("#gridContainer").resizable();
 
   $('#setFrozenColumn').click(function () {
     var val = -1;

--- a/examples/example-frozen-columns.html
+++ b/examples/example-frozen-columns.html
@@ -6,9 +6,10 @@
   <title>SlickGrid example: Frozen Columns</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css" media="screen" charset="utf-8"/>
   <link rel="stylesheet" href="../controls/slick.pager.css" type="text/css" media="screen" charset="utf-8"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css" media="screen" charset="utf-8"/>
+  <link rel="stylesheet" href="examples-unicode-icons.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css" media="screen" charset="utf-8"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <style>
     .cell-title {
       font-weight: bold;
@@ -41,7 +42,7 @@
 <div style="width:600px;">
   <div class="grid-header" style="width:100%">
     <label>SlickGrid</label>
-    <span style="float:right" class="ui-icon ui-icon-search" title="Toggle search panel"
+    <span style="float:right;margin:0px 4px auto 6px;background:transparent;cursor:pointer;" class="slick-icon-search" title="Toggle search panel"
           onclick="toggleFilterRow()"></span>
   </div>
   <div id="myGrid" style="width:100%;height:350px;"></div>
@@ -55,7 +56,7 @@
     <label style="width:200px;float:left">Show tasks with % at least: </label>
 
     <div style="padding:2px;">
-      <div style="width:100px;display:inline-block;" id="pcSlider"></div>
+      <input style="width:100px;display:inline-block;" id="pcSlider" type="range" min="1" max="100" value="1">
     </div>
     <br/>
     <label style="width:200px;float:left">And title including:</label>
@@ -89,19 +90,19 @@
   </div>
 </div>
 
-<div id="inlineFilterPanelL" style="display:none;background:#dddddd;padding:3px;color:black;">
+<div id="inlineFilterPanelL" style="display:none;background:#dddddd;color:black;">
   Show tasks with title including <input type="text" id="txtSearch2">
 </div>
 
-<div id="inlineFilterPanelR" style="display:none;background:#dddddd;padding:6px;color:black;">
+<div id="inlineFilterPanelR" style="display:none;background:#dddddd;color:black;">
   and % at least &nbsp;
-  <div style="width:100px;display:inline-block;" id="pcSlider2"></div>
+  <input style="width:100px;display:inline-block;" id="pcSlider2" type="range" min="1" max="100" value="1">
 </div>
 
 <script language="JavaScript" src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
@@ -134,9 +135,9 @@ var columns = [
   ,
   {id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentComplete, editor: Slick.Editors.PercentComplete, sortable: true}
   ,
-  {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date, sortable: true}
+  {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Flatpickr, sortable: true}
   ,
-  {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date, sortable: true}
+  {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Flatpickr, sortable: true}
   ,
   {id: "effort-driven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.YesNo, editor: Slick.Editors.YesNoSelect, cannotTriggerInsert: true, sortable: true}
   ,
@@ -357,19 +358,20 @@ $(function () {
   var h_runfilters = null;
 
   // wire up the slider to apply the filter to the model
-  $("#pcSlider,#pcSlider2").slider({
-    "range": "min",
-    "slide": function (event, ui) {
-      Slick.GlobalEditorLock.cancelCurrentEdit();
+  var slider = document.getElementById("pcSlider");
+  var slider2 = document.getElementById("pcSlider2");
+  var sliderCallback = function() {
+    Slick.GlobalEditorLock.cancelCurrentEdit();
 
-      if (percentCompleteThreshold != ui.value) {
-        window.clearTimeout(h_runfilters);
-        h_runfilters = window.setTimeout(dataView.refresh, 10);
-        percentCompleteThreshold = ui.value;
-      }
+    if (percentCompleteThreshold != this.value) {
+      window.clearTimeout(h_runfilters);
+      h_runfilters = window.setTimeout(dataView.refresh, 10);
+      percentCompleteThreshold = this.value;
     }
-  });
-
+  }
+  
+  slider.oninput = sliderCallback;
+  slider2.oninput = sliderCallback;
 
   // wire up the search textbox to apply the filter to the model
   $("#txtSearch,#txtSearch2").keyup(function (e) {
@@ -405,8 +407,6 @@ $(function () {
   dataView.setItems(data);
   dataView.setFilter(myFilter);
   dataView.endUpdate();
-
-  $("#gridContainer").resizable();
 
   $('#setFrozenColumn').click(function () {
     var val = -1;

--- a/examples/example-frozen-row-reordering.html
+++ b/examples/example-frozen-row-reordering.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example 9: Row reordering</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
     .cell-title {
@@ -85,7 +84,6 @@
 <script src="../lib/jquery-3.1.0.js"></script>
 <script src="../lib/jquery.event.drag-2.3.0.js"></script>
 <script src="../lib/jquery.event.drop-2.3.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 
 <script src="../slick.core.js"></script>
 <script src="../slick.interactions.js"></script>

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -3,7 +3,6 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.gridmenu.css" type="text/css"/>
@@ -129,7 +128,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-grouping-checkbox-row-select.html
+++ b/examples/example-grouping-checkbox-row-select.html
@@ -6,8 +6,8 @@
   <title>SlickGrid example: Grouping</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.pager.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="examples-unicode-icons.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
   <style>
     .cell-effort-driven {
@@ -44,7 +44,7 @@
       <label style="width:200px;float:left">Show tasks with % at least: </label>
 
       <div style="padding:2px;">
-        <div style="width:100px;display:inline-block;" id="pcSlider"></div>
+        <input style="width:100px;display:inline-block;" id="pcSlider" type="range" min="1" max="100" value="1">
       </div>
       <br/><br/>
       <button onclick="loadData(50)">50 rows</button>
@@ -92,7 +92,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
@@ -364,19 +363,17 @@ $(function () {
   var h_runfilters = null;
 
   // wire up the slider to apply the filter to the model
-  $("#pcSlider,#pcSlider2").slider({
-    "range": "min",
-    "slide": function (event, ui) {
-      Slick.GlobalEditorLock.cancelCurrentEdit();
+  var slider = document.getElementById("pcSlider");
+  var sliderCallback = function() {
+    Slick.GlobalEditorLock.cancelCurrentEdit();
 
-      if (percentCompleteThreshold != ui.value) {
-        window.clearTimeout(h_runfilters);
-        h_runfilters = window.setTimeout(filterAndUpdate, 10);
-        percentCompleteThreshold = ui.value;
-      }
+    if (percentCompleteThreshold != this.value) {
+      window.clearTimeout(h_runfilters);
+      h_runfilters = window.setTimeout(filterAndUpdate, 10);
+      percentCompleteThreshold = this.value;
     }
-  });
-
+  }
+  slider.oninput = sliderCallback;
 
   function filterAndUpdate() {
     var isNarrowing = percentCompleteThreshold > prevPercentCompleteThreshold;
@@ -406,9 +403,7 @@ $(function () {
   loadData(50);
   groupByDuration();
   dataView.endUpdate();
-
-  $("#gridContainer").resizable();
-})
+});
 </script>
 </body>
 </html>

--- a/examples/example-grouping-groupcolumn.html
+++ b/examples/example-grouping-groupcolumn.html
@@ -6,8 +6,8 @@
   <title>SlickGrid example: Row Group column</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.pager.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="examples-unicode-icons.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
   <style>
     .cell-effort-driven {
@@ -58,7 +58,7 @@
       <label style="width:200px;float:left">Show tasks with % at least: </label>
 
       <div style="padding:2px;">
-        <div style="width:100px;display:inline-block;" id="pcSlider"></div>
+        <input style="width:100px;display:inline-block;" id="pcSlider" type="range" min="1" max="100" value="1">
       </div>
       <br/><br/>
       <button onclick="loadData(50)">50 rows</button>
@@ -106,7 +106,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
@@ -408,19 +407,17 @@ $(function () {
   var h_runfilters = null;
 
   // wire up the slider to apply the filter to the model
-  $("#pcSlider,#pcSlider2").slider({
-    "range": "min",
-    "slide": function (event, ui) {
-      Slick.GlobalEditorLock.cancelCurrentEdit();
+  var slider = document.getElementById("pcSlider");
+  var sliderCallback = function() {
+    Slick.GlobalEditorLock.cancelCurrentEdit();
 
-      if (percentCompleteThreshold != ui.value) {
-        window.clearTimeout(h_runfilters);
-        h_runfilters = window.setTimeout(filterAndUpdate, 10);
-        percentCompleteThreshold = ui.value;
-      }
+    if (percentCompleteThreshold != this.value) {
+      window.clearTimeout(h_runfilters);
+      h_runfilters = window.setTimeout(filterAndUpdate, 10);
+      percentCompleteThreshold = this.value;
     }
-  });
-
+  }
+  slider.oninput = sliderCallback;
 
   function filterAndUpdate() {
     var isNarrowing = percentCompleteThreshold > prevPercentCompleteThreshold;
@@ -450,9 +447,7 @@ $(function () {
   loadData(50);
   groupByDuration();
   dataView.endUpdate();
-
-  $("#gridContainer").resizable();
-})
+});
 </script>
 </body>
 </html>

--- a/examples/example-grouping.html
+++ b/examples/example-grouping.html
@@ -6,8 +6,8 @@
   <title>SlickGrid example: Grouping</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.pager.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="examples-unicode-icons.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
   <style>
     .cell-effort-driven {
@@ -49,7 +49,7 @@
       <label style="width:200px;float:left">Show tasks with % at least: </label>
 
       <div style="padding:2px;">
-        <div style="width:100px;display:inline-block;" id="pcSlider"></div>
+        <input style="width:100px;display:inline-block;" id="pcSlider" type="range" min="1" max="100" value="1">
       </div>
       <br/><br/>
       <button data-test="add-500-rows-btn" onclick="loadData(500)">500 rows</button>
@@ -95,7 +95,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
@@ -369,19 +368,17 @@ $(function () {
   var h_runfilters = null;
 
   // wire up the slider to apply the filter to the model
-  $("#pcSlider,#pcSlider2").slider({
-    "range": "min",
-    "slide": function (event, ui) {
-      Slick.GlobalEditorLock.cancelCurrentEdit();
+  var slider = document.getElementById("pcSlider");
+  var sliderCallback = function() {
+    Slick.GlobalEditorLock.cancelCurrentEdit();
 
-      if (percentCompleteThreshold != ui.value) {
-        window.clearTimeout(h_runfilters);
-        h_runfilters = window.setTimeout(filterAndUpdate, 10);
-        percentCompleteThreshold = ui.value;
-      }
+    if (percentCompleteThreshold != this.value) {
+      window.clearTimeout(h_runfilters);
+      h_runfilters = window.setTimeout(filterAndUpdate, 10);
+      percentCompleteThreshold = this.value;
     }
-  });
-
+  }
+  slider.oninput = sliderCallback;
 
   function filterAndUpdate() {
     var isNarrowing = percentCompleteThreshold > prevPercentCompleteThreshold;
@@ -411,9 +408,7 @@ $(function () {
   loadData(50);
   groupByDuration();
   dataView.endUpdate();
-
-  $("#gridContainer").resizable();
-})
+});
 </script>
 </body>
 </html>

--- a/examples/example-header-row.html
+++ b/examples/example-header-row.html
@@ -3,7 +3,6 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
@@ -46,7 +45,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-html-sanitizer.html
+++ b/examples/example-html-sanitizer.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: Sanitizer</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
 </head>
 <body>
@@ -31,7 +30,6 @@
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 <script src="../lib/firebugx.js"></script>
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 
 <script src="../slick.core.js"></script>
 <script src="../slick.interactions.js"></script>

--- a/examples/example-multi-column-sort.html
+++ b/examples/example-multi-column-sort.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: Multi Column Sort</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
 </head>
 <body>

--- a/examples/example-multi-column-tristate-numbered-sort.html
+++ b/examples/example-multi-column-tristate-numbered-sort.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: Multi Column Sort</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
 </head>
 <body>

--- a/examples/example-multi-grid-basic.html
+++ b/examples/example-multi-grid-basic.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: Two Basic grids on page</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.gridmenu.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>

--- a/examples/example-multiselect-editor.html
+++ b/examples/example-multiselect-editor.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid Example- Multiselect Dropdown Editor</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
     .cell-title {
@@ -40,7 +39,6 @@
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 <script src="../lib/firebugx.js"></script>
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="../slick.core.js"></script>
 <script src="../slick.interactions.js"></script>
 <script src="../plugins/slick.cellrangedecorator.js"></script>

--- a/examples/example-optimizing-updates.html
+++ b/examples/example-optimizing-updates.html
@@ -5,9 +5,9 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: Optimizing Updates</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.pager.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="examples-unicode-icons.css" type="text/css"/>
   <style>
     .cell-title {
       font-weight: bold;
@@ -64,7 +64,6 @@
 </div>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-plugin-contextmenu.html
+++ b/examples/example-plugin-contextmenu.html
@@ -8,7 +8,6 @@
   <link rel="stylesheet" href="../slick.grid.css" type="text/css" />
   <link rel="stylesheet" href="../plugins/slick.cellmenu.css" type="text/css" />
   <link rel="stylesheet" href="../plugins/slick.contextmenu.css" type="text/css" />
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css" />
   <link rel="stylesheet" href="examples.css" type="text/css" />
   <style>
     .bold {
@@ -162,7 +161,6 @@
   <script src="../lib/firebugx.js"></script>
 
   <script src="../lib/jquery-3.1.0.js"></script>
-  <script src="../lib/jquery-ui.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
   <script src="../slick.core.js"></script>

--- a/examples/example-plugin-custom-tooltip.html
+++ b/examples/example-plugin-custom-tooltip.html
@@ -6,9 +6,9 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example 3: Editing</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css" />
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css" />
   <link rel="stylesheet" href="../plugins/slick.customtooltip.css" type="text/css" />
   <link rel="stylesheet" href="examples.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <style>
     .cell-title, .bold {
       font-weight: bold;
@@ -128,7 +128,7 @@
   <script src="../lib/firebugx.js"></script>
 
   <script src="../lib/jquery-3.1.0.js"></script>
-  <script src="../lib/jquery-ui.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
   <script src="../slick.core.js"></script>
@@ -243,9 +243,9 @@
         editor: Slick.Editors.PercentComplete,
         customTooltip: { useRegularTooltip: true },
       },
-      { id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date },
+      { id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Flatpickr },
       { 
-        id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date,
+        id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Flatpickr,
         // you could disable the custom/regular tooltip via either of the following 2 options
         disableTooltip: true,
         // customTooltip: {

--- a/examples/example-plugin-headerbuttons.html
+++ b/examples/example-plugin-headerbuttons.html
@@ -3,7 +3,6 @@
 
 <head>
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css" />
   <link rel="stylesheet" href="../slick.grid.css" type="text/css" />
   <link rel="stylesheet" href="examples.css" type="text/css" />
   <link rel="stylesheet" href="../plugins/slick.headerbuttons.css" type="text/css" />
@@ -46,7 +45,6 @@
   <script src="../lib/firebugx.js"></script>
 
   <script src="../lib/jquery-3.1.0.js"></script>
-  <script src="../lib/jquery-ui.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
   <script src="../slick.core.js"></script>

--- a/examples/example-plugin-headermenu.html
+++ b/examples/example-plugin-headermenu.html
@@ -5,7 +5,6 @@
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <link rel="stylesheet" href="../slick.grid.css" type="text/css" />
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css" />
   <link rel="stylesheet" href="../plugins/slick.headermenu.css" type="text/css" />
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css" />
   <link rel="stylesheet" href="examples.css" type="text/css" />

--- a/examples/example-select2-editor.html
+++ b/examples/example-select2-editor.html
@@ -5,18 +5,18 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: 'Select2' javascript dropdown editor</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <link rel="stylesheet" href="../css/select2.css" type="text/css"/>
-   <style>
-	.select2-container {
-		top: -3px;
-		left: -6px;
-	}
-    .select2-container .select2-selection--single {
-		height: 26px;
-	}  
-</style>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+  <style>
+    .select2-container {
+      top: -3px;
+      left: -6px;
+    }
+      .select2-container .select2-selection--single {
+      height: 26px;
+    }  
+  </style>
 </head>
 <body>
 <div style="position:relative">
@@ -45,7 +45,7 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
@@ -398,8 +398,8 @@ var countryIsoAndNameList = {
   var columns = [
     {id: "title", name: "Title", field: "title", width: 80, cssClass: "cell-title", editor: Slick.Editors.Text},
     {id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Text},
-    {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date},
-    {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date},
+    {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Flatpickr},
+    {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Flatpickr},
 	{id: "CountryOfOrigin", name: "Country Of Origin", field: "country", minWidth: 200, formatter: Select2Formatter, 
 		editor: Select2Editor, dataSource: countryIsoAndNameList }
   ];

--- a/examples/example-select2-multiselect-editor.html
+++ b/examples/example-select2-multiselect-editor.html
@@ -5,18 +5,18 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: 'Select2' javascript dropdown editor</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <link rel="stylesheet" href="../css/select2.css" type="text/css"/>
-   <style>
-	.select2-container {
-		top: -3px;
-		left: -6px;
-	}
-    .select2-container .select2-selection--single {
-		height: 26px;
-	}  
-</style>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+  <style>
+    .select2-container {
+      top: -3px;
+      left: -6px;
+    }
+      .select2-container .select2-selection--single {
+      height: 26px;
+    }  
+  </style>
 </head>
 <body>
 <div style="position:relative">
@@ -45,7 +45,7 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
@@ -419,8 +419,8 @@ var countryIsoAndNameList = {
   var columns = [
     {id: "title", name: "Title", field: "title", width: 80, cssClass: "cell-title", editor: Slick.Editors.Text},
     {id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Text},
-    {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date},
-    {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date},
+    {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Flatpickr},
+    {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Flatpickr},
 	{id: "CountryOfOrigin", name: "Country Of Origin", field: "country", minWidth: 200, formatter: Select2MultiFormatter, 
 		editor: Select2Editor, dataSource: countryIsoAndNameList }
   ];

--- a/examples/example-size-to-content.html
+++ b/examples/example-size-to-content.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example: Column Content Sizing</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="../controls/slick.pager.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
@@ -726,7 +725,6 @@
 </div>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-spreadsheet.html
+++ b/examples/example-spreadsheet.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example 3: Editing</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
     .slick-cell.copied {
@@ -40,7 +39,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example-totals-via-data-provider.html
+++ b/examples/example-totals-via-data-provider.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
@@ -35,7 +34,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example10-async-post-render.html
+++ b/examples/example10-async-post-render.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example 10: Async post render</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
     .cell-title {
@@ -63,7 +62,6 @@ nb: sparkline 2.x will <a href="https://github.com/mleibman/SlickGrid/issues/855
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="../lib/jquery-migrate-1.2.1.min.js"></script>
 <!-- nb: sparkline 2.x will cause a memory leak in the current architecture, so we use sparkline 1.x and jquery-migrate -->
 <script src="../lib/jquery.sparkline.min.js"></script>

--- a/examples/example10a-async-post-render-cleanup.html
+++ b/examples/example10a-async-post-render-cleanup.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example 10: Async post render</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
     .cell-title {
@@ -66,7 +65,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="../lib/jquery.sparkline-2-1-2.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 

--- a/examples/example15-auto-resize.html
+++ b/examples/example15-auto-resize.html
@@ -6,7 +6,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example 15: Grid Auto-Resize on Window Resize</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css" />
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css" />
   <link rel="stylesheet" href="examples.css" type="text/css" />
 </head>
 

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -4,7 +4,6 @@
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <link rel="stylesheet" href="../plugins/slick.rowdetailview.css" type="text/css"/>
   <style>
@@ -138,7 +137,6 @@
   <script src="../lib/firebugx.js"></script>
 
   <script src="../lib/jquery-3.1.0.js"></script>
-  <script src="../lib/jquery-ui.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
   <script src="../slick.core.js"></script>

--- a/examples/example17-row-detail-many-columns.html
+++ b/examples/example17-row-detail-many-columns.html
@@ -4,7 +4,6 @@
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <link rel="stylesheet" href="../plugins/slick.rowdetailview.css" type="text/css"/>
   <style>
@@ -122,7 +121,6 @@
   <script src="../lib/firebugx.js"></script>
 
   <script src="../lib/jquery-3.1.0.js"></script>
-  <script src="../lib/jquery-ui.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
   <script src="../slick.core.js"></script>

--- a/examples/example3-editing.html
+++ b/examples/example3-editing.html
@@ -5,8 +5,9 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example 3: Editing</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="examples-unicode-icons.css" type="text/css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <style>
     .cell-title {
       font-weight: bold;
@@ -45,8 +46,8 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
 <script src="../plugins/slick.cellrangedecorator.js"></script>
@@ -73,8 +74,8 @@
     {id: "desc", name: "Description", field: "description", width: 100, editor: Slick.Editors.LongText},
     {id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Text},
     {id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete},
-    {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date},
-    {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date},
+    {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Flatpickr},
+    {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Flatpickr},
     {id: "effort-driven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark, editor: Slick.Editors.Checkbox}
   ];
   var options = {

--- a/examples/example3a-compound-editors.html
+++ b/examples/example3a-compound-editors.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example 3a: Advanced Editing</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
     .cell-title {
@@ -39,7 +38,6 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/examples/example3b-editing-with-undo.html
+++ b/examples/example3b-editing-with-undo.html
@@ -5,8 +5,9 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example 3: Editing</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="examples-unicode-icons.css" type="text/css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <style>
     .cell-title {
       font-weight: bold;
@@ -41,7 +42,7 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
@@ -66,8 +67,8 @@
     {id: "desc", name: "Description", field: "description", width: 100, editor: Slick.Editors.LongText},
     {id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Text},
     {id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete},
-    {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date},
-    {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date},
+    {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Flatpickr},
+    {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Flatpickr},
     {id: "effort-driven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark, editor: Slick.Editors.Checkbox}
   ];
 

--- a/examples/example5-collapsing-treeGrid-sort.html
+++ b/examples/example5-collapsing-treeGrid-sort.html
@@ -5,8 +5,8 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example 5: Collapsing</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <style>
     .cell-title {
       font-weight: bold;
@@ -40,7 +40,7 @@
         <label>Show tasks with % at least: </label>
 
         <div style="padding:4px;">
-          <div style="width:100px;" id="pcSlider"></div>
+          <input style="width:100px;display:inline-block;" id="pcSlider" type="range" min="1" max="100" value="1">
         </div>
         <br/>
         <label>And title including:</label>
@@ -67,7 +67,7 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
@@ -278,8 +278,8 @@ var columns = [
   {id: "title", sortable:true, name: "Title", field: "title", width: 220, cssClass: "cell-title", formatter: TaskNameFormatter, editor: Slick.Editors.Text, validator: requiredFieldValidator},
   {id: "duration", sortable:true, name: "Duration", field: "duration", editor: Slick.Editors.Text},
   {id: "%", sortable:true, name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete},
-  {id: "start", sortable:true, name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date},
-  {id: "finish", sortable:true, name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date},
+  {id: "start", sortable:true, name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Flatpickr},
+  {id: "finish", sortable:true, name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Flatpickr},
   {id: "effort-driven", sortable:true, name: "Effort Driven", width: 120, minWidth: 20, maxWidth: 120, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark, editor: Slick.Editors.Checkbox, cannotTriggerInsert: true}
 ];
 
@@ -642,18 +642,18 @@ function bindGridEvents() {
   var h_runfilters = null;
 
   // wire up the slider to apply the filter to the model
-  $("#pcSlider").slider({
-    "range": "min",
-    "slide": function (event, ui) {
-      Slick.GlobalEditorLock.cancelCurrentEdit();
+  var slider = document.getElementById("pcSlider");
+  var sliderCallback = function() {
+    Slick.GlobalEditorLock.cancelCurrentEdit();
 
-      if (percentCompleteThreshold != ui.value) {
-        window.clearTimeout(h_runfilters);
-        h_runfilters = window.setTimeout(dataView.refresh, 10);
-        percentCompleteThreshold = ui.value;
-      }
+    if (percentCompleteThreshold != this.value) {
+      window.clearTimeout(h_runfilters);
+      h_runfilters = window.setTimeout(dataView.refresh, 10);
+      percentCompleteThreshold = this.value;
     }
-  });
+  }
+  
+  slider.oninput = sliderCallback;
 
 
   // wire up the search textbox to apply the filter to the model

--- a/examples/example5-collapsing.html
+++ b/examples/example5-collapsing.html
@@ -5,8 +5,8 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example 5: Collapsing</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <style>
     .cell-title {
       font-weight: bold;
@@ -40,7 +40,7 @@
         <label>Show tasks with % at least: </label>
 
         <div style="padding:4px;">
-          <div style="width:100px;" id="pcSlider"></div>
+          <input style="width:100px;display:inline-block;" id="pcSlider" type="range" min="1" max="100" value="1">
         </div>
         <br/>
         <label>And title including:</label>
@@ -67,7 +67,7 @@
 <script src="../lib/firebugx.js"></script>
 
 <script src="../lib/jquery-3.1.0.js"></script>
-<script src="../lib/jquery-ui.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
 
 <script src="../slick.core.js"></script>
@@ -111,8 +111,8 @@ var columns = [
   {id: "title", name: "Title", field: "title", width: 220, cssClass: "cell-title", formatter: TaskNameFormatter, editor: Slick.Editors.Text, validator: requiredFieldValidator},
   {id: "duration", name: "Duration", field: "duration", editor: Slick.Editors.Text},
   {id: "%", name: "% Complete", field: "percentComplete", width: 80, resizable: false, formatter: Slick.Formatters.PercentCompleteBar, editor: Slick.Editors.PercentComplete},
-  {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Date},
-  {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Date},
+  {id: "start", name: "Start", field: "start", minWidth: 60, editor: Slick.Editors.Flatpickr},
+  {id: "finish", name: "Finish", field: "finish", minWidth: 60, editor: Slick.Editors.Flatpickr},
   {id: "effort-driven", name: "Effort Driven", width: 80, minWidth: 20, maxWidth: 80, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark, editor: Slick.Editors.Checkbox, cannotTriggerInsert: true}
 ];
 
@@ -250,19 +250,18 @@ $(function () {
   var h_runfilters = null;
 
   // wire up the slider to apply the filter to the model
-  $("#pcSlider").slider({
-    "range": "min",
-    "slide": function (event, ui) {
-      Slick.GlobalEditorLock.cancelCurrentEdit();
+  var slider = document.getElementById("pcSlider");
+  var sliderCallback = function() {
+    Slick.GlobalEditorLock.cancelCurrentEdit();
 
-      if (percentCompleteThreshold != ui.value) {
-        window.clearTimeout(h_runfilters);
-        h_runfilters = window.setTimeout(dataView.refresh, 10);
-        percentCompleteThreshold = ui.value;
-      }
+    if (percentCompleteThreshold != this.value) {
+      window.clearTimeout(h_runfilters);
+      h_runfilters = window.setTimeout(dataView.refresh, 10);
+      percentCompleteThreshold = this.value;
     }
-  });
-
+  }
+  
+  slider.oninput = sliderCallback;
 
   // wire up the search textbox to apply the filter to the model
   $("#txtSearch").keyup(function (e) {

--- a/examples/example8-alternative-display.html
+++ b/examples/example8-alternative-display.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example 8: Alternative display</title>
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
-  <link rel="stylesheet" href="../css/smoothness/jquery-ui.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
   <style>
     .slick-cell {

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -145,7 +145,8 @@
 
       e.stopImmediatePropagation();
 
-      var top = e.pageY - $(_canvas).offset().top;
+      var targetEvent = e.touches ? e.touches[0] : e;
+      var top = targetEvent.pageY - $(_canvas).offset().top;
       dd.selectionProxy.css("top", top - 5).show();
 
       // if the row move shadow is enabled, we'll also make it follow the mouse cursor

--- a/tests/plugins/autotooltips.html
+++ b/tests/plugins/autotooltips.html
@@ -18,8 +18,6 @@
 	
 	<script type="text/javascript" src="../../lib/qunit.js"></script>
 	<script type="text/javascript" src="../../lib/jquery-3.1.0.js"></script>
-	<script type="text/javascript" src="../../lib/jquery-ui-1.11.3.min.js"></script>
-	<script type="text/javascript" src="../../lib/jquery.event.drag-2.3.0.js"></script>
 	<script type="text/javascript" src="../../lib/qunit.js"></script>
 	<script type="text/javascript">
 		jQuery.noConflict();

--- a/tests/plugins/cellrangedecorator.html
+++ b/tests/plugins/cellrangedecorator.html
@@ -18,8 +18,6 @@
 
 	<script type="text/javascript" src="../../lib/qunit.js"></script>
 	<script type="text/javascript" src="../../lib/jquery-3.1.0.js"></script>
-	<script type="text/javascript" src="../../lib/jquery-ui-1.11.3.min.js"></script>
-	<script type="text/javascript" src="../../lib/jquery.event.drag-2.3.0.js"></script>
 	<script type="text/javascript" src="../../lib/qunit.js"></script>
 	<script type="text/javascript">
 		jQuery.noConflict();

--- a/tests/plugins/cellrangeselector.html
+++ b/tests/plugins/cellrangeselector.html
@@ -18,8 +18,6 @@
 
 	<script type="text/javascript" src="../../lib/qunit.js"></script>
 	<script type="text/javascript" src="../../lib/jquery-3.1.0.js"></script>
-	<script type="text/javascript" src="../../lib/jquery-ui-1.11.3.min.js"></script>
-	<script type="text/javascript" src="../../lib/jquery.event.drag-2.3.0.js"></script>
 	<script type="text/javascript" src="../../lib/qunit.js"></script>
 	<script type="text/javascript">
 		jQuery.noConflict();

--- a/tests/plugins/cellselectionmodel.html
+++ b/tests/plugins/cellselectionmodel.html
@@ -18,8 +18,6 @@
 
 	<script type="text/javascript" src="../../lib/qunit.js"></script>
 	<script type="text/javascript" src="../../lib/jquery-3.1.0.js"></script>
-	<script type="text/javascript" src="../../lib/jquery-ui-1.11.3.min.js"></script>
-	<script type="text/javascript" src="../../lib/jquery.event.drag-2.3.0.js"></script>
 	<script type="text/javascript" src="../../lib/qunit.js"></script>
 	<script type="text/javascript">
 		jQuery.noConflict();


### PR DESCRIPTION
- some examples must explicitly use jQueryUI, like the demo with grids in jQueryUI tabs and so we won't change those examples, but for nearly all other examples we'll remove jQueryUI