### PR TITLE
feat: add `autoCommitEdit` grid option

### DIFF
--- a/cypress/integration/example3-editing.spec.js
+++ b/cypress/integration/example3-editing.spec.js
@@ -1,0 +1,115 @@
+/// <reference types="cypress" />
+
+describe('Example3 Editing', () => {
+  const titles = ['Title', 'Description', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
+  const GRID_ROW_HEIGHT = 25;
+
+  beforeEach(() => {
+    // create a console.log spy for later use
+    cy.window().then((win) => {
+      cy.spy(win.console, "log");
+    });
+  });
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example3-editing.html`);
+    cy.get('h2').contains('Demonstrates');
+    cy.get('h2 + ul > li').first().contains('adding basic keyboard navigation and editing');
+  });
+
+  it('should have exact Column Titles in the grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(titles[index]));
+  });
+
+  it('should be able to able to edit "Description" by double-clicking on first row and expect no more editable cell', () => {
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(1)`).should('contain', 'This is a sample');
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(1)`).click();
+    cy.get('.slick-large-editor-text').should('have.length', 0);
+
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(1)`).dblclick();
+    cy.get('.slick-large-editor-text').should('have.length', 1);
+
+    cy.get('.slick-large-editor-text textarea')
+      .type('Something else');
+
+    cy.get('.slick-large-editor-text')
+      .contains('Save')
+      .click();
+
+    cy.get('.slick-large-editor-text').should('have.length', 0);
+  });
+
+  it('should click on "Auto-Edit ON" button', () => {
+    cy.get('[data-test="auto-edit-on-btn"]')
+      .click();
+  });
+
+  it('should be able to able to edit "Description" by clicking once on second row and expect next row to become editable after clicking "Save" button', () => {
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(1)`).should('contain', 'This is a sample');
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(1)`).click();
+    cy.get('.slick-large-editor-text').should('have.length', 1);
+
+    cy.get('.slick-large-editor-text textarea')
+      .type('Second Row!');
+
+    cy.get('.slick-large-editor-text')
+      .contains('Save')
+      .click();
+
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(1)`).should('contain', 'Second Row!');
+    cy.get('.slick-large-editor-text').should('have.length', 1);
+
+    cy.get('.slick-large-editor-text textarea')
+      .invoke('val')
+      .then(text => expect(text).to.eq('This is a sample task description.\n  It can be multiline'));
+  });
+
+  it('should click on "Auto-Commit ON" button', () => {
+    cy.get('[data-test="auto-commit-on-btn"]')
+      .click();
+  });
+
+  it('should be able to able to edit "Description" by clicking once on second row and expect next row and not expect next line to become editable', () => {
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(1)`).should('contain', 'This is a sample');
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(1)`).click();
+    cy.get('.slick-large-editor-text').should('have.length', 1);
+
+    cy.get('.slick-large-editor-text textarea')
+      .type('Third Row Text');
+
+    cy.get('.slick-large-editor-text')
+      .contains('Save')
+      .click();
+
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(1)`).should('contain', 'Third Row Text');
+    cy.get('.slick-large-editor-text').should('have.length', 0);
+  });
+
+  it('should click on "Auto-Commit OFF" button', () => {
+    cy.get('[data-test="auto-commit-off-btn"]')
+      .click();
+  });
+
+  it('should be able to able to edit "Description" and expect once again that the next line will become editable', () => {
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 3}px"] > .slick-cell:nth(1)`).should('contain', 'This is a sample');
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 3}px"] > .slick-cell:nth(1)`).click();
+    cy.get('.slick-large-editor-text').should('have.length', 1);
+
+    cy.get('.slick-large-editor-text textarea')
+      .type('Fourth Row');
+
+    cy.get('.slick-large-editor-text')
+      .contains('Save')
+      .click();
+
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 3}px"] > .slick-cell:nth(1)`).should('contain', 'Fourth Row');
+    cy.get('.slick-large-editor-text').should('have.length', 1);
+
+    cy.get('.slick-large-editor-text textarea')
+      .invoke('val')
+      .then(text => expect(text).to.eq('This is a sample task description.\n  It can be multiline'));
+  });
+});

--- a/examples/example3-editing.html
+++ b/examples/example3-editing.html
@@ -33,13 +33,21 @@
     </ul>
 
     <h2>Options:</h2>
-    <button onclick="grid.setOptions({autoEdit:true})">Auto-edit ON</button>
-    &nbsp;
-    <button onclick="grid.setOptions({autoEdit:false})">Auto-edit OFF</button>
-      <h2>View Source:</h2>
-      <ul>
-          <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example3-editing.html" target="_sourcewindow"> View the source for this example on Github</a></li>
-      </ul>
+    <p>
+      <button data-test="auto-edit-on-btn" onclick="grid.setOptions({autoEdit:true})">Auto-edit ON</button>
+      &nbsp;
+      <button data-test="auto-edit-off-btn" onclick="grid.setOptions({autoEdit:false})">Auto-edit OFF</button>
+    </p>
+    <p>
+      <button data-test="auto-commit-on-btn"  onclick="grid.setOptions({autoCommitEdit:true})">AutoCommitEdit ON</button>
+      &nbsp;
+      <button data-test="auto-commit-off-btn"  onclick="grid.setOptions({autoCommitEdit:false})">AutoCommitEdit OFF</button>
+    </p>
+
+    <h2>View Source:</h2>
+    <ul>
+        <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example3-editing.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+    </ul>
   </div>
 </div>
 
@@ -83,7 +91,8 @@
     enableAddRow: true,
     enableCellNavigation: true,
     asyncEditorLoading: false,
-    autoEdit: false
+    autoEdit: false,
+    autoCommitEdit: false
   };
 
   $(function () {

--- a/slick.editors.js
+++ b/slick.editors.js
@@ -791,7 +791,12 @@
     };
 
     this.save = function () {
-      args.commitChanges();
+      const gridOptions = args.grid.getOptions() || {};
+      if (gridOptions.autoCommitEdit) {
+        args.grid.getEditorLock().commitCurrentEdit();
+      } else {
+        args.commitChanges();
+      }
     };
 
     this.cancel = function () {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -54,6 +54,7 @@ if (typeof Slick === "undefined") {
       leaveSpaceForNewRows: false,
       editable: false,
       autoEdit: true,
+      autoCommitEdit: false,
       suppressActiveCellChangeOnEdit: false,
       enableCellNavigation: true,
       enableColumnReorder: true,
@@ -5327,7 +5328,7 @@ if (typeof Slick === "undefined") {
       // if so, do not steal the focus from the editor
       if (getEditorLock().commitCurrentEdit()) {
         setFocus();
-        if (options.autoEdit) {
+        if (options.autoEdit && !options.autoCommitEdit) {
           navigateDown();
         }
       }


### PR DESCRIPTION
- this new option is helpful when `autoEdit` is enabled, by default the `autoEdit` will automatically navigate down and automatically open the next row cell, however when `autoCommitEdit` is enabled it will save but not open the next row cell

#### differences between `autoEdit` and the new `autoCommitEdit`
- `autoEdit` after an editor save, will automatically change active cell to the next bottom cell editor and open it
- `autoCommitEdit` after an editor save, will stay in the same cell position and will **not** open the next row editor

Note:
I actually already have this feature in all my other SlickGrid libs since couple years but I was actually patching the issue by calling `commitCurrentEdit()` (which I also added in this PR) but then it was automatically navigating down, so what I was doing was to change again the cell position to the previous position that the editor originated. So I decided to do this PR to avoid having to patch my libs and fix the source directly. This PR will avoid having to change position twice and fix the source (SlickGrid has always navigated down when `autoEdit` is enabled but not every user are happy with this).

https://github.com/6pac/SlickGrid/blob/b58e4bc4167336ac0371eeaf1212d54dd188dd7c/slick.grid.js#L5330-L5332

![brave_UMgjvjLCrF](https://user-images.githubusercontent.com/643976/217718145-cdcefaf3-45dc-4393-bc79-ab72b1f46491.gif)
