### PR TITLE
feat: exclude checkbox selection from col picker/grid menu

### DIFF
--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -333,7 +333,11 @@
         sortable: false,
         cssClass: _options.cssClass,
         hideSelectAllCheckbox: _options.hideSelectAllCheckbox,
-        formatter: checkboxSelectionFormatter
+        formatter: checkboxSelectionFormatter,
+        // exclude from all menus, defaults to true unless the option is provided differently by the user
+        excludeFromColumnPicker: typeof _options.excludeFromColumnPicker !== 'undefined' ? _options.excludeFromColumnPicker : true,
+        excludeFromGridMenu: typeof _options.excludeFromGridMenu !== 'undefined' ? _options.excludeFromGridMenu : true,
+        excludeFromHeaderMenu: typeof _options.excludeFromHeaderMenu !== 'undefined' ? _options.excludeFromHeaderMenu : true,
       };
     }
 


### PR DESCRIPTION
- the checkbox row selection column should be excluded from all menus, defaults to true unless the option is provided differently by the user
- this was asked on Stack Overflow https://stackoverflow.com/questions/76424966/slickgrid-how-to-exclude-checkboxselectcolumn-from-columnpicker

![image](https://github.com/6pac/SlickGrid/assets/643976/f46d0393-fc6c-427d-9463-4c118ed076cc)
