### PR TITLE
show tooltip if the cell content is taller than the cell height - fixes #740

### DIFF
--- a/plugins/slick.autotooltips.js
+++ b/plugins/slick.autotooltips.js
@@ -56,7 +56,9 @@
             if (options.maxToolTipLength && text.length > options.maxToolTipLength) {
               text = text.substr(0, options.maxToolTipLength - 3) + "...";
             }
-          } else {
+          } else if ($node.innerHeight() < $node[0].scrollHeight) {
+            text = $.trim($node.text());
+	  } else {
             text = "";
           }
           $node.attr("title", text);

--- a/plugins/slick.autotooltips.js
+++ b/plugins/slick.autotooltips.js
@@ -51,13 +51,11 @@
         var $node = $(_grid.getCellNode(cell.row, cell.cell));
         var text;
         if (!$node.attr("title") || options.replaceExisting) {
-          if ($node.innerWidth() < $node[0].scrollWidth) {
+          if (($node.innerWidth() < $node[0].scrollWidth) || ($node.innerHeight() < $node[0].scrollHeight)) {
             text = $.trim($node.text());
             if (options.maxToolTipLength && text.length > options.maxToolTipLength) {
               text = text.substr(0, options.maxToolTipLength - 3) + "...";
             }
-          } else if ($node.innerHeight() < $node[0].scrollHeight) {
-            text = $.trim($node.text());
 	  } else {
             text = "";
           }


### PR DESCRIPTION
The current code does not show a tooltip when word wrap is turned on and the text is taller than the cell height.