### PR TITLE
fix: `getComputedStyle` could throw when DOM element is invalid

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -5335,7 +5335,7 @@ if (typeof Slick === "undefined") {
       // walk up the tree
       var offsetParent = elem.offsetParent;
       while ((elem = elem.parentNode) != document.body) {
-        if (elem == null) {
+        if (!elem || !elem.parentNode) {
           break;
         }
 


### PR DESCRIPTION
- fixes an error detected in our Salesforce environment as shown below, the issue is simply that we should always make sure that we do have a valid DOM element before calling any method on that said element

![image](https://github.com/6pac/SlickGrid/assets/643976/27c3bc41-f0a5-4f0b-b60d-680278fb4605)
