### PR TITLE
fix: throw error when freezing columns are wider than canvas

### DIFF
--- a/slick.core.js
+++ b/slick.core.js
@@ -845,7 +845,7 @@
   }
 
   function width(el, value) {
-    if (!el) return;
+    if (!el || !el.getBoundingClientRect) return;
     if (value === undefined) {
       return el.getBoundingClientRect().width
     }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -904,6 +904,11 @@ if (typeof Slick === "undefined") {
         utils.width(_headerR, headersWidthR);
 
         if (hasFrozenColumns()) {
+          const cWidth = utils.width(_container) || 0;
+          if (cWidth > 0 && canvasWidthL > cWidth) {
+            throw new Error('[SlickGrid] Frozen columns cannot be wider than the actual grid container width. '
+              + 'Make sure to have less columns freezed or make your grid container wider');
+          }
           utils.width(_canvasTopR, canvasWidthR);
 
           utils.width(_paneHeaderL, canvasWidthL);


### PR DESCRIPTION
- closes #667
- freezing columns cannot be wider than the actual grid canvas because when that happens, the viewport scroll becomes hidden behind the canvas... so let's throw an error advising the user to make adjustments