### PR TITLE
fix: Grid Menu is shown twice after changing frozen options

### DIFF
--- a/controls/slick.gridmenu.js
+++ b/controls/slick.gridmenu.js
@@ -284,6 +284,7 @@
         // put back original width (fixes width and frozen+gridMenu on left header)
         _headerElm.style.width = '100%';
       }
+      _buttonElm && _buttonElm.remove();
       _menuElm && _menuElm.remove();
     }
 


### PR DESCRIPTION
- when removing frozen columns and then reapplying them, we might end up with 2 Grid Menu icons, we need to make sure to delete any previous grid menu icon before recreating a new one

after calling these 2 actions multiple times, we get 2x grid menu icons

![image](https://github.com/6pac/SlickGrid/assets/643976/178f538b-8f23-4040-a71c-2830e2f86ebb)

as shown below

![image](https://github.com/6pac/SlickGrid/assets/643976/61edf7eb-030c-4d53-a779-e6adc0ebf3ee)
