### PR TITLE
fix(demo): example with 3 plugins not sorting correctly

### DIFF
--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -248,18 +248,6 @@
       checkboxSelectorPlugin = new Slick.CheckboxSelectColumn({ cssClass: "slick-cell-checkboxsel" });
       columns.splice(columnIndex, 0, checkboxSelectorPlugin.getColumnDefinition());
 
-      grid = new Slick.Grid("#myGrid", dataView, columns, options);
-
-      // register the Selection Model that will be used for all Plugins
-      grid.setSelectionModel(new Slick.RowSelectionModel({
-        selectActiveRow: false,
-        dragToSelect: true
-      }));
-
-      // register all Plugins (Row Selection / Row Detail)
-      grid.registerPlugin(checkboxSelectorPlugin);
-      grid.registerPlugin(detailViewPlugin);
-
       rowMovePlugin = new Slick.RowMoveManager({
         cancelEditOnDrag: true,
         singleRowMove: true,
@@ -274,10 +262,22 @@
           return (dataContext.id % 2 === 1);
         }
       });
-      grid.registerPlugin(rowMovePlugin);
 
       // use unshift to make it the 1st column OR splice to position it where you wish
       columns.splice(1, 0, rowMovePlugin.getColumnDefinition());
+
+      grid = new Slick.Grid("#myGrid", dataView, columns, options);
+
+      // register the Selection Model that will be used for all Plugins
+      grid.setSelectionModel(new Slick.RowSelectionModel({
+        selectActiveRow: false,
+        dragToSelect: true
+      }));
+
+      // register all Plugins (Row Selection / Row Detail)
+      grid.registerPlugin(checkboxSelectorPlugin);
+      grid.registerPlugin(detailViewPlugin);
+      grid.registerPlugin(rowMovePlugin);
 
       rowMovePlugin.onBeforeMoveRows.subscribe(function (e, args) {
         // collapse any Row Details to avoid any rendering issues


### PR DESCRIPTION
- example with 3 plugins was sorting with a column offset, the reason was because the RowMove plugin was created after SlickGrid and for that reason RowMove wasn't part of the columns passed to SlickGrid
- in short all plugins must change the `columns` array before passing it to the SlickGrid creation

![brave_28WEVqcU72](https://github.com/6pac/SlickGrid/assets/643976/7a0a0548-08fd-4283-ba66-28dbab7cd96b)
