### PR TITLE
fix: make sure column is defined before calling hidden prop

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -778,7 +778,7 @@ if (typeof Slick === "undefined") {
       var includeScrollbar = !options.autoHeight;
 
       for (var i = 0, ii = columns.length; i < ii; i++) {
-        if (columns[ i ].hidden) continue;
+        if (!columns[i] || columns[i].hidden) continue;
 
         var width = columns[ i ].width;
 
@@ -857,7 +857,7 @@ if (typeof Slick === "undefined") {
       canvasWidthL = canvasWidthR = 0;
 
       while (i--) {
-       if (columns[ i ].hidden) continue;
+       if (!columns[i] || columns[i].hidden) continue;
 
         if (hasFrozenColumns() && (i > options.frozenColumn)) {
           canvasWidthR += columns[i].width;
@@ -1181,7 +1181,7 @@ if (typeof Slick === "undefined") {
 
         for (var i = 0; i < columns.length; i++) {
           var m = columns[i];
-          if (m.hidden) continue;
+          if (!m || m.hidden) continue;
 
           const footerRowCell = utils.createDomElement('div', { className: `ui-state-default slick-footerrow-column l${i} r${i}` }, hasFrozenColumns() && (i > options.frozenColumn) ? _footerRowR : _footerRowL);
           const className = hasFrozenColumns() && i <= options.frozenColumn? 'frozen': null;
@@ -1281,7 +1281,7 @@ if (typeof Slick === "undefined") {
 
       for (var i = 0; i < columns.length; i++) {
         const m = columns[i];
-        if (m.hidden) continue;
+        if (!m || m.hidden) continue;
 
         const headerTarget = hasFrozenColumns() ? ((i <= options.frozenColumn) ? _headerL : _headerR) : _headerL;
         const headerRowTarget = hasFrozenColumns() ? ((i <= options.frozenColumn) ? _headerRowL : _headerRowR) : _headerRowL;
@@ -1605,7 +1605,7 @@ if (typeof Slick === "undefined") {
           handle.remove();
         });
 
-        if (i >= columns.length || columns[i].hidden) {
+        if (i >= columns.length || !columns[i] || columns[i].hidden) {
           continue;
         }
 
@@ -1624,7 +1624,7 @@ if (typeof Slick === "undefined") {
       for (let i = 0; i < children.length; i++) {
         const colElm = children[i];
 
-        if (i >= columns.length || columns[i].hidden) { continue; }
+        if (i >= columns.length || !columns[i] || columns[i].hidden) { continue; }
         if (i < firstResizable || (options.forceFitColumns && i >= lastResizable)) {
           continue;
         }
@@ -1647,7 +1647,7 @@ if (typeof Slick === "undefined") {
               var shrinkLeewayOnRight = null, stretchLeewayOnRight = null;
               // lock each column's width option to current width
               for (let pw = 0; pw < children.length; pw++) {
-                if (pw >= columns.length || columns[pw].hidden) {
+                if (pw >= columns.length || !columns[pw] || columns[pw].hidden) {
                   continue;
                 }
                 columns[pw].previousWidth = children[pw].offsetWidth;
@@ -1658,7 +1658,7 @@ if (typeof Slick === "undefined") {
                 // colums on right affect maxPageX/minPageX
                 for (j = i + 1; j < columns.length; j++) {
                   c = columns[j];
-                  if (c.resizable && !c.hidden) {
+                  if (c && c.resizable && !c.hidden) {
                     if (stretchLeewayOnRight !== null) {
                       if (c.maxWidth) {
                         stretchLeewayOnRight += c.maxWidth - c.previousWidth;
@@ -1674,7 +1674,7 @@ if (typeof Slick === "undefined") {
               for (j = 0; j <= i; j++) {
                 // columns on left only affect minPageX
                 c = columns[j];
-                if (c.resizable && !c.hidden) {
+                if (c && c.resizable && !c.hidden) {
                   if (stretchLeewayOnLeft !== null) {
                     if (c.maxWidth) {
                       stretchLeewayOnLeft += c.maxWidth - c.previousWidth;
@@ -1712,7 +1712,7 @@ if (typeof Slick === "undefined") {
 
                 for (j = i; j >= 0; j--) {
                   c = columns[j];
-                  if (c.resizable && !c.hidden) {
+                  if (c && c.resizable && !c.hidden) {
                     actualMinWidth = Math.max(c.minWidth || 0, absoluteColumnMinWidth);
                     if (x && c.previousWidth + x < actualMinWidth) {
                       x += c.previousWidth - actualMinWidth;
@@ -1726,8 +1726,8 @@ if (typeof Slick === "undefined") {
 
                 for (k = 0; k <= i; k++) {
                   c = columns[k];
-                  if (c.hidden) { continue; }
- 
+                  if (!c || c.hidden) { continue; }
+
                   if (hasFrozenColumns() && (k > options.frozenColumn)) {
                     newCanvasWidthR += c.width;
                   } else {
@@ -1739,7 +1739,7 @@ if (typeof Slick === "undefined") {
                   x = -d;
                   for (j = i + 1; j < columns.length; j++) {
                     c = columns[j];
-                    if (c.hidden) { continue; }
+                    if (!c || c.hidden) { continue; }
                     if (c.resizable) {
                       if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
                         x -= c.maxWidth - c.previousWidth;
@@ -1759,8 +1759,8 @@ if (typeof Slick === "undefined") {
                 } else {
                   for (j = i + 1; j < columns.length; j++) {
                     c = columns[j];
-                    if (c.hidden) { continue; }
- 
+                    if (!c || c.hidden) { continue; }
+
                     if (hasFrozenColumns() && (j > options.frozenColumn)) {
                       newCanvasWidthR += c.width;
                     } else {
@@ -1773,7 +1773,7 @@ if (typeof Slick === "undefined") {
                   x = -d;
                   for (j = i + 1; j < columns.length; j++) {
                     c = columns[j];
-                     if (c.hidden) { continue; }
+                     if (!c || c.hidden) { continue; }
                      if (c.resizable) {
                       if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
                         x -= c.maxWidth - c.previousWidth;
@@ -1793,7 +1793,7 @@ if (typeof Slick === "undefined") {
 
                 for (j = i; j >= 0; j--) {
                   c = columns[j];
-                  if (c.hidden) { continue; }
+                  if (!c || c.hidden) { continue; }
                   if (c.resizable) {
                     if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
                       x -= c.maxWidth - c.previousWidth;
@@ -1818,8 +1818,8 @@ if (typeof Slick === "undefined") {
 
                 for (k = 0; k <= i; k++) {
                   c = columns[k];
-                  if (c.hidden) { continue; }
- 
+                  if (!c || c.hidden) { continue; }
+
                   if (hasFrozenColumns() && (k > options.frozenColumn)) {
                     newCanvasWidthR += c.width;
                   } else {
@@ -1831,7 +1831,7 @@ if (typeof Slick === "undefined") {
                   x = -d;
                   for (j = i + 1; j < columns.length; j++) {
                     c = columns[j];
-                    if (c.hidden) { continue; }
+                    if (!c || c.hidden) { continue; }
                     if (c.resizable) {
                       actualMinWidth = Math.max(c.minWidth || 0, absoluteColumnMinWidth);
                       if (x && c.previousWidth + x < actualMinWidth) {
@@ -1852,7 +1852,7 @@ if (typeof Slick === "undefined") {
                 } else {
                   for (j = i + 1; j < columns.length; j++) {
                     c = columns[j];
-                    if (c.hidden) { continue; }
+                    if (!c || c.hidden) { continue; }
 
                     if (hasFrozenColumns() && (j > options.frozenColumn)) {
                       newCanvasWidthR += c.width;
@@ -1887,7 +1887,7 @@ if (typeof Slick === "undefined") {
               var newWidth;
               for (j = 0; j < columns.length; j++) {
                 c = columns[j];
-                if (c.hidden) { continue; }
+                if (!c || c.hidden) { continue; }
                 newWidth = children[j].offsetWidth;
 
                 if (c.previousWidth !== newWidth && c.rerenderOnResize) {
@@ -2069,8 +2069,8 @@ if (typeof Slick === "undefined") {
       ];
 
       for (var i = 0; i < columns.length; i++) {
-        if (columns[i].hidden) continue;
-        
+        if (!columns[i] || columns[i].hidden) continue;
+
         rules.push("." + uid + " .l" + i + " { }");
         rules.push("." + uid + " .r" + i + " { }");
       }
@@ -2400,8 +2400,8 @@ if (typeof Slick === "undefined") {
           // if addl space remains in the viewport and there are SizeToRemaining cols, just the SizeToRemaining cols expand proportionally to fill viewport
           for (i = 0; i < columns.length; i++) {
             c = columns[i];
-            if (c.hidden) continue;
-            
+            if (!c || c.hidden) continue;
+
             var totalSTRViewportWidth = viewportWidth - totalWidthLessSTR;
             if (c.autoSize.sizeToRemaining) {
               colWidth = totalSTRViewportWidth * c.autoSize.widthPx / strColTotalGuideWidth;
@@ -2424,8 +2424,8 @@ if (typeof Slick === "undefined") {
           var unallocatedViewportWidth = viewportWidth - totalLockedColWidth - strColsMinWidth;
           for (i = 0; i < columns.length; i++) {
             c = columns[i];
-            if (c.hidden) continue;            
-            
+            if (!c || c.hidden) continue;
+
             colWidth = c.width;
             if (c.autoSize.autosizeMode !== Slick.ColAutosizeMode.Locked && !treatAsLocked(c.autoSize)) {
               if (c.autoSize.sizeToRemaining) {
@@ -2459,8 +2459,8 @@ if (typeof Slick === "undefined") {
       if (autosizeMode === Slick.GridAutosizeColsMode.IgnoreViewport) {
         // just size columns as-is
         for (i = 0; i < columns.length; i++) {
-          if (columns[i].hidden) continue;
-          
+          if (!columns[i] || columns[i].hidden) continue;
+
           colWidth = columns[i].autoSize.widthPx;
           if (columns[i].rerenderOnResize && columns[i].width != colWidth) {
             reRender = true;
@@ -2477,7 +2477,7 @@ if (typeof Slick === "undefined") {
       for (var i = 0; i < columns.length; i++) { s += ' ' + (columns[i].hidden ? "H" : columns[i].width); }
       console.log(s);
     }
-    
+
     function getColAutosizeWidth(columnDef, colIndex, gridCanvas, isInit, colArrayIndex) {
       var autoSize = columnDef.autoSize;
 
@@ -2765,7 +2765,7 @@ if (typeof Slick === "undefined") {
 
       for (i = 0; i < columns.length; i++) {
         c = columns[i];
-        if (c.hidden) continue;        
+        if (!c || c.hidden) continue;
         widths.push(c.width);
         total += c.width;
         if (c.resizable) {
@@ -2779,7 +2779,7 @@ if (typeof Slick === "undefined") {
         var shrinkProportion = (total - availWidth) / shrinkLeeway;
         for (i = 0; i < columns.length && total > availWidth; i++) {
           c = columns[i];
-          if (c.hidden) continue;        
+          if (!c || c.hidden) continue;
           var width = widths[i];
           if (!c.resizable || width <= c.minWidth || width <= absoluteColumnMinWidth) {
             continue;
@@ -2803,7 +2803,7 @@ if (typeof Slick === "undefined") {
         var growProportion = availWidth / total;
         for (i = 0; i < columns.length && total < availWidth; i++) {
           c = columns[i];
-          if (c.hidden) continue;        
+          if (!c || c.hidden) continue;
           var currentWidth = widths[i];
           var growSize;
 
@@ -2823,7 +2823,7 @@ if (typeof Slick === "undefined") {
 
       var reRender = false;
       for (i = 0; i < columns.length; i++) {
-        if (c.hidden) continue;        
+        if (!c || c.hidden) continue;
 
         if (columns[i].rerenderOnResize && columns[i].width != widths[i]) {
           reRender = true;
@@ -2849,7 +2849,7 @@ if (typeof Slick === "undefined") {
     function getVisibleColumns() {
       return columns.filter(c => !c.hidden);
     }
-    
+
     //////////////////////////////////////////////////////////////////////////////////////////////
     // General
     //////////////////////////////////////////////////////////////////////////////////////////////
@@ -2897,7 +2897,7 @@ if (typeof Slick === "undefined") {
     function applyColumnWidths() {
       var x = 0, w, rule;
       for (var i = 0; i < columns.length; i++) {
-        if (!columns[i].hidden) {       
+        if (!(columns[i] && columns[i].hidden)) {
           w = columns[i].width;
 
           rule = getColumnCssRules(i);
@@ -3035,8 +3035,8 @@ if (typeof Slick === "undefined") {
       columnPosRight = [];
       var x = 0;
       for (var i = 0, ii = columns.length; i < ii; i++) {
-        if (columns[i].hidden) continue;
-        
+        if (!columns[i] || columns[i].hidden) continue;
+
         columnPosLeft[i] = x;
         columnPosRight[i] = x + columns[i].width;
 
@@ -3071,14 +3071,14 @@ if (typeof Slick === "undefined") {
       columns = columnDefinitions;
 
       columns = columnDefinitions;
-      updateColumnsInternal();      
+      updateColumnsInternal();
     }
-    
+
     function updateColumns() {
       trigger(self.onBeforeUpdateColumns, { columns: columns, grid: self });
       updateColumnsInternal();
     }
-    
+
     function updateColumnsInternal() {
       updateColumnProps();
       updateColumnCaches();
@@ -3149,7 +3149,7 @@ if (typeof Slick === "undefined") {
       if (!suppressColumnSet) {
         setColumns(columns);
       }
-      
+
       if (options.enableMouseWheelScrollHandler && _viewport && (!slickMouseWheelInstances || slickMouseWheelInstances.length === 0)) {
         _viewport.forEach(function (view) {
           slickMouseWheelInstances.push(Slick.MouseWheel({
@@ -3384,8 +3384,8 @@ if (typeof Slick === "undefined") {
       var colspan, m;
       for (var i = 0, ii = columns.length; i < ii; i++) {
         m = columns[i];
-        if (m.hidden) continue;
-        
+        if (!m || m.hidden) continue;
+
         colspan = 1;
         if (metadata && metadata.columns) {
           var columnData = metadata.columns[m.id] || metadata.columns[i];
@@ -3661,7 +3661,7 @@ if (typeof Slick === "undefined") {
 
         columnIdx = columnIdx | 0;
         var m = columns[columnIdx],
-        
+
         node = cacheEntry.cellNodesByColumnIdx[columnIdx];
 
         if (row === activeRow && columnIdx === activeCell && currentEditor) {
@@ -4078,8 +4078,8 @@ if (typeof Slick === "undefined") {
 
         // TODO:  shorten this loop (index? heuristics? binary search?)
         for (var i = 0, ii = columns.length; i < ii; i++) {
-          if (columns[i].hidden) continue;
-          
+          if (!columns[i] || columns[i].hidden) continue;
+
           // Cells to the right are outside the range.
           if (columnPosLeft[i] > range.rightPx) {
             break;
@@ -4930,8 +4930,8 @@ if (typeof Slick === "undefined") {
 
       var w = 0;
       for (var i = 0; i < columns.length && w < x; i++) {
-        if (columns[i].hidden) continue;
-        
+        if (!columns[i] || columns[i].hidden) continue;
+
         w += columns[i].width;
         cell++;
       }
@@ -5045,8 +5045,8 @@ if (typeof Slick === "undefined") {
       var y2 = y1 + options.rowHeight - 1;
       var x1 = 0;
       for (var i = 0; i < cell; i++) {
-        if (columns[i].hidden) continue;
-        
+        if (!columns[i] || columns[i].hidden) continue;
+
         x1 += columns[i].width;
 
         if (options.frozenColumn == i) {
@@ -5201,7 +5201,7 @@ if (typeof Slick === "undefined") {
       }
 
       // does this cell have an editor?
-      if (columns[cell].hidden || !getEditor(row, cell)) {
+      if (!columns[cell] || columns[cell].hidden || !getEditor(row, cell)) {
         return false;
       }
 
@@ -5923,10 +5923,10 @@ if (typeof Slick === "undefined") {
         return false;
       }
 
-      if (columns[cell].hidden) {
+      if (!columns[cell] || columns[cell].hidden) {
         return false;
       }
-      
+
       var rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
       if (rowMetadata && typeof rowMetadata.focusable !== "undefined") {
         return !!rowMetadata.focusable;
@@ -5948,10 +5948,10 @@ if (typeof Slick === "undefined") {
         return false;
       }
 
-      if (columns[cell].hidden) {
+      if (!columns[cell] || columns[cell].hidden) {
         return false;
       }
-      
+
       var rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
       if (rowMetadata && typeof rowMetadata.selectable !== "undefined") {
         return !!rowMetadata.selectable;


### PR DESCRIPTION
- while testing in all other SlickGrid libs, I got the following console error thrown, so this PR fixes it by making sure all columns are defined before going further
> Cannot read properties of undefined (reading 'hidden')

and with these 2 PRs, I'm done with my libs testing, I'll be ready for an official release (that is after addressing the issues with hidden feature)