### PR TITLE
feat(dataView): add option to apply row selection to all pages

### DIFF
--- a/cypress/integration/example-checkbox-header-row.spec.js
+++ b/cypress/integration/example-checkbox-header-row.spec.js
@@ -268,6 +268,20 @@ describe('Example - Checkbox Header Row', () => {
       });
   });
 
+  it('should clear all filters and expect 75 rows to be selected', () => {
+    cy.get('[data-test="clear-filters"]').click();
+
+    cy.get('.slick-headerrow-column')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(''));
+
+    cy.get('#idsCount')
+      .then($elm => {
+        let newSelectedIdsCount = +$elm[0].textContent;
+        expect(newSelectedIdsCount).to.be.eq(75);
+      });
+  });
+
   it('should clear all filters & clear all row selections', () => {
     cy.get('[data-test="clear-filters"]').click();
 
@@ -334,7 +348,18 @@ describe('Example - Checkbox Header Row', () => {
       .should('not.be.checked');
   });
 
-  it('should revert back to same previous filter and expect back to have "Select All" checkbox to be selected again', () => {
+  it('should sort and expect same selected Ids as previous test', () => {
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(1)')
+      .click();
+
+    cy.get('#idsCount')
+      .then($elm => {
+        expect(+$elm[0].textContent).to.be.eq(selectedIdsCount);
+      });
+  });
+
+  it('should revert back to the same filter as before and still expect the same selected Ids to be selected again', () => {
     cy.get('#myGrid')
       .find('.slick-headerrow-column.l1.r1')
       .find('input')

--- a/cypress/integration/example-checkbox-header-row.spec.js
+++ b/cypress/integration/example-checkbox-header-row.spec.js
@@ -100,7 +100,7 @@ describe('Example - Checkbox Header Row', () => {
     });
   });
 
-  it('Should display "Showing page 1 of 6" text after changing Pagination to 25 items per page', () => {
+  it('should display "Showing page 1 of 6" text after changing Pagination to 25 items per page', () => {
     cy.get('.ui-icon-lightbulb')
       .click();
 
@@ -115,8 +115,29 @@ describe('Example - Checkbox Header Row', () => {
       .contains('Showing page 1 of 6');
   });
 
+  it('should change row selection across multiple pages, first page should have 2 selected', () => {
+    cy.get('[data-test="set-dynamic-rows"]').click();
+
+    // Row index 3, 5 and 21 (last one will be on 2nd page)
+    cy.get('input[type="checkbox"]:checked').should('have.length', 2); // 2x in current page and 1x in next page
+    cy.get('[style="top:75px"] > .slick-cell:nth(0) input[type="checkbox"]').should('be.checked');
+    cy.get('[style="top:125px"] > .slick-cell:nth(0) input[type="checkbox"]').should('be.checked');
+  });
+
+  it('should go to next page and expect 1 row selected in that second page', () => {
+    cy.get('.ui-icon-seek-next')
+      .click();
+
+    cy.get('input[type="checkbox"]:checked').should('have.length', 1); // only 1x row in page 2
+    cy.get('[style="top:100px"] > .slick-cell:nth(0) input[type="checkbox"]').should('be.checked');
+  });
+
   it('should click on "Select All" checkbox and expect all rows selected in current page', () => {
     const expectedRows = '1,3,5,7,9,11,13,15,17,19,21,23';
+
+    // go back to 1st page
+    cy.get('.ui-icon-seek-prev')
+      .click();
 
     cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
       .click({ force: true });
@@ -125,8 +146,8 @@ describe('Example - Checkbox Header Row', () => {
       .contains(expectedRows);
 
     cy.window().then((win) => {
-      expect(win.console.log).to.have.callCount(2);
-      expect(win.console.log).to.be.calledWith('Previously Selected Rows: ');
+      expect(win.console.log).to.have.callCount(4);
+      expect(win.console.log).to.be.calledWith('Previously Selected Rows: 3,5'); // from previous test
       expect(win.console.log).to.be.calledWith(`Selected Rows: ${expectedRows}`);
     });
   });

--- a/cypress/integration/example-checkbox-header-row.spec.js
+++ b/cypress/integration/example-checkbox-header-row.spec.js
@@ -2,6 +2,7 @@
 
 describe('Example - Checkbox Header Row', () => {
   const titles = ['', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];
+  let selectedIdsCount = 0;
 
   beforeEach(() => {
     // create a console.log spy for later use
@@ -66,7 +67,7 @@ describe('Example - Checkbox Header Row', () => {
   });
 
   it('should click on Select All and display previous and new selected rows', () => {
-    const expectedRows = '1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99';
+    const expectedRows = '1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99,101,103,105,107,109,111,113,115,117,119,121,123,125,127,129,131,133,135,137,139,141,143,145,147,149';
 
     cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
       .click({ force: true });
@@ -82,7 +83,7 @@ describe('Example - Checkbox Header Row', () => {
   });
 
   it('should click on Select All again and expect no new selected rows', () => {
-    const expectedPreviousRows = '1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99';
+    const expectedPreviousRows = '1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99,101,103,105,107,109,111,113,115,117,119,121,123,125,127,129,131,133,135,137,139,141,143,145,147,149';
 
     cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
       .click({ force: true });
@@ -97,5 +98,258 @@ describe('Example - Checkbox Header Row', () => {
       expect(win.console.log).to.be.calledWith(`Previously Selected Rows: ${expectedPreviousRows}`);
       expect(win.console.log).to.be.calledWith('Selected Rows: ');
     });
+  });
+
+  it('Should display "Showing page 1 of 6" text after changing Pagination to 25 items per page', () => {
+    cy.get('.ui-icon-lightbulb')
+      .click();
+
+    cy.get('.slick-pager-settings-expanded')
+      .should('be.visible');
+
+    cy.get('.slick-pager-settings-expanded')
+      .contains('25')
+      .click();
+
+    cy.get('.slick-pager-status')
+      .contains('Showing page 1 of 6');
+  });
+
+  it('should click on "Select All" checkbox and expect all rows selected in current page', () => {
+    const expectedRows = '1,3,5,7,9,11,13,15,17,19,21,23';
+
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .click({ force: true });
+
+    cy.get('#selectedRows')
+      .contains(expectedRows);
+
+    cy.window().then((win) => {
+      expect(win.console.log).to.have.callCount(2);
+      expect(win.console.log).to.be.calledWith('Previously Selected Rows: ');
+      expect(win.console.log).to.be.calledWith(`Selected Rows: ${expectedRows}`);
+    });
+  });
+
+  it('should go to next page and still expect all rows selected in current page', () => {
+    cy.get('.ui-icon-seek-next')
+      .click();
+
+    cy.get('.slick-cell-checkboxsel input:checked')
+      .should('have.length', 11);
+  });
+
+  it('should go to last page and still expect all rows selected in current page', () => {
+    cy.get('.ui-icon-seek-end')
+      .click();
+
+    cy.get('.slick-cell-checkboxsel input:checked')
+      .should('have.length', 11);
+
+    cy.get('.slick-pager-status')
+      .contains('Showing page 6 of 6');
+
+    cy.get('#selectedRows')
+      .should('contain', '0,2,4,6,8,10,12,14,16,18,20,22,24');
+
+    cy.get('#selectedIds')
+      .should('contain', '9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99,101,103,105,107');
+  });
+
+  it('should uncheck first checkbox and expect the "Select All" button to be unchecked', () => {
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .should('be.checked');
+
+    cy.get('.slick-row:nth(0) .slick-cell:nth(0) input[type=checkbox]')
+      .click({ force: true });
+
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .should('not.be.checked');
+
+    cy.get('.slick-cell-checkboxsel input:checked')
+      .should('have.length', 10);
+
+    cy.get('#selectedRows')
+      .should('contain', '2,4,6,8,10,12,14,16,18,20,22,24');
+
+    cy.get('#selectedIds')
+      .should('contain', '9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99,101,103,105,107,109,111,113,115,117,119,121,123,125,127,129,131,135,137,139,141,143,145,147,149,151,153,155,157');
+  });
+
+  it('should go back to first page and still expect all rows selected in current page', () => {
+    cy.get('.ui-icon-seek-first')
+      .click();
+
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .should('not.be.checked');
+
+    cy.get('.slick-cell-checkboxsel input:checked')
+      .should('have.length', 11);
+
+    cy.get('.slick-pager-status')
+      .contains('Showing page 1 of 6');
+
+    cy.get('#selectedRows')
+      .should('contain', '1,3,5,7,9,11,13,15,17,19,21,23');
+
+    cy.get('#selectedIds')
+      .should('contain', '9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99,101,103,105,107,109,111,113,115,117,119,121,123,125,127,129,131,135,137,139,141,143,145,147,149,151,153,155,157');
+  });
+
+  it('should go back to last page then re-select the first row and expect "Select All" to be checked', () => {
+    cy.get('.ui-icon-seek-end')
+      .click();
+
+    cy.get('.slick-row:nth(0) .slick-cell:nth(0) input[type=checkbox]')
+      .click({ force: true });
+
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .should('be.checked');
+
+    cy.get('.slick-cell-checkboxsel input:checked')
+      .should('have.length', 11);
+
+    cy.get('.slick-pager-status')
+      .contains('Showing page 6 of 6');
+
+    cy.get('#selectedRows')
+      .should('contain', '0,2,4,6,8,10,12,14,16,18,20,22,24');
+
+    cy.get('#selectedIds')
+      .should('contain', '9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85,87,89,91,93,95,97,99,101,103,105,107');
+  });
+
+  it('should have lower count of selected Ids after filtering data', () => {
+    let prevSelectedIdsCount = 0;
+    let newSelectedIdsCount = 0;
+    let prevSelectedRowsCount = 0;
+    let newSelectedRowsCount = 0;
+
+    cy.get('#idsCount')
+      .then($elm => {
+        console.log($elm)
+        prevSelectedIdsCount = +$elm[0].textContent;
+        expect(prevSelectedIdsCount).to.be.greaterThan(0);
+      });
+
+    cy.get('#rowsCount')
+      .then($elm => {
+        console.log($elm)
+        prevSelectedRowsCount = +$elm[0].textContent;
+        expect(prevSelectedRowsCount).to.be.greaterThan(0);
+        expect(prevSelectedIdsCount).not.to.be.eq(prevSelectedRowsCount);
+      });
+
+    cy.get('.slick-pager-status')
+      .should('not.contain', 'Showing page 1 of 1');
+
+    cy.get('#myGrid')
+      .find('.slick-headerrow-column.l1.r1')
+      .find('input')
+      .type('5');
+
+    cy.get('#idsCount')
+      .then($elm => {
+        newSelectedIdsCount = +$elm[0].textContent;
+        expect(newSelectedIdsCount).to.be.lessThan(prevSelectedIdsCount);
+      });
+
+    cy.get('#rowsCount')
+      .then($elm => {
+        newSelectedRowsCount = +$elm[0].textContent;
+      });
+
+    cy.get('.slick-pager-status')
+      .then($elm => {
+        const pagerInfo = $elm[0].textContent;
+        if (pagerInfo === 'Showing page 1 of 1') {
+          expect(newSelectedIdsCount).to.be.eq(newSelectedRowsCount);
+        }
+      });
+  });
+
+  it('should clear all filters & clear all row selections', () => {
+    cy.get('[data-test="clear-filters"]').click();
+
+    cy.get('.slick-headerrow-column')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(''));
+
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .click({ force: true });
+
+    cy.get('#rowsCount')
+      .then($elm => {
+        let newSelectedRowsCount = +$elm[0].textContent;
+        expect(newSelectedRowsCount).to.be.eq(0);
+      });
+
+    cy.get('#idsCount')
+      .then($elm => {
+        selectedIdsCount = +$elm[0].textContent;
+        expect(selectedIdsCount).to.be.eq(0);
+      });
+  });
+
+  it('should filter data with text having "5" to show on a single page and then click on "Select All" checkbox', () => {
+    cy.get('#myGrid')
+      .find('.slick-headerrow-column.l1.r1')
+      .find('input')
+      .type('5');
+
+    cy.get('.slick-pager-status')
+      .should('contain', 'Showing page 1 of 1');
+
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .click({ force: true });
+
+    cy.get('#idsCount')
+      .then($elm => {
+        selectedIdsCount = +$elm[0].textContent;
+        expect(selectedIdsCount).to.be.greaterThan(0);
+      });
+  });
+
+  it('should remove filter and not expect "Select All" checkbox to be selected but still expect same selected Ids', () => {
+    let newSelectedIdsCount = 0;
+    cy.get('[data-test="clear-filters"]').click();
+
+    cy.get('.slick-headerrow-column')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(''));
+
+    cy.get('#idsCount')
+      .then($elm => {
+        newSelectedIdsCount = +$elm[0].textContent;
+        expect(newSelectedIdsCount).to.be.eq(selectedIdsCount);
+      });
+
+    cy.get('#rowsCount')
+      .then($elm => {
+        let newSelectedRowsCount = +$elm[0].textContent;
+        expect(newSelectedRowsCount).not.to.be.eq(newSelectedIdsCount);
+      });
+
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .should('not.be.checked');
+  });
+
+  it('should revert back to same previous filter and expect back to have "Select All" checkbox to be selected again', () => {
+    cy.get('#myGrid')
+      .find('.slick-headerrow-column.l1.r1')
+      .find('input')
+      .type('5');
+
+    cy.get('.slick-pager-status')
+      .should('contain', 'Showing page 1 of 1');
+
+    cy.get('#idsCount')
+      .then($elm => {
+        selectedIdsCount = +$elm[0].textContent;
+        expect(selectedIdsCount).to.be.greaterThan(0);
+      });
+
+    cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
+      .should('be.checked');
   });
 });

--- a/cypress/integration/example-row-detail-selection-and-move.spec.js
+++ b/cypress/integration/example-row-detail-selection-and-move.spec.js
@@ -167,21 +167,4 @@ describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
         cy.get('input[id="assignee_3"]')
             .should('exist');
     });
-
-    it('should collapse all rows', () => {
-        cy.get('[data-test="collapse-all"]').click();
-    })
-
-    it('should change row selection dynamically and expect them to show up in the grid', () => {
-        cy.get('[data-test="set-dynamic-rows"]').click();
-
-        cy.get('#selectedTitles').should('have.text', 'Task 4,Task 5,Task 8,Task 10');
-
-        // Task 4,5,8,10 should be selected
-        cy.get('input[type="checkbox"]:checked').should('have.length', 4);
-        cy.get('[style="top:50px"] > .slick-cell:nth(2) input[type="checkbox"]').should('be.checked')
-        cy.get('[style="top:75px"] > .slick-cell:nth(2) input[type="checkbox"]').should('be.checked')
-        cy.get('[style="top:150px"] > .slick-cell:nth(2) input[type="checkbox"]').should('be.checked')
-        cy.get('[style="top:250px"] > .slick-cell:nth(2) input[type="checkbox"]').should('be.checked')
-    })
 });

--- a/cypress/integration/example-row-detail-selection-and-move.spec.js
+++ b/cypress/integration/example-row-detail-selection-and-move.spec.js
@@ -147,7 +147,7 @@ describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
         cy.get('[style="top:175px"] > .slick-cell:nth(4)').should('contain', 'Task 3');
         cy.get('[style="top:200px"] > .slick-cell:nth(4)').should('contain', 'Task 1');
 
-        // // Task 1 and 3 should be selected
+        // Task 1 and 3 should be selected
         cy.get('input[type="checkbox"]:checked').should('have.length', 2);
         cy.get('[style="top:175px"] > .slick-cell:nth(2) input[type="checkbox"]:checked').should('have.length', 1);
         cy.get('[style="top:200px"] > .slick-cell:nth(2) input[type="checkbox"]:checked').should('have.length', 1);
@@ -167,4 +167,21 @@ describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
         cy.get('input[id="assignee_3"]')
             .should('exist');
     });
+
+    it('should collapse all rows', () => {
+        cy.get('[data-test="collapse-all"]').click();
+    })
+
+    it('should change row selection dynamically and expect them to show up in the grid', () => {
+        cy.get('[data-test="set-dynamic-rows"]').click();
+
+        cy.get('#selectedTitles').should('have.text', 'Task 4,Task 5,Task 8,Task 10');
+
+        // Task 4,5,8,10 should be selected
+        cy.get('input[type="checkbox"]:checked').should('have.length', 4);
+        cy.get('[style="top:50px"] > .slick-cell:nth(2) input[type="checkbox"]').should('be.checked')
+        cy.get('[style="top:75px"] > .slick-cell:nth(2) input[type="checkbox"]').should('be.checked')
+        cy.get('[style="top:150px"] > .slick-cell:nth(2) input[type="checkbox"]').should('be.checked')
+        cy.get('[style="top:250px"] > .slick-cell:nth(2) input[type="checkbox"]').should('be.checked')
+    })
 });

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -4,8 +4,10 @@
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
+  <link rel="stylesheet" href="../controls/slick.pager.css" type="text/css" />
   <link rel="stylesheet" href="../controls/slick.columnpicker.css" type="text/css"/>
   <link rel="stylesheet" href="examples.css" type="text/css"/>
+  <link rel="stylesheet" href="examples-unicode-icons.css" type="text/css"/>
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" crossorigin="anonymous">
   <style>
     .slick-headerrow-column {
@@ -68,6 +70,7 @@
 <div style="position:relative">
   <div style="width:600px;">
     <div id="myGrid" style="width:100%;height:500px;"></div>
+    <div id="pager" style="width:100%;height:20px;"></div>
   </div>
 
   <div class="options-panel">
@@ -83,6 +86,9 @@
       <p>
         <button onclick="toggleWhichRowToShowSelectAll()">Toggle which row to show "Select All" checkbox</button>
       </p>
+      <p>
+        <button data-test="clear-filters" onclick="clearFilters()">Clear Filters</button>
+      </p>
     </ul>
     <h2>View Source:</h2>
     <ul>
@@ -91,8 +97,13 @@
 
     <hr/>
 
-    <h3>Selected Rows:</h3>
+    <h3>Selected Rows (<span id="rowsCount">0</span>):</h3>
     <div id="selectedRows" style="overflow-x: auto;"></div>
+
+    <hr/>
+
+    <h3>Selected Ids (<span id="idsCount">0</span>) with index/id offset=<span id="idOffset"></span>:</h3>
+    <div id="selectedIds" style="overflow-x: auto;"></div>
   </div>
 </div>
 
@@ -103,6 +114,7 @@
 
 <script src="../plugins/slick.checkboxselectcolumn.js"></script>
 <script src="../plugins/slick.rowselectionmodel.js"></script>
+<script src="../controls/slick.pager.js"></script>
 <script src="../controls/slick.columnpicker.js"></script>
 
 <script src="../slick.core.js"></script>
@@ -126,8 +138,13 @@
   var isSelectAllCheckboxHidden = false;
   var isSelectAllShownAsColumnTitle = false;
 
+  // add an offset so that the IDs are not equal to the row number, to fully validate that DataView selected IDs work as intended
+  var idOffset = 8;
+  $('#idOffset').text(idOffset);
+
   checkboxSelector = new Slick.CheckboxSelectColumn({
     cssClass: "slick-cell-checkboxsel",
+    applySelectOnAllPages: true, // defaults to false, when that is enabled the "Select All" will be applied to all pages
     hideInColumnTitleRow: !isSelectAllShownAsColumnTitle,
     hideInFilterHeaderRow: isSelectAllShownAsColumnTitle,
 
@@ -141,11 +158,19 @@
 
   for (var i = 0; i < 10; i++) {
     columns.push({
-      id: i,
+      id: i + idOffset,
       name: String.fromCharCode("A".charCodeAt(0) + i),
       field: i,
       width: 60
     });
+  }
+
+  function clearFilters() {
+    $('.slick-headerrow-column').children().val('');
+    for (var columnId in columnFilters) {
+      columnFilters[columnId] = "";
+    }
+    dataView.refresh();
   }
 
   function filter(item) {
@@ -174,9 +199,9 @@
   }
 
   $(function () {
-    for (var i = 0; i < 100; i++) {
+    for (var i = 0; i < 150; i++) {
       var d = (data[i] = {});
-      d["id"] = i;
+      d["id"] = i + idOffset;
       for (var j = 0; j < columns.length; j++) {
         d[j] = Math.round(Math.random() * 10);
       }
@@ -186,9 +211,10 @@
     grid = new Slick.Grid("#myGrid", dataView, columns, options);
     grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
     grid.registerPlugin(checkboxSelector);
+    dataView.syncGridSelection(grid, false, true);
 
+    var pager = new Slick.Controls.Pager(dataView, grid, $("#pager"));
     var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
-
 
     dataView.onRowCountChanged.subscribe(function (e, args) {
       grid.updateRowCount();
@@ -207,6 +233,13 @@
       console.log("Previously Selected Rows: " + previousSelectedRows.toString());
       console.log("Selected Rows: " + sortedSelectedRows.toString());
       $('#selectedRows').text(sortedSelectedRows.toString());
+      $('#rowsCount').text(sortedSelectedRows.length); 
+    });
+    
+    dataView.onSelectedRowIdsChanged.subscribe(function(e, args) {
+      var sortedSelectedIds = args.filteredIds.sort(function (a, b) { return a - b });
+      $('#selectedIds').text(sortedSelectedIds.toString());
+      $('#idsCount').text(sortedSelectedIds.length); 
     });
 
     $(grid.getHeaderRow()).on("change keyup", ":input", function (e) {

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -89,6 +89,12 @@
       <p>
         <button data-test="clear-filters" onclick="clearFilters()">Clear Filters</button>
       </p>
+      <p>
+        Change Pagination to 25 and apply row selection across multiple pages <br/>
+        <button data-test="set-dynamic-rows" onclick="setSelectedRowIds()" style="margin-top: 4px">
+          Change Row Selections (row index 3, 5 and 21)
+        </button>
+      </p>
     </ul>
     <h2>View Source:</h2>
     <ul>
@@ -190,6 +196,19 @@
     }
     return true;
   }
+
+  // change row selection dynamically and apply it to the DataView and the Grid UI
+  function setSelectedRowIds() {
+      // change row selection even across multiple pages via DataView
+      dataView.setSelectedIds([11, 13, 37]); // don't forget we have an id offset of +8
+      
+      // you can also provide optional options (all defaults to true)
+      // dataView.setSelectedIds([4, 5, 8, 10], { 
+      //   isRowBeingAdded: true, 
+      //   shouldTriggerEvent: true, 
+      //   applyGridRowSelection: true 
+      // });
+    }
 
   function toggleHideSelectAllCheckbox() {
     isSelectAllCheckboxHidden = !isSelectAllCheckboxHidden;

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -199,16 +199,16 @@
 
   // change row selection dynamically and apply it to the DataView and the Grid UI
   function setSelectedRowIds() {
-      // change row selection even across multiple pages via DataView
-      dataView.setSelectedIds([11, 13, 37]); // don't forget we have an id offset of +8
-      
-      // you can also provide optional options (all defaults to true)
-      // dataView.setSelectedIds([4, 5, 8, 10], { 
-      //   isRowBeingAdded: true, 
-      //   shouldTriggerEvent: true, 
-      //   applyGridRowSelection: true 
-      // });
-    }
+    // change row selection even across multiple pages via DataView
+    dataView.setSelectedIds([11, 13, 37]); // don't forget we have an id offset of +8
+    
+    // you can also provide optional options (all defaults to true)
+    // dataView.setSelectedIds([4, 5, 8, 10], { 
+    //   isRowBeingAdded: true,
+    //   shouldTriggerEvent: true,
+    //   applyGridRowSelection: true)
+    // });
+  }
 
   function toggleHideSelectAllCheckbox() {
     isSelectAllCheckboxHidden = !isSelectAllCheckboxHidden;

--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -161,8 +161,14 @@
       id: i + idOffset,
       name: String.fromCharCode("A".charCodeAt(0) + i),
       field: i,
-      width: 60
+      width: 60,
+      sortable: true
     });
+  }
+
+  function comparer(a, b) {
+    var x = a[sortcol], y = b[sortcol];
+    return (x == y ? 0 : (x > y ? 1 : -1));
   }
 
   function clearFilters() {
@@ -238,6 +244,7 @@
     
     dataView.onSelectedRowIdsChanged.subscribe(function(e, args) {
       var sortedSelectedIds = args.filteredIds.sort(function (a, b) { return a - b });
+      // console.log('sortedSelectedIds', args.selectedRowIds);
       $('#selectedIds').text(sortedSelectedIds.toString());
       $('#idsCount').text(sortedSelectedIds.length); 
     });
@@ -258,6 +265,15 @@
            .val(columnFilters[args.column.id])
            .appendTo(args.node);
       }
+    });
+
+    grid.onSort.subscribe(function (e, args) {
+      sortdir = args.sortAsc ? 1 : -1;
+      sortcol = args.sortCol.field;
+    
+      // using native sort with comparer
+      // preferred method but can be very slow in IE with huge datasets
+      dataView.sort(comparer, args.sortAsc);
     });
 
     grid.init();

--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -95,6 +95,12 @@
         <button onclick="rowMovePlugin.setOptions({ singleRowMove: false, disableRowSelection: false })">
           Single Row Move OFF
         </button>
+        <button data-test="collapse-all" onclick="collapseAllRowDetails()" style="margin-top: 4px">
+          Collapse All Row Details
+        </button>
+        <button data-test="set-dynamic-rows" onclick="setSelectedRowIds()" style="margin-top: 4px">
+          Change Row Selections (Task 4, 5, 8, 10)
+        </button>
       </p>
       <p>
         The RowMoveManager Plugin can be configured with an "usabilityOverride" which will make the row moveable
@@ -195,6 +201,20 @@
         '<div class="detail"><label>Effort Driven:</label> <span>' + itemDetail.effortDriven + '</span></div>',
         '</div>'
       ].join('');
+    }
+
+    function collapseAllRowDetails() {
+      detailViewPlugin.collapseAll();
+    }
+
+    // change row selection dynamically and apply it to the DataView and the Grid UI
+    function setSelectedRowIds() {
+      // grid.scrollRowToTop();
+      dataView.setSelectedIds([4, 5, 8, 10], { 
+        isRowBeingAdded: true, 
+        shouldTriggerEvent: true, 
+        applyGridRowSelection: true 
+      });
     }
 
     // fill the template with a delay to simulate a server call
@@ -376,6 +396,10 @@
       dataView.setItems(data);
       dataView.endUpdate();
       dataView.syncGridSelection(grid, true);
+
+      dataView.onSelectedRowIdsChanged.subscribe(function (e, args) {
+        console.log('onSelectedRowIdsChanged', args)
+      });
     });
   </script>
 </body>

--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -95,12 +95,6 @@
         <button onclick="rowMovePlugin.setOptions({ singleRowMove: false, disableRowSelection: false })">
           Single Row Move OFF
         </button>
-        <button data-test="collapse-all" onclick="collapseAllRowDetails()" style="margin-top: 4px">
-          Collapse All Row Details
-        </button>
-        <button data-test="set-dynamic-rows" onclick="setSelectedRowIds()" style="margin-top: 4px">
-          Change Row Selections (Task 4, 5, 8, 10)
-        </button>
       </p>
       <p>
         The RowMoveManager Plugin can be configured with an "usabilityOverride" which will make the row moveable
@@ -201,23 +195,6 @@
         '<div class="detail"><label>Effort Driven:</label> <span>' + itemDetail.effortDriven + '</span></div>',
         '</div>'
       ].join('');
-    }
-
-    function collapseAllRowDetails() {
-      detailViewPlugin.collapseAll();
-    }
-
-    // change row selection dynamically and apply it to the DataView and the Grid UI
-    function setSelectedRowIds() {
-      // grid.scrollRowToTop();
-      dataView.setSelectedIds([4, 5, 8, 10]);
-      
-      // you can also provide optional options (all defaults to true)
-      // dataView.setSelectedIds([4, 5, 8, 10], { 
-      //   isRowBeingAdded: true, 
-      //   shouldTriggerEvent: true, 
-      //   applyGridRowSelection: true 
-      // });
     }
 
     // fill the template with a delay to simulate a server call

--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -210,11 +210,14 @@
     // change row selection dynamically and apply it to the DataView and the Grid UI
     function setSelectedRowIds() {
       // grid.scrollRowToTop();
-      dataView.setSelectedIds([4, 5, 8, 10], { 
-        isRowBeingAdded: true, 
-        shouldTriggerEvent: true, 
-        applyGridRowSelection: true 
-      });
+      dataView.setSelectedIds([4, 5, 8, 10]);
+      
+      // you can also provide optional options (all defaults to true)
+      // dataView.setSelectedIds([4, 5, 8, 10], { 
+      //   isRowBeingAdded: true, 
+      //   shouldTriggerEvent: true, 
+      //   applyGridRowSelection: true 
+      // });
     }
 
     // fill the template with a delay to simulate a server call

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -287,7 +287,7 @@
               ids.push(dataviewRowItem[_dataView.getIdPropertyName()]);
             }
           }
-          _dataView.setSelectedIds(ids, isAllSelected);
+          _dataView.setSelectedIds(ids, { isRowBeingAdded: isAllSelected });
         }
         _grid.setSelectedRows(rows, caller);
         e.stopPropagation();

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -8,7 +8,9 @@
 
 
   function CheckboxSelectColumn(options) {
+    var _dataView;
     var _grid;
+    var _isUsingDataView = false;
     var _selectableOverride = null;
     var _selectAll_UID = createUID();
     var _handler = new Slick.EventHandler();
@@ -19,6 +21,7 @@
       hideSelectAllCheckbox: false,
       toolTip: "Select/Deselect All",
       width: 30,
+      applySelectOnAllPages: false, // defaults to false, when that is enabled the "Select All" will be applied to all pages (when using Pagination)
       hideInColumnTitleRow: false,
       hideInFilterHeaderRow: true
     };
@@ -33,10 +36,20 @@
 
     function init(grid) {
       _grid = grid;
+      _isUsingDataView = !Array.isArray(grid.getData());
+      if (_isUsingDataView) {
+        _dataView = grid.getData();
+      }
       _handler
         .subscribe(_grid.onSelectedRowsChanged, handleSelectedRowsChanged)
         .subscribe(_grid.onClick, handleClick)
         .subscribe(_grid.onKeyDown, handleKeyDown);
+
+      if (_isUsingDataView && _dataView && _options.applySelectOnAllPages) {
+        _handler
+          .subscribe(_dataView.onSelectedRowIdsChanged, handleDataViewSelectedIdsChanged)
+          .subscribe(_dataView.onPagingInfoChanged, handleDataViewSelectedIdsChanged)
+      }
 
       if (!_options.hideInFilterHeaderRow) {
         addCheckboxToFilterHeaderRow(grid);
@@ -122,15 +135,18 @@
       }
       _selectedRowsLookup = lookup;
       _grid.render();
-      _isSelectAllChecked = selectedRows.length && selectedRows.length + disabledCount >= _grid.getDataLength();
+      _isSelectAllChecked = selectedRows && selectedRows.length + disabledCount >= _grid.getDataLength();
 
-      if (!_options.hideInColumnTitleRow && !_options.hideSelectAllCheckbox) {
-        renderSelectAllCheckbox(_isSelectAllChecked);
+      if (!_isUsingDataView || !_options.applySelectOnAllPages) {
+        if (!_options.hideInColumnTitleRow && !_options.hideSelectAllCheckbox) {
+          renderSelectAllCheckbox(_isSelectAllChecked);
+        }
+        if (!_options.hideInFilterHeaderRow) {
+          var selectAllElm = $("#header-filter-selector" + _selectAll_UID);
+          selectAllElm.prop("checked", _isSelectAllChecked);
+        }
       }
-      if (!_options.hideInFilterHeaderRow) {
-        var selectAllElm = $("#header-filter-selector" + _selectAll_UID);
-        selectAllElm.prop("checked", _isSelectAllChecked);
-      }
+
       // Remove items that shouln't of been selected in the first place (Got here Ctrl + click)
       if (removeList.length > 0) {
         for (i = 0; i < removeList.length; i++) {
@@ -138,6 +154,36 @@
           selectedRows.splice(remIdx, 1);
         }
         _grid.setSelectedRows(selectedRows, "click.cleanup");
+      }
+    }
+
+    function handleDataViewSelectedIdsChanged() {
+      var selectedIds = _dataView.getAllSelectedFilteredIds();
+      var filteredItems = _dataView.getFilteredItems();
+      var disabledCount = 0;
+
+      if (typeof _selectableOverride === 'function' && selectedIds.length > 0) {
+        for (var k = 0; k < _dataView.getItemCount(); k++) {
+          // If we are allowed to select the row
+          var dataItem = _dataView.getItemByIdx(k);
+          var idProperty = _dataView.getIdPropertyName();
+          var dataItemId = dataItem[idProperty];
+          var foundItemIdx = filteredItems.findIndex(function (item) {
+            return item[idProperty] === dataItemId;
+          });
+          if (foundItemIdx >= 0 && !checkSelectableOverride(k, dataItem, _grid)) {
+            disabledCount++;
+          }
+        }
+      }
+      _isSelectAllChecked = (selectedIds && selectedIds.length) + disabledCount >= filteredItems.length;
+
+      if (!_options.hideInColumnTitleRow && !_options.hideSelectAllCheckbox) {
+        renderSelectAllCheckbox(_isSelectAllChecked);
+      }
+      if (!_options.hideInFilterHeaderRow) {
+        var selectAllElm = $("#header-filter-selector" + _selectAll_UID);
+        selectAllElm.prop("checked", _isSelectAllChecked);
       }
     }
 
@@ -217,8 +263,9 @@
           return;
         }
 
-        if ($(e.target).is(":checked")) {
-          var rows = [];
+        var isAllSelected = $(e.target).is(":checked") || false;
+        var rows = [];
+        if (isAllSelected) {
           for (var i = 0; i < _grid.getDataLength(); i++) {
             // Get the row and check it's a selectable row before pushing it onto the stack
             var rowItem = _grid.getDataItem(i);
@@ -226,10 +273,21 @@
               rows.push(i);
             }
           }
-          _grid.setSelectedRows(rows, "click.selectAll");
-        } else {
-          _grid.setSelectedRows([], "click.selectAll");
+          isAllSelected = true;
         }
+        if (_isUsingDataView && _dataView && _options.applySelectOnAllPages) {
+          var ids = [];
+          var filteredItems = _dataView.getFilteredItems();
+          for (var j = 0; j < filteredItems.length; j++) {
+            // Get the row and check it's a selectable ID (it could be in a different page) before pushing it onto the stack
+            var dataviewRowItem = filteredItems[j];
+            if (checkSelectableOverride(j, dataviewRowItem, _grid)) {
+              ids.push(dataviewRowItem[_dataView.getIdPropertyName()]);
+            }
+          }
+          _dataView.setSelectedIds(ids, isAllSelected);
+        }
+        _grid.setSelectedRows(rows, "click.selectAll");
         e.stopPropagation();
         e.stopImmediatePropagation();
       }

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -99,7 +99,7 @@
       $("#filter-checkbox-selectall-container").hide();
     }
 
-    function handleSelectedRowsChanged(e, args) {
+    function handleSelectedRowsChanged() {
       var selectedRows = _grid.getSelectedRows();
       var lookup = {}, row, i, k;
       var disabledCount = 0;
@@ -264,7 +264,9 @@
         }
 
         var isAllSelected = $(e.target).is(":checked") || false;
+        var caller = isAllSelected ? 'click.selectAll' : 'click.unselectAll';
         var rows = [];
+
         if (isAllSelected) {
           for (var i = 0; i < _grid.getDataLength(); i++) {
             // Get the row and check it's a selectable row before pushing it onto the stack
@@ -287,7 +289,7 @@
           }
           _dataView.setSelectedIds(ids, isAllSelected);
         }
-        _grid.setSelectedRows(rows, "click.selectAll");
+        _grid.setSelectedRows(rows, caller);
         e.stopPropagation();
         e.stopImmediatePropagation();
       }

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -1383,24 +1383,40 @@
      * NOTE: This will NOT change the selection in the grid, if you need to do that then you still need to call
      * "grid.setSelectedRows(rows)"
      * @param {Array} selectedIds - list of IDs which have been selected for this action
-     * @param {boolean} added - are the new selected IDs being added (or removed) as new row selection
+     * @param {Object} options
+     *  - `isRowBeingAdded`: are the new selected IDs being added (or removed) as new row selections
+     *  - `shouldTriggerEvent`: should we trigger `onSelectedRowIdsChanged` event (defaults to true)
+     *  - `applyGridRowSelection`: should we apply the row selections to the grid in the UI
      */
-    function setSelectedIds(selectedIds, added) {
-      if (typeof added === typeof undefined) {
-        added = true;
+    function setSelectedIds(selectedIds, options) {
+      var isRowBeingAdded = options && options.isRowBeingAdded;
+      var shouldTriggerEvent = options && options.shouldTriggerEvent;
+      var applyGridRowSelection = options && options.applyGridRowSelection;
+
+      if (typeof isRowBeingAdded === typeof undefined) {
+        isRowBeingAdded = true;
       }
+      var selectedRows = self.mapIdsToRows(selectedIds);
       var selectedRowsChangedArgs = {
         "grid": _grid,
         "ids": selectedIds,
-        "rows": self.mapIdsToRows(selectedIds),
-        "added": added,
+        "rows": selectedRows,
+        "added": isRowBeingAdded,
         "dataView": self
       };
       preSelectedRowIdsChangeFn(selectedRowsChangedArgs);
-      onSelectedRowIdsChanged.notify(Object.assign(selectedRowsChangedArgs, {
-        "selectedRowIds": selectedRowIds,
-        "filteredIds": self.getAllSelectedFilteredIds(),
-      }), new Slick.EventData(), self);
+
+      if (shouldTriggerEvent !== false) {
+        onSelectedRowIdsChanged.notify(Object.assign(selectedRowsChangedArgs, {
+          "selectedRowIds": selectedRowIds,
+          "filteredIds": self.getAllSelectedFilteredIds(),
+        }), new Slick.EventData(), self);
+      }
+
+      // should we also apply the row selection in to the grid (UI) as well?
+      if (applyGridRowSelection && _grid) {
+        _grid.setSelectedRows(selectedRows);
+      }
     }
 
     /**

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -61,7 +61,7 @@
     var toggledGroupsByLevel = [];
     var groupingDelimiter = ':|:';
     var selectedRowIds = null;
-    var selectedRowChangedFn;
+    var preSelectedRowIdsChangeFn;
 
     var pagesize = 0;
     var pagenum = 0;
@@ -1287,10 +1287,12 @@
             var selectedRowsChangedArgs = {
               "grid": _grid,
               "ids": self.mapRowsToIds(selectedRows),
+              "rows": selectedRows,
               "dataView": self
             };
-            selectedRowChangedFn(selectedRowsChangedArgs);
+            preSelectedRowIdsChangeFn(selectedRowsChangedArgs);
             onSelectedRowIdsChanged.notify(Object.assign(selectedRowsChangedArgs, {
+              "selectedRowIds": selectedRowIds,
               "filteredIds": self.getAllSelectedFilteredIds(),
             }), new Slick.EventData(), self);
           }
@@ -1301,29 +1303,30 @@
 
       grid.onSelectedRowsChanged.subscribe(function (e, args) {
         if (!inHandler) {
-          var newSelectedRowIds = self.mapRowsToIds(grid.getSelectedRows());
+          var newSelectedRowIds = self.mapRowsToIds(args.rows);
           var selectedRowsChangedArgs = {
             "grid": _grid,
             "ids": newSelectedRowIds,
+            "rows": args.rows,
             "added": true,
             "dataView": self
           };
-          selectedRowChangedFn(selectedRowsChangedArgs);
+          preSelectedRowIdsChangeFn(selectedRowsChangedArgs);
           onSelectedRowIdsChanged.notify(Object.assign(selectedRowsChangedArgs, {
+            "selectedRowIds": selectedRowIds,
             "filteredIds": self.getAllSelectedFilteredIds(),
           }), new Slick.EventData(), self);
         }
       });
 
-      selectedRowChangedFn = function (args) {
+      preSelectedRowIdsChangeFn = function (args) {
         if (!inHandler) {
           inHandler = true;
           var overwrite = (typeof args.added === typeof undefined);
 
           if (overwrite) {
             setSelectedRowIds(args.ids);
-          }
-          else {
+          } else {
             var rowIds;
             if (args.added) {
               if (preserveHiddenOnSelectionChange && grid.getOptions().multiSelect) {
@@ -1376,12 +1379,11 @@
     }
 
     /**
-     * Set currently selected IDs array (regardless of Pagination)
+     * Set current row selected IDs array (regardless of Pagination)
      * NOTE: This will NOT change the selection in the grid, if you need to do that then you still need to call
      * "grid.setSelectedRows(rows)"
-     *
      * @param {Array} selectedIds - list of IDs which have been selected for this action
-     * @param {boolean} added - if the selected IDs have been added to selection or removed from it
+     * @param {boolean} added - are the new selected IDs being added (or removed) as new row selection
      */
     function setSelectedIds(selectedIds, added) {
       if (typeof added === typeof undefined) {
@@ -1390,11 +1392,13 @@
       var selectedRowsChangedArgs = {
         "grid": _grid,
         "ids": selectedIds,
+        "rows": self.mapIdsToRows(selectedIds),
         "added": added,
         "dataView": self
       };
-      selectedRowChangedFn(selectedRowsChangedArgs);
+      preSelectedRowIdsChangeFn(selectedRowsChangedArgs);
       onSelectedRowIdsChanged.notify(Object.assign(selectedRowsChangedArgs, {
+        "selectedRowIds": selectedRowIds,
         "filteredIds": self.getAllSelectedFilteredIds(),
       }), new Slick.EventData(), self);
     }

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -1384,16 +1384,16 @@
      * "grid.setSelectedRows(rows)"
      * @param {Array} selectedIds - list of IDs which have been selected for this action
      * @param {Object} options
-     *  - `isRowBeingAdded`: are the new selected IDs being added (or removed) as new row selections
-     *  - `shouldTriggerEvent`: should we trigger `onSelectedRowIdsChanged` event (defaults to true)
-     *  - `applyRowSelectionToGrid`: should we apply the row selections to the grid in the UI
+     *  - `isRowBeingAdded`: defaults to true, are the new selected IDs being added (or removed) as new row selections
+     *  - `shouldTriggerEvent`: defaults to true, should we trigger `onSelectedRowIdsChanged` event
+     *  - `applyRowSelectionToGrid`: defaults to true, should we apply the row selections to the grid in the UI
      */
     function setSelectedIds(selectedIds, options) {
       var isRowBeingAdded = options && options.isRowBeingAdded;
       var shouldTriggerEvent = options && options.shouldTriggerEvent;
       var applyRowSelectionToGrid = options && options.applyRowSelectionToGrid;
 
-      if (typeof isRowBeingAdded === typeof undefined) {
+      if (isRowBeingAdded !== false) {
         isRowBeingAdded = true;
       }
       var selectedRows = self.mapIdsToRows(selectedIds);
@@ -1414,7 +1414,7 @@
       }
 
       // should we also apply the row selection in to the grid (UI) as well?
-      if (applyRowSelectionToGrid && _grid) {
+      if (applyRowSelectionToGrid !== false && _grid) {
         _grid.setSelectedRows(selectedRows);
       }
     }

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -1386,12 +1386,12 @@
      * @param {Object} options
      *  - `isRowBeingAdded`: are the new selected IDs being added (or removed) as new row selections
      *  - `shouldTriggerEvent`: should we trigger `onSelectedRowIdsChanged` event (defaults to true)
-     *  - `applyGridRowSelection`: should we apply the row selections to the grid in the UI
+     *  - `applyRowSelectionToGrid`: should we apply the row selections to the grid in the UI
      */
     function setSelectedIds(selectedIds, options) {
       var isRowBeingAdded = options && options.isRowBeingAdded;
       var shouldTriggerEvent = options && options.shouldTriggerEvent;
-      var applyGridRowSelection = options && options.applyGridRowSelection;
+      var applyRowSelectionToGrid = options && options.applyRowSelectionToGrid;
 
       if (typeof isRowBeingAdded === typeof undefined) {
         isRowBeingAdded = true;
@@ -1414,7 +1414,7 @@
       }
 
       // should we also apply the row selection in to the grid (UI) as well?
-      if (applyGridRowSelection && _grid) {
+      if (applyRowSelectionToGrid && _grid) {
         _grid.setSelectedRows(selectedRows);
       }
     }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -228,6 +228,7 @@ if (typeof Slick === "undefined") {
     var sortColumns = [];
     var columnPosLeft = [];
     var columnPosRight = [];
+    var allColumns = [];
 
     var pagingActive = false;
     var pagingIsLastPage = false;
@@ -1464,7 +1465,8 @@ if (typeof Slick === "undefined") {
               multiColumnSort: true,
               previousSortColumns: previousSortColumns,
               sortCols: $.map(sortColumns, function(col) {
-                return {columnId: columns[getColumnIndex(col.columnId)].id, sortCol: columns[getColumnIndex(col.columnId)], sortAsc: col.sortAsc };
+                var column = getColumnById(col.columnId, false);
+                return { columnId: column && column.id, sortCol: column, sortAsc: col.sortAsc };
               })
             };
           }
@@ -3012,6 +3014,19 @@ if (typeof Slick === "undefined") {
       return columns;
     }
 
+    function getColumnById(columnId, useOnlyVisibleColumns) {
+      var columnList = useOnlyVisibleColumns ? getColumns() : getAllColumns(true);
+      var column = null;
+
+      for (var c = 0; c < columnList.length; c++) {
+        if (columnList[c].id === columnId) {
+          column = columnList[c];
+          break;
+        }
+      }
+      return column;
+    }
+
     function updateColumnCaches() {
       // Pre-calculate cell boundaries.
       columnPosLeft = [];
@@ -3049,6 +3064,29 @@ if (typeof Slick === "undefined") {
           //m.autoSize.autosizeMode = Slick.ColAutosizeMode.Locked;
         }
       }
+    }
+
+    function setAllColumns(columnDefinitions) {
+      var _columns = columns.slice(0);
+      var _initialized = initialized;
+
+      initialized = false;
+      setColumns(columnDefinitions);
+      allColumns = columns.slice(0);
+      columns = _columns;
+      initialized = _initialized;
+    }
+
+    /**
+     *
+     * @param {boolean} [defaultToColumns=true]
+     * @return {[]|Array}
+     */
+    function getAllColumns(defaultToColumns) {
+      if (typeof defaultToColumns === typeof undefined) {
+        defaultToColumns = true;
+      }
+      return defaultToColumns ? (allColumns.length ? allColumns : columns) : allColumns;
     }
 
     function setColumns(columnDefinitions) {
@@ -6212,6 +6250,9 @@ if (typeof Slick === "undefined") {
       "getPluginByName": getPluginByName,
       "getColumns": getColumns,
       "setColumns": setColumns,
+      "getAllColumns": getAllColumns,
+      "setAllColumns": setAllColumns,
+      "getColumnById": getColumnById,
       "getColumnIndex": getColumnIndex,
       "updateColumnHeader": updateColumnHeader,
       "setSortColumn": setSortColumn,

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -228,7 +228,6 @@ if (typeof Slick === "undefined") {
     var sortColumns = [];
     var columnPosLeft = [];
     var columnPosRight = [];
-    var allColumns = [];
 
     var pagingActive = false;
     var pagingIsLastPage = false;
@@ -1465,8 +1464,7 @@ if (typeof Slick === "undefined") {
               multiColumnSort: true,
               previousSortColumns: previousSortColumns,
               sortCols: $.map(sortColumns, function(col) {
-                var column = getColumnById(col.columnId, false);
-                return { columnId: column && column.id, sortCol: column, sortAsc: col.sortAsc };
+                return { columnId: columns[getColumnIndex(col.columnId)].id, sortCol: columns[getColumnIndex(col.columnId)], sortAsc: col.sortAsc };
               })
             };
           }
@@ -3014,19 +3012,6 @@ if (typeof Slick === "undefined") {
       return columns;
     }
 
-    function getColumnById(columnId, useOnlyVisibleColumns) {
-      var columnList = useOnlyVisibleColumns ? getColumns() : getAllColumns(true);
-      var column = null;
-
-      for (var c = 0; c < columnList.length; c++) {
-        if (columnList[c].id === columnId) {
-          column = columnList[c];
-          break;
-        }
-      }
-      return column;
-    }
-
     function updateColumnCaches() {
       // Pre-calculate cell boundaries.
       columnPosLeft = [];
@@ -3064,29 +3049,6 @@ if (typeof Slick === "undefined") {
           //m.autoSize.autosizeMode = Slick.ColAutosizeMode.Locked;
         }
       }
-    }
-
-    function setAllColumns(columnDefinitions) {
-      var _columns = columns.slice(0);
-      var _initialized = initialized;
-
-      initialized = false;
-      setColumns(columnDefinitions);
-      allColumns = columns.slice(0);
-      columns = _columns;
-      initialized = _initialized;
-    }
-
-    /**
-     *
-     * @param {boolean} [defaultToColumns=true]
-     * @return {[]|Array}
-     */
-    function getAllColumns(defaultToColumns) {
-      if (typeof defaultToColumns === typeof undefined) {
-        defaultToColumns = true;
-      }
-      return defaultToColumns ? (allColumns.length ? allColumns : columns) : allColumns;
     }
 
     function setColumns(columnDefinitions) {
@@ -6250,9 +6212,6 @@ if (typeof Slick === "undefined") {
       "getPluginByName": getPluginByName,
       "getColumns": getColumns,
       "setColumns": setColumns,
-      "getAllColumns": getAllColumns,
-      "setAllColumns": setAllColumns,
-      "getColumnById": getColumnById,
       "getColumnIndex": getColumnIndex,
       "updateColumnHeader": updateColumnHeader,
       "setSortColumn": setSortColumn,


### PR DESCRIPTION
- supersede #689, most Grid & DataView changes were kept with some small changes & fixes, also added more Cypress E2E tests
- when having pages and `syncGridSelection` is called with `preserveHiddenOnSelectionChange`,  clicking on Select All checkbox:
  - it will apply row selections on all rows
  - if nothing is selected and we filter data, then we click on Select All, it will apply row selections only to the item being filtered and if we remove filters then the Select All  is not expect to be selected

#### Changes compared to previous PR #689
- most of the files are the same (~`slick.grid.js`,~ `slick.checkboxselectcolumn.js`, `example-checkbox-header-row.html`), however `slick.dataview.js` got modified a bit
- added back `filteredIds` which was added originally but removed in PR #689
- the method `syncGridSelection` had a `onSelectedRowIdsChanged.subscribe` (1) inside it but there was a racing issue because the Example (demo) is also calling `onSelectedRowIdsChanged` (2), but the sequence should be run (1) and then only after run (2), we could fix this by adding a `setTimeout` but it isn't a very clean approach, however we can simply change the (1) from `onSelectedRowIdsChanged.subscribe`  to a function named `selectedRowChangedFn` and execute it prior to (2), this way is a clean approach and it doesn't have any racing issue since we are only left with the (2) subscribe
- I still don't understand the difference between `preserveHidden` and `preserveHiddenOnSelectionChange` but as far as I see it, the Example only works as intended (the steps written above) when these 2 flags are set to `preserveHidden: false` and `preserveHiddenOnSelectionChange: true`. I'm not sure if this is intended @arashdalir could probably confirm
- this PR supersede #689 and is based on SlickGrid v3.x 
- I don't think the changes to `slick.grid.js` are required for applying Select All across all pages, we should probably move that code change to a separate PR
  - rollback `slick.grid.js` changes, since there's already another PR #549 and we should keep PR as small as possible

#### Requires Confirmations before merging
It requires review & confirmation by @arashdalir before merging this PR