### PR TITLE
fix: `onBeforeAppendCell` should only be used when it's a string

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3457,9 +3457,13 @@ if (typeof Slick === "undefined") {
       }
 
       // get addl css class names from object type formatter return and from string type return of onBeforeAppendCell
+      // we will only use the event result as CSS classes when it is a string type (undefined event always return a true boolean which is not a valid css class)
       const evt = trigger(self.onBeforeAppendCell, { row: row, cell: cell, value: value, dataContext: item });
-      var addlCssClasses = evt.getReturnValue() || '';
-      addlCssClasses += (formatterResult && formatterResult.addClasses ? (addlCssClasses ? ' ' : '') + formatterResult.addClasses : '');
+      var appendCellResult = evt.getReturnValue();
+      var addlCssClasses = typeof appendCellResult === 'string' ? appendCellResult : '';
+      if (formatterResult && formatterResult.addClasses) {
+        addlCssClasses += (addlCssClasses ? ' ' : '') + formatterResult.addClasses;
+      }
       var toolTip = formatterResult && formatterResult.toolTip ? "title='" + formatterResult.toolTip + "'" : '';
 
       var customAttrStr = '';


### PR DESCRIPTION
- the `onBeforeAppendCell` event can be used to return CSS classes as demoed in this [example2-formatters-event.html](http://6pac.github.io/SlickGrid/examples/example2-formatters-event.html), however when the user doesn't define or use this event then the event is always a `true` boolean that sometime gets added to the the `slick-cell` divs and that code was implemented that way from the beginning, we should really only use the event response when it is of type string but don't use it otherwise (because when the event is not defined or used by the user, its output will always be a `true` boolean and we don't want that to be added to our list of css classes)
- the original implementation was found in this old [commit](https://github.com/6pac/SlickGrid/commit/bef3203d722b96853a312929a74121eac15ebed5) and on top of that `onBeforeAppendCell` event is actually deprecated to use.

### before the fix (we see a bunch of "true" class for some grids)

![image](https://github.com/6pac/SlickGrid/assets/643976/592078b1-9ac2-4810-b77e-75f34cdd2553)


### with the fix

![image](https://github.com/6pac/SlickGrid/assets/643976/f4db282d-37d7-496c-8138-c34bbc264b81)
