### PR TITLE
chore: excel copy manager slickrange args was incorrect

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
-      "require": "./dist/browser/index.js",
+      "require": "./dist/cjs/index.js",
       "default": "./dist/esm/index.js"
     },
     "./*": "./*"

--- a/scripts/dev-watch.mjs
+++ b/scripts/dev-watch.mjs
@@ -3,7 +3,7 @@ import chokidar from 'chokidar';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-import { buildAllSassFiles, buildIifeFile, buildSassFile, buildAllIifeFiles, executeEsmBuild, executeFullBuild } from './builds.mjs';
+import { buildAllSassFiles, buildIifeFile, buildSassFile, buildAllIifeFiles, executeCjsEsmBuilds, executeFullBuild } from './builds.mjs';
 
 const argv = yargs(hideBin(process.argv)).argv;
 
@@ -103,7 +103,7 @@ const argv = yargs(hideBin(process.argv)).argv;
           processing = true;
           if (filepath.endsWith('.js') || filepath.endsWith('.ts')) {
             // 1. ESM requires is always a full build since it is bundled into a single "index.js" file
-            await executeEsmBuild();
+            await executeCjsEsmBuilds();
 
             // 2. for iife format, we can rebuild each separate file (unless it's the initial build, if so execute full rebuild)
             await (initialBuild

--- a/src/plugins/slick.cellexternalcopymanager.ts
+++ b/src/plugins/slick.cellexternalcopymanager.ts
@@ -287,10 +287,10 @@ export class SlickCellExternalCopyManager implements Plugin {
         }
 
         const bRange = new SlickRange(
-          activeCell,
           activeRow,
-          activeCell + this._clipCommand.w - 1,
-          activeRow + this._clipCommand.h - 1
+          activeCell,
+          activeRow + this._clipCommand.h - 1,
+          activeCell + this._clipCommand.w - 1
         );
 
         this.markCopySelection([bRange]);
@@ -306,10 +306,11 @@ export class SlickCellExternalCopyManager implements Plugin {
 
             if (desty < this._clipCommand.maxDestY && destx < this._clipCommand.maxDestX) {
               const dt = grid.getDataItem(desty);
-              if (oneCellToMultiple)
+              if (oneCellToMultiple) {
                 this._clipCommand.setDataItemValueForColumn(dt, columns[destx], this._clipCommand.oldValues[0][0]);
-              else
+              } else {
                 this._clipCommand.setDataItemValueForColumn(dt, columns[destx], this._clipCommand.oldValues[y][x]);
+              }
               grid.updateCell(desty, destx);
               grid.onCellChange.notify({
                 row: desty,
@@ -323,10 +324,10 @@ export class SlickCellExternalCopyManager implements Plugin {
         }
 
         const bRange = new SlickRange(
-          activeCell,
           activeRow,
-          activeCell + this._clipCommand.w - 1,
-          activeRow + this._clipCommand.h - 1
+          activeCell,
+          activeRow + this._clipCommand.h - 1,
+          activeCell + this._clipCommand.w - 1
         );
 
         this.markCopySelection([bRange]);

--- a/src/slick.core.ts
+++ b/src/slick.core.ts
@@ -18,10 +18,10 @@ export class SlickEventData {
   protected _isImmediatePropagationStopped = false;
   protected _isDefaultPrevented = false;
   protected returnValues: string[] = [];
-  protected returnValue = undefined;
+  protected returnValue: any = undefined;
   protected target?: EventTarget | null;
-  protected nativeEvent;
-  protected arguments_;
+  protected nativeEvent?: Event | null;
+  protected arguments_: any;
 
   constructor(protected event?: Event | null, protected args?: any) {
     this.nativeEvent = event;

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -1371,7 +1371,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    */
   getHeaderRowColumn(columnIdOrIdx: number | string) {
     let idx = (typeof columnIdOrIdx === 'number' ? columnIdOrIdx : this.getColumnIndex(columnIdOrIdx));
-    let headerRowTarget;
+    let headerRowTarget: HTMLDivElement;
 
     if (this.hasFrozenColumns()) {
       if (idx <= this._options.frozenColumn!) {
@@ -1384,13 +1384,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       headerRowTarget = this._headerRowL;
     }
 
-    return headerRowTarget.children[idx];
+    return headerRowTarget.children[idx] as HTMLDivElement;
   }
 
   /** Get the Footer Row Column DOM element */
   getFooterRowColumn(columnIdOrIdx: number | string) {
     let idx = (typeof columnIdOrIdx === 'number' ? columnIdOrIdx : this.getColumnIndex(columnIdOrIdx));
-    let footerRowTarget;
+    let footerRowTarget: HTMLDivElement;
 
     if (this.hasFrozenColumns()) {
       if (idx <= this._options.frozenColumn!) {
@@ -1404,7 +1404,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       footerRowTarget = this._footerRowL;
     }
 
-    return footerRowTarget.children[idx];
+    return footerRowTarget.children[idx] as HTMLDivElement;
   }
 
   protected createColumnFooter() {


### PR DESCRIPTION
- SlickCellExternalCopyManager was creating SlickRange with arguments in incorrect order
- add CJS build so that Slickgrid-Universal unit tests would work with Jest which requires CJS