### PR TITLE
chore: add badge to show npm version and CI status

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Cypress E2E Tests
+name: CI Build
 on:
   # Trigger the workflow on push or pull request,
   # but only for the master branch on Push and any branches on PR

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Cypress.io](https://img.shields.io/badge/tested%20with-Cypress-04C38E.svg)](https://www.cypress.io/)
+[![NPM downloads](https://img.shields.io/npm/dm/slickgrid.svg)](https://npmjs.org/package/slickgrid)
+[![npm](https://img.shields.io/npm/v/slickgrid.svg?logo=npm&logoColor=fff&label=npm)](https://npmjs.org/package/slickgrid)
+[![Actions Status](https://github.com/6pac/SlickGrid/workflows/CI%20Build/badge.svg)](https://github.com/6pac/SlickGrid/actions)
+
 ## This is the 6pac SlickGrid repo
 
 Check out the NEW SlickGrid Website! http://slickgrid.net/


### PR DESCRIPTION
show a few useful badges on the readme page, mostly the npm version & CI build status

![image](https://user-images.githubusercontent.com/643976/200751599-8e1b0d64-e9b9-4896-b3d3-439d9bcb0a10.png)
