### PR TITLE
fix: dist source map file naming was incorrect

### DIFF
--- a/scripts/minify.js
+++ b/scripts/minify.js
@@ -97,7 +97,7 @@ function minifyJsFiles(filenames, version) {
     for (const filename of filenames) {
         console.log(filename);
         const writeFilePath = './dist/' + filename.replace('./', '').replace('.js', '.min.js');
-        const writeFileSourcePath = './dist/' + filename.replace('./', '').replace('.js', '.js.map');
+        const writeFileSourcePath = './dist/' + filename.replace('./', '').replace('.js', '.min.js.map');
         ensureDirectoryExistence(writeFilePath);
 
         const minifiedFile = UglifyJS.minify(


### PR DESCRIPTION
- JS source map must be named the same as the original JS file + `.map` suffix, in our case since we have `.min.js`, we need the sourcemap to be named `.min.js.map` to be auto-detected but ours were named incorrectly as `.js.map` (missing `.min` prefix and cannot auto-detected by Chrome

![image](https://user-images.githubusercontent.com/643976/221238150-3469c208-52f3-46fd-b87f-b4f8a0772572.png)
