### PR TITLE
Viewport height fix

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3704,6 +3704,8 @@ if (typeof Slick === "undefined") {
 
         const style = getComputedStyle(_container);
         viewportH = utils.toFloat(style.height)
+          + utils.toFloat(style.borderBottom)
+          + utils.toFloat(style.borderTop)
           - utils.toFloat(style.paddingTop)
           - utils.toFloat(style.paddingBottom)
           - columnNamesH


### PR DESCRIPTION
Hi team, 

I am using SlickGrid in my project and I have noticed that it is giving an unnecessary scrollbar when there's a single record in it and 2 empty pixels after the last row.

I have investigated the code and found that that while calculating the viewport height, the 2 pixels used for the **border** haven’t been considered. So, I have raised a PR for it.

**Before:**
This is the gird for single item. There is an unnecessary scrollbar and an unutilized 2px after the row.
![img1](https://github.com/6pac/SlickGrid/assets/38428547/617c70f3-b8b2-4eb1-b054-b611eb463814)

_For multiple items._
Same here, unutilized 2px after the last row.
![img2](https://github.com/6pac/SlickGrid/assets/38428547/460a474f-cfa5-49f0-abcc-e0f3593838cd)

**After the fix:**
_For single row._
![img3](https://github.com/6pac/SlickGrid/assets/38428547/de16f5cb-9c0f-4a6e-aa58-f4f192bbd1c8)
_For multiple items._
![img4](https://github.com/6pac/SlickGrid/assets/38428547/c70f2546-1fcb-4fdb-8eab-aecca91668d4)

Thanks.
