### PR TITLE
fix: `idxById` could be undefined when changing page in SPA

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -137,6 +137,7 @@
      * by recomputing the items and idxById members.
      */
     function processBulkDelete() {
+      if (!idxById) return;
       // the bulk update is processed by
       // recomputing the whole items array and the index lookup in one go.
       // this is done by placing the not-deleted items
@@ -173,7 +174,7 @@
     }
 
     function updateIdxById(startingIndex) {
-      if (isBulkSuspend) { // during bulk update we do not reorganize
+      if (isBulkSuspend || !idxById) { // during bulk update we do not reorganize
         return;
       }
       startingIndex = startingIndex || 0;
@@ -188,7 +189,7 @@
     }
 
     function ensureIdUniqueness() {
-      if (isBulkSuspend) { // during bulk update we do not reorganize
+      if (isBulkSuspend || !idxById) { // during bulk update we do not reorganize
         return;
       }
       var id;
@@ -381,7 +382,7 @@
     }
 
     function getIdxById(id) {
-      return idxById.get(id);
+      return idxById && idxById.get(id);
     }
 
     function ensureRowsByIdCache() {
@@ -404,7 +405,7 @@
     }
 
     function getItemById(id) {
-      return items[idxById.get(id)];
+      return items[idxById && idxById.get(id)];
     }
 
     function mapItemsToRows(itemArray) {
@@ -449,6 +450,8 @@
      * @param item The item which should be the new value for the given id.
      */
     function updateSingleItem(id, item) {
+      if (!idxById) return;
+
       // see also https://github.com/mleibman/SlickGrid/issues/1082
       if (!idxById.has(id)) {
         throw new Error("[SlickGrid DataView] Invalid id");
@@ -559,6 +562,7 @@
      * @param id The id identifying the object to delete.
      */
     function deleteItem(id) {
+      if (!idxById) return;
       if (isBulkSuspend) {
         bulkDeleteIds.set(id, true);
       } else {
@@ -578,7 +582,7 @@
      * @param ids {Array} The ids of the items to delete.
      */
     function deleteItems(ids) {
-      if (ids.length === 0) {
+      if (ids.length === 0 || !idxById) {
         return;
       }
 
@@ -624,6 +628,7 @@
     }
 
     function sortedUpdateItem(id, item) {
+      if (!idxById) return;
       if (!idxById.has(id) || id !== item[idProperty]) {
         throw new Error("[SlickGrid DataView] Invalid or non-matching id " + idxById.get(id));
       }


### PR DESCRIPTION
- in some rare occasion in a SPA (single page app), changing page could change `idxById` to be undefined because it could get undefined in `destroy` function, this PR will avoid errors showing up in console