### PR TITLE
fix: rollback JS event passive mode in SlickGrid

### DIFF
--- a/slick.core.js
+++ b/slick.core.js
@@ -624,32 +624,6 @@
     return Object.entries(obj).length === 0;
   }
 
-  /**
-   * Check if `passive` option is supported when adding event listener, follows detection provided in MDN:
-   * https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#safely_detecting_option_support
-   */
-  function passiveSupported() {
-    let passiveSupported = false;
-
-    try {
-      const options = {
-        get passive() {
-          passiveSupported = true;
-          return false;
-        },
-      };
-      window.addEventListener('test', null, options);
-      window.removeEventListener('test', null, options);
-    } catch (err) {
-      passiveSupported = false;
-    }
-    return passiveSupported;
-  }
-
-  function enablePassiveWhenSupported() {
-    return passiveSupported() ? { passive: true } : false
-  }
-
   function noop() { }
 
   function offset(el) {
@@ -917,8 +891,6 @@
       "calculateAvailableSpace": calculateAvailableSpace,
       "createDomElement": createDomElement,
       "emptyElement": emptyElement,
-      "passiveSupported": passiveSupported,
-      "enablePassiveWhenSupported": enablePassiveWhenSupported,
       "innerSize": innerSize,
       "isEmptyObject": isEmptyObject,
       "noop": noop,

--- a/slick.interactions.js
+++ b/slick.interactions.js
@@ -39,8 +39,8 @@
     };
 
     if (containerElement) {
-      containerElement.addEventListener('mousedown', userPressed, Slick.Utils.enablePassiveWhenSupported());
-      containerElement.addEventListener('touchstart', userPressed, Slick.Utils.enablePassiveWhenSupported());
+      containerElement.addEventListener('mousedown', userPressed);
+      containerElement.addEventListener('touchstart', userPressed);
     }
 
     function executeDragCallbackWhenDefined(callback, e, dd) {
@@ -51,8 +51,8 @@
 
     function destroy() {
       if (containerElement) {
-        containerElement.removeEventListener('mousedown', userPressed, Slick.Utils.enablePassiveWhenSupported());
-        containerElement.removeEventListener('touchstart', userPressed, Slick.Utils.enablePassiveWhenSupported());
+        containerElement.removeEventListener('mousedown', userPressed);
+        containerElement.removeEventListener('touchstart', userPressed);
       }
     }
 


### PR DESCRIPTION
- rollback PR #769 that brough event passive mode, it turns out that all our SlickGrid events can use `preventDefault` which is what passive mode is for, so it's better to rollback all of it

console error caught while editing any cell on [example3-editing.html](https://6pac.github.io/SlickGrid/examples/example3-editing.html)

![image](https://github.com/6pac/SlickGrid/assets/643976/b6a09ca4-fe7e-4a03-80e7-cd0f77a58a2a)
