### PR TITLE
Remove 'columns' and 'options' object replacement on initialisation

### DIFF
--- a/slick.core.js
+++ b/slick.core.js
@@ -760,6 +760,16 @@
     callback();
   }
 
+  function applyDefaults(targetObj, srcObj) {
+    for (const key in srcObj) {
+      if (srcObj.hasOwnProperty(key)) {
+        if (!targetObj.hasOwnProperty(key)) {
+          targetObj[key] = srcObj[key];
+        }
+      }
+    }
+  }
+
   // jQuery's extend
   var getProto = Object.getPrototypeOf;
   var class2type = {};
@@ -908,6 +918,7 @@
       "hide": hide,
       "slideUp": slideUp,
       "slideDown": slideDown,
+      "applyDefaults": applyDefaults,
       "storage": {
         // https://stackoverflow.com/questions/29222027/vanilla-alternative-to-jquery-data-function-any-native-javascript-alternati
         _storage: new WeakMap(),


### PR DESCRIPTION
This will allow passed-in ```options``` and ```columns``` objects to be maintained and updated, rather than extending them from an empty object during initialisation, which reassigns the variable and breaks the link to the original object.

    var options = {
      editable: true,
      enableAddRow: true,
      topPanelHeight: 25
    };
    grid = new Slick.Grid("#myGrid", dataView, columns, options);
 
Before this PR, ```options``` would no longer be connected to the ```options``` variable inside the grid. After, it will remain connected.

This could be a breaking change only if code depends on the ```options``` or ```columns``` objects remaining unchanged, for example if they are used as an 'original state' which is to be preserved and reused later.

For  ```columns```, the main reason for preservation of the original object would be showing/hiding. Since the introduction of the ```hidden``` column property, this approach (which is over-complex and fragile) is able to be simplified and the existing columns shown or hidden simply by changing the property and refreshing the grid. This means this it is only ever necessary to have a single copy of the columns.

There is a new option ```useLegacySettingObjectConfiguration``` which, if true, preserves the previous method of initialisation. This PR defaults it to false for the time being so we can Break Stuff during testing.

For ```options```, there is a new ```updateOptions``` method which can be used in place of ```setOptions```. It will trigger changes to the grid after externally updating properties of the ```options``` object, and can trigger an ```onUpdateOptions``` event, which is different to the ```onSetOptions event``` in that it only passes the current ```options``` object rather than the before and after versions.

The ```columns``` property already has an ```updateColumns``` method which was added for the same reason, to provide grid updates after external changes to column objects in the ```columns``` array.

@ghiscoding wanting your evaluation and approval of this PR. 