### PR TITLE
chore: `slickGridVersion` property should also be updated in slick.grid

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -214,7 +214,13 @@ function updatePackageVersion(newVersion) {
  */
 function updateSlickGridVersion(newVersion) {
   const slickGridJs = fs.readFileSync(path.resolve(__dirname, '../slick.grid.js'), { encoding: 'utf8', flag: 'r' });
-  const updatedSlickGridJs = slickGridJs.replace(/(SlickGrid v)([0-9-.alpha|beta]*)/gi, `$1${newVersion}`);
+
+  // replaces version in 2 areas (a version could be "2.4.45" or "2.4.45-alpha.0"): 
+  // 1- in top comments, ie: SlickGrid v2.4.45
+  // 2- in public API definitions, ie: "slickGridVersion": "2.4.45",
+  const updatedSlickGridJs = slickGridJs
+    .replace(/(SlickGrid v)([0-9-.alpha|beta]*)/gi, `$1${newVersion}`)
+    .replace(/("slickGridVersion"): "([0-9\.]*([\-\.]?alpha[\-\.]?|[\-\.]?beta[\-\.]?)?[0-9\-\.]*)"/gi, `$1: "${newVersion}"`);
 
   if (options.dryRun) {
     console.log(`${chalk.magenta('[dry-run]')}`);


### PR DESCRIPTION
- release script should also update `slickGridVersion`, it seems like this was missed in original script.

![image](https://user-images.githubusercontent.com/643976/209615666-c58b792b-bf2f-40b6-a3fe-e216517853b5.png)

- I have done a dry-run and it seems to be all good

#### first replacement
![image](https://user-images.githubusercontent.com/643976/209616421-6c30f42c-e155-4f9a-a324-ee693853901f.png)

#### second replacement
![image](https://user-images.githubusercontent.com/643976/209616355-5b837b9c-2121-4b36-98a8-eef2b0d1d2e5.png)
