### PR TITLE
fix: make sure DOM element is valid before calling method on it

### DIFF
--- a/slick.core.js
+++ b/slick.core.js
@@ -696,6 +696,9 @@
     const hidden = selector == ":hidden";
 
     while ((el = el.parentNode) && el !== document) {
+      if (!el || !el.parentNode) {
+        break;
+      }
       if (hidden) {
         if(isHidden(el)) {
           parents.push(el);


### PR DESCRIPTION
- similar to the other PR I've opened but in a different method, we need to make sure that we have a valid DOM element before calling any method on that said element. In this case, the `parents()` function was throwing when trying to call `el.matches(...)` because the element was invalid