### PR TITLE
fix: horizontal scrolling can cause screen flickering

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -4410,30 +4410,34 @@ if (typeof Slick === "undefined") {
       if (hScrollDist) {
         prevScrollLeft = scrollLeft;
 
-        $viewportScrollContainerX[0].scrollLeft = scrollLeft;
-        $headerScrollContainer[0].scrollLeft = scrollLeft;
-        $topPanelScroller[0].scrollLeft = scrollLeft;
-        $headerRowScrollContainer[0].scrollLeft = scrollLeft;
-        if (options.createFooterRow) {
-          $footerRowScrollContainer[0].scrollLeft = scrollLeft;
-        }
-        if (options.createPreHeaderPanel) {
-          if (hasFrozenColumns()) {
-            $preHeaderPanelScrollerR[0].scrollLeft = scrollLeft;
-          } else {
-            $preHeaderPanelScroller[0].scrollLeft = scrollLeft;
+        // adjust scroll position of all div containers when scrolling the grid
+        // add a delay to avoid screen flickering
+        setTimeout(function () {
+          $viewportScrollContainerX[0].scrollLeft = scrollLeft;
+          $headerScrollContainer[0].scrollLeft = scrollLeft;
+          $topPanelScroller[0].scrollLeft = scrollLeft;
+          $headerRowScrollContainer[0].scrollLeft = scrollLeft;
+          if (options.createFooterRow) {
+            $footerRowScrollContainer[0].scrollLeft = scrollLeft;
           }
-        }
+          if (options.createPreHeaderPanel) {
+            if (hasFrozenColumns()) {
+              $preHeaderPanelScrollerR[0].scrollLeft = scrollLeft;
+            } else {
+              $preHeaderPanelScroller[0].scrollLeft = scrollLeft;
+            }
+          }
 
-        if (hasFrozenColumns()) {
-          if (hasFrozenRows) {
-            $viewportTopR[0].scrollLeft = scrollLeft;
+          if (hasFrozenColumns()) {
+            if (hasFrozenRows) {
+              $viewportTopR[0].scrollLeft = scrollLeft;
+            }
+          } else {
+            if (hasFrozenRows) {
+              $viewportTopL[0].scrollLeft = scrollLeft;
+            }
           }
-        } else {
-          if (hasFrozenRows) {
-            $viewportTopL[0].scrollLeft = scrollLeft;
-          }
-        }
+        }, 0);
       }
 
       // autoheight suppresses vertical scrolling, but editors can create a div larger than 


### PR DESCRIPTION
- add a delay of a cycle to avoid screen flickering that we observed to be worst in Chrome and Salesforce. This small delay of 1 cycle is enough to remove the flickering
- the process is that when the grid is being scrolled horizontally, it has to change the scroll position of every other div container that might exist (preheader, headerrow, footer) and if we change the position at the same time as the grid scroll it can cause flickering
- this flickering only happens in Chromium based browser (Firefox doesn't have this problem) and I'm pretty sure that last year we didn't have this problem so it might be a new Chrome bug (or Salesforce I don't know) but regardless of when, this PR should help in any case
- this PR should also help with this Stack Overflow [question](https://stackoverflow.com/questions/75096446/in-slick-grid-while-scrolling-through-columns-using-horizontal-bar-when-toggle)

The animated gif is not actually fast enough to catch the entire flickering, it's a lot worst for the user but it happens in millisecond and hard to catch by the recorder by annoying enough for human eyes. even if the gif is not showing the real flickering, it's enough to demonstrate the flickering we observed

![msedge_Uqid8Oe7TS](https://user-images.githubusercontent.com/643976/216388908-49ec78ed-30c8-4c33-b73d-49774c957b64.gif)
