### PR TITLE
chore: remove Map polyfill since we will target ES6

### DIFF
--- a/slick.core.js
+++ b/slick.core.js
@@ -684,55 +684,6 @@
     };
   }
 
-  /***
-   * Polyfill for Map to support old browsers but
-   * benefit of the Map speed in modern browsers.
-   * @class Map
-   * @constructor
-   */
-  var Map = 'Map' in window ? window.Map : function Map() {
-    var data = {};
-
-    /***
-     * Gets the item with the given key from the map or undefined if
-     * the map does not contain the item.
-     * @method get
-     * @param key {Map} The key of the item in the map.
-     */
-    this.get = function(key) {
-      return data[key];
-    };
-
-    /***
-     * Adds or updates the item with the given key in the map.
-     * @method set
-     * @param key The key of the item in the map.
-     * @param value The value to insert into the map of the item in the map.
-     */
-    this.set = function(key, value) {
-      data[key] = value;
-    };
-
-    /***
-     * Gets a value indicating whether the given key is present in the map.
-     * @method has
-     * @param key The key of the item in the map.
-     * @return {Boolean}
-     */
-    this.has = function(key) {
-      return key in data;
-    };
-
-    /***
-     * Removes the item with the given key from the map.
-     * @method delete
-     * @param key The key of the item in the map.
-     */
-    this.delete = function(key) {
-      delete data[key];
-    };
-  };
-
   function regexSanitizer(dirtyHtml) {
      return dirtyHtml.replace(/(\b)(on[a-z]+)(\s*)=|javascript:([^>]*)[^>]*|(<\s*)(\/*)script([<>]*).*(<\s*)(\/*)script(>*)|(&lt;)(\/*)(script|script defer)(.*)(&gt;|&gt;">)/gi, '');
   }
@@ -1086,7 +1037,6 @@
     "EventData": EventData,
     "EventHandler": EventHandler,
     "Range": Range,
-    "Map": Map,
     "NonDataRow": NonDataItem,
     "Group": Group,
     "GroupTotals": GroupTotals,
@@ -1137,73 +1087,74 @@
         }
       }
     },
-      /***
-       * A global singleton editor lock.
-       * @class GlobalEditorLock
-       * @static
-       * @constructor
-       */
-      "GlobalEditorLock": new EditorLock(),
-      "TreeColumns": TreeColumns,
 
-      "keyCode": {
-        SPACE: 8,
-        BACKSPACE: 8,
-        DELETE: 46,
-        DOWN: 40,
-        END: 35,
-        ENTER: 13,
-        ESCAPE: 27,
-        HOME: 36,
-        INSERT: 45,
-        LEFT: 37,
-        PAGE_DOWN: 34,
-        PAGE_UP: 33,
-        RIGHT: 39,
-        TAB: 9,
-        UP: 38,
-        A: 65
-      },
-      "preClickClassName" : "slick-edit-preclick",
+    /***
+     * A global singleton editor lock.
+     * @class GlobalEditorLock
+     * @static
+     * @constructor
+     */
+    "GlobalEditorLock": new EditorLock(),
+    "TreeColumns": TreeColumns,
 
-      "GridAutosizeColsMode": {
-        None: 'NOA',
-        LegacyOff: 'LOF',
-        LegacyForceFit: 'LFF',
-        IgnoreViewport: 'IGV',
-        FitColsToViewport: 'FCV',
-        FitViewportToCols: 'FVC'
-      },
+    "keyCode": {
+      SPACE: 8,
+      BACKSPACE: 8,
+      DELETE: 46,
+      DOWN: 40,
+      END: 35,
+      ENTER: 13,
+      ESCAPE: 27,
+      HOME: 36,
+      INSERT: 45,
+      LEFT: 37,
+      PAGE_DOWN: 34,
+      PAGE_UP: 33,
+      RIGHT: 39,
+      TAB: 9,
+      UP: 38,
+      A: 65
+    },
+    "preClickClassName": "slick-edit-preclick",
 
-      "ColAutosizeMode": {
-        Locked: 'LCK',
-        Guide: 'GUI',
-        Content: 'CON',
-        ContentExpandOnly: 'CXO',
-        ContentIntelligent: 'CTI'
-      },
+    "GridAutosizeColsMode": {
+      None: 'NOA',
+      LegacyOff: 'LOF',
+      LegacyForceFit: 'LFF',
+      IgnoreViewport: 'IGV',
+      FitColsToViewport: 'FCV',
+      FitViewportToCols: 'FVC'
+    },
 
-      "RowSelectionMode": {
-        FirstRow: 'FS1',
-        FirstNRows: 'FSN',
-        AllRows: 'ALL',
-        LastRow: 'LS1'
-      },
+    "ColAutosizeMode": {
+      Locked: 'LCK',
+      Guide: 'GUI',
+      Content: 'CON',
+      ContentExpandOnly: 'CXO',
+      ContentIntelligent: 'CTI'
+    },
 
-      "ValueFilterMode": {
-        None: 'NONE',
-        DeDuplicate: 'DEDP',
-        GetGreatestAndSub: 'GR8T',
-        GetLongestTextAndSub: 'LNSB',
-        GetLongestText: 'LNSC'
-      },
+    "RowSelectionMode": {
+      FirstRow: 'FS1',
+      FirstNRows: 'FSN',
+      AllRows: 'ALL',
+      LastRow: 'LS1'
+    },
 
-      "WidthEvalMode": {
-        Auto: 'AUTO',
-        TextOnly: 'CANV',
-        HTML: 'HTML'
-      }
+    "ValueFilterMode": {
+      None: 'NONE',
+      DeDuplicate: 'DEDP',
+      GetGreatestAndSub: 'GR8T',
+      GetLongestTextAndSub: 'LNSB',
+      GetLongestText: 'LNSC'
+    },
+
+    "WidthEvalMode": {
+      Auto: 'AUTO',
+      TextOnly: 'CANV',
+      HTML: 'HTML'
     }
+  }
 
   /*  eslint-disable no-undef */
   // also add to global object when exist

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -17,7 +17,7 @@
     var idProperty = "id";          // property holding a unique row id
     var items = [];                 // data by index
     var rows = [];                  // data by row
-    var idxById = new Slick.Map();   // indexes by id
+    var idxById = new Map();   // indexes by id
     var rowsById = null;            // rows by id; lazy-calculated
     var filter = null;              // filter function
     var updated = null;             // updated item ids
@@ -25,7 +25,7 @@
     var isBulkSuspend = false;      // delays various operations like the
                                     // index update and delete to efficient
                                     // versions at endUpdate
-    var bulkDeleteIds = new Slick.Map();
+    var bulkDeleteIds = new Map();
     var sortAsc = true;
     var fastSortField;
     var sortComparer;
@@ -169,7 +169,7 @@
       // inserted in the cleanup loop above.
       items.length = newIdx;
       // and finally cleanup the deleted ids to start cleanly on the next update.
-      bulkDeleteIds = new Slick.Map();
+      bulkDeleteIds = new Map();
     }
 
     function updateIdxById(startingIndex) {
@@ -214,7 +214,7 @@
       }
       items = filteredItems = data;
       onSetItemsCalled.notify({ idProperty: objectIdProperty, itemCount: items.length }, null, self);
-      idxById = new Slick.Map();
+      idxById = new Map();
       updateIdxById();
       ensureIdUniqueness();
       refresh();
@@ -253,7 +253,7 @@
       if (ascending === false) {
         items.reverse();
       }
-      idxById = new Slick.Map();
+      idxById = new Map();
       updateIdxById();
       refresh();
     }
@@ -281,7 +281,7 @@
       if (ascending === false) {
         items.reverse();
       }
-      idxById = new Slick.Map();
+      idxById = new Map();
       updateIdxById();
       refresh();
     }


### PR DESCRIPTION
- Slick.Map polyfill is no longer required since Map is included in ES6 browsers