### PR TITLE
chore(deps): upgrade to Cypress v13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       - run: npm --version
 
       - name: Install npm dependencies
-        run: npm install --legacy-peer-deps
+        run: npm install
 
       - name: Prod Build with TS Types
         run: npm run build:prod

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       - run: npm --version
 
       - name: Install npm dependencies
-        run: npm install
+        run: npm install --legacy-peer-deps
 
       - name: Prod Build with TS Types
         run: npm run build:prod

--- a/cypress/e2e/example-0070-plugin-state.cy.ts
+++ b/cypress/e2e/example-0070-plugin-state.cy.ts
@@ -1,4 +1,3 @@
-
 describe('Example 0070 - Grid State using Local Storage', () => {
   const originalTitles = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];
 

--- a/cypress/e2e/example-auto-scroll-when-dragging.cy.ts
+++ b/cypress/e2e/example-auto-scroll-when-dragging.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 import { getScrollDistanceWhenDragOutsideGrid } from '../support/drag';
 
 describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
@@ -103,7 +101,7 @@ describe('Example - Auto scroll when dragging', { retries: 1 }, () => {
 
       return cy.get(viewportSelector).invoke('scrollTop').then(scrollAfter => {
         cy.dragEnd(selector);
-        var interval = performance.now() - start;
+        const interval = performance.now() - start;
         expect(scrollBefore).to.be.lessThan(scrollAfter);
         cy.get(viewportSelector).scrollTo(0, 0, { ensureScrollable: false });
         return cy.wrap(interval);

--- a/cypress/e2e/example-autotooltips.cy.ts
+++ b/cypress/e2e/example-autotooltips.cy.ts
@@ -1,4 +1,3 @@
-
 describe('Example AutoTooltips Plugin', () => {
   const GRID_ROW_HEIGHT = 25;
   const originalTitles = ['Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];

--- a/cypress/e2e/example-checkbox-header-row.cy.ts
+++ b/cypress/e2e/example-checkbox-header-row.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 describe('Example - Checkbox Header Row', () => {
   const titles = ['', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];
   let selectedIdsCount = 0;
@@ -294,11 +292,11 @@ describe('Example - Checkbox Header Row', () => {
 
     cy.get('.slick-headerrow-column')
       .children()
-      .each(($child, index) => expect($child.text()).to.eq(''));
+      .each(($child) => expect($child.text()).to.eq(''));
 
     cy.get('#idsCount')
       .then($elm => {
-        let newSelectedIdsCount = +$elm[0].textContent;
+        const newSelectedIdsCount = +$elm[0].textContent;
         expect(newSelectedIdsCount).to.be.eq(75);
       });
   });
@@ -308,14 +306,14 @@ describe('Example - Checkbox Header Row', () => {
 
     cy.get('.slick-headerrow-column')
       .children()
-      .each(($child, index) => expect($child.text()).to.eq(''));
+      .each(($child) => expect($child.text()).to.eq(''));
 
     cy.get('#filter-checkbox-selectall-container input[type=checkbox]')
       .click({ force: true });
 
     cy.get('#rowsCount')
       .then($elm => {
-        let newSelectedRowsCount = +$elm[0].textContent;
+        const newSelectedRowsCount = +$elm[0].textContent;
         expect(newSelectedRowsCount).to.be.eq(0);
       });
 
@@ -351,7 +349,7 @@ describe('Example - Checkbox Header Row', () => {
 
     cy.get('.slick-headerrow-column')
       .children()
-      .each(($child, index) => expect($child.text()).to.eq(''));
+      .each(($child) => expect($child.text()).to.eq(''));
 
     cy.get('#idsCount')
       .then($elm => {
@@ -361,7 +359,7 @@ describe('Example - Checkbox Header Row', () => {
 
     cy.get('#rowsCount')
       .then($elm => {
-        let newSelectedRowsCount = +$elm[0].textContent;
+        const newSelectedRowsCount = +$elm[0].textContent;
         expect(newSelectedRowsCount).not.to.be.eq(newSelectedIdsCount);
       });
 

--- a/cypress/e2e/example-checkbox-row-select.cy.ts
+++ b/cypress/e2e/example-checkbox-row-select.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 describe('Example - Checkbox Row Select', () => {
   const titles = ['', 'A', 'B', 'C', 'D', 'E'];
   const GRID_ROW_HEIGHT = 25;

--- a/cypress/e2e/example-colspan.cy.ts
+++ b/cypress/e2e/example-colspan.cy.ts
@@ -1,4 +1,3 @@
-/// <reference types='cypress' />
 describe('Example - Column Span & Header Grouping', { retries: 1 }, () => {
     // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
     const GRID_ROW_HEIGHT = 25;

--- a/cypress/e2e/example-composite-editor-modal-dialog.cy.ts
+++ b/cypress/e2e/example-composite-editor-modal-dialog.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 describe('Example - Composite Editor Modal with Create/Edit/Mass-Update/Mass-Selection', () => {
   const GRID_ROW_HEIGHT = 25;
   const titles = ['', 'Title', 'Description', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];

--- a/cypress/e2e/example-draggable-grouping.cy.ts
+++ b/cypress/e2e/example-draggable-grouping.cy.ts
@@ -1,4 +1,3 @@
-/// <reference types='cypress' />
 describe('Example - Draggable Grouping', { retries: 1 }, () => {
   // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
   const GRID_ROW_HEIGHT = 25;

--- a/cypress/e2e/example-frozen-columns-and-column-group.cy.ts
+++ b/cypress/e2e/example-frozen-columns-and-column-group.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="Cypress" />
-
 describe('Example - Row Grouping Titles', () => {
     const fullPreTitles = ['', 'Common Factor', 'Period', 'Analysis'];
     const fullTitles = ['#', 'Title', 'Duration', 'Start', 'Finish', '% Complete', 'Effort Driven'];

--- a/cypress/e2e/example-frozen-columns-and-rows.cy.ts
+++ b/cypress/e2e/example-frozen-columns-and-rows.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 describe('Example - Frozen Columns & Rows', { retries: 1 }, () => {
   // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
 

--- a/cypress/e2e/example-frozen-rows.cy.ts
+++ b/cypress/e2e/example-frozen-rows.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 describe('Example - Frozen Rows', { retries: 1 }, () => {
   // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
 

--- a/cypress/e2e/example-grid-menu.cy.ts
+++ b/cypress/e2e/example-grid-menu.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="Cypress" />
-
 import '@4tw/cypress-drag-drop';
 
 describe('Example - Grid Menu', () => {

--- a/cypress/e2e/example-grouping-esm.cy.ts
+++ b/cypress/e2e/example-grouping-esm.cy.ts
@@ -1,4 +1,3 @@
-/// <reference types='cypress' />
 describe('Example - Grouping & Aggregators (ESM)', { retries: 1 }, () => {
   // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
   const GRID_ROW_HEIGHT = 28;

--- a/cypress/e2e/example-grouping.cy.ts
+++ b/cypress/e2e/example-grouping.cy.ts
@@ -1,4 +1,3 @@
-/// <reference types='cypress' />
 describe('Example - Grouping & Aggregators', { retries: 1 }, () => {
     // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
     const GRID_ROW_HEIGHT = 25;

--- a/cypress/e2e/example-multi-grid-basic.cy.ts
+++ b/cypress/e2e/example-multi-grid-basic.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="Cypress" />
-
 describe('Example - Multi Grid on a Page', () => {
   const fullTitles = ['Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
 

--- a/cypress/e2e/example-optimizing-updates.cy.ts
+++ b/cypress/e2e/example-optimizing-updates.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="Cypress" />
-
 describe('Example - Optimizing Updates', () => {
   const titles = ['#', 'Severity', 'Time', 'Message'];
 
@@ -34,7 +32,7 @@ describe('Example - Optimizing Updates', () => {
 
     cy.get('#myGrid')
       .find('.slick-row')
-      .each(($child, index) => {
+      .each(($child) => {
           const message = $child.find('.cell-message').text();
           const number = parseInt(message.substring("Log Entry ".length));
           expect(number).to.be.lessThan(1000)
@@ -46,7 +44,7 @@ describe('Example - Optimizing Updates', () => {
 
     cy.get('#myGrid')
       .find('.slick-row')
-      .each(($child, index) => {
+      .each(($child) => {
           const message = $child.find('.cell-message').text();
           const number = parseInt(message.substring("Log Entry ".length));
           expect(number).to.be.greaterThan(90000)
@@ -58,7 +56,7 @@ describe('Example - Optimizing Updates', () => {
 
     cy.get('#myGrid')
       .find('.slick-row')
-      .each(($child, index) => {
+      .each(($child) => {
           const message = $child.find('.cell-message').text();
           const number = parseInt(message.substring("Log Entry ".length));
           expect(number).to.be.lessThan(1000)
@@ -70,7 +68,7 @@ describe('Example - Optimizing Updates', () => {
 
     cy.get('#myGrid')
       .find('.slick-row')
-      .each(($child, index) => {
+      .each(($child) => {
           const message = $child.find('.cell-message').text();
           const number = parseInt(message.substring("Log Entry ".length));
           expect(number).to.be.greaterThan(90000)
@@ -85,16 +83,16 @@ describe('Example - Optimizing Updates', () => {
       .contains('(inefficient)')
       .click();
     cy.get('#duration').should('not.be.empty').then($duration => {
-        let inEfficientTime = parseInt($duration.text());
+      const inEfficientTime = parseInt($duration.text());
 
-        cy.get('#duration').invoke('text', '').should('be.empty');
+      cy.get('#duration').invoke('text', '').should('be.empty');
       cy.get('.options-panel button')
-          .contains('(efficient)')
-          .click();
-        cy.get('#duration').should('not.be.empty').then($duration2 => {
-            let efficientTime = parseInt($duration2.text());
-            expect(efficientTime).to.be.lessThan(inEfficientTime / 2);
-        });
+        .contains('(efficient)')
+        .click();
+      cy.get('#duration').should('not.be.empty').then($duration2 => {
+        const efficientTime = parseInt($duration2.text());
+        expect(efficientTime).to.be.lessThan(inEfficientTime / 2);
+      });
     });
 
   });

--- a/cypress/e2e/example-plugin-contextmenu.cy.ts
+++ b/cypress/e2e/example-plugin-contextmenu.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="Cypress" />
-
 describe('Example - Context Menu & Cell Menu', () => {
   const fullTitles = ['#', 'Title', '% Complete', 'Start', 'Finish', 'Priority', 'Effort Driven', 'Action'];
 

--- a/cypress/e2e/example-plugin-custom-tooltip.cy.ts
+++ b/cypress/e2e/example-plugin-custom-tooltip.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 describe('Example - Custom Tooltip', () => {
   const GRID_ROW_HEIGHT = 25;
   const titles = ['', 'Title', 'Description', 'Description 2', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];

--- a/cypress/e2e/example-plugin-headerbuttons.cy.ts
+++ b/cypress/e2e/example-plugin-headerbuttons.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 describe('Example - Header Button', () => {
   const titles = ['Resize me!', 'Hover me!', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];
 

--- a/cypress/e2e/example-plugin-headermenu.cy.ts
+++ b/cypress/e2e/example-plugin-headermenu.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 describe('Example - Header Menu', () => {
   const titles = ['Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
 

--- a/cypress/e2e/example-row-detail-selection-and-move.cy.ts
+++ b/cypress/e2e/example-row-detail-selection-and-move.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="Cypress" />
-
 describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
     const fullTitles = ['', '', '', '#', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
 

--- a/cypress/e2e/example15-auto-resize.cy.ts
+++ b/cypress/e2e/example15-auto-resize.cy.ts
@@ -1,4 +1,3 @@
-
 describe('Example 0070 - Grid State using Local Storage', () => {
   const titles = ['Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
 

--- a/cypress/e2e/example3-editing.cy.ts
+++ b/cypress/e2e/example3-editing.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 describe('Example3 Editing', () => {
   const titles = ['Title', 'Description', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
   const GRID_ROW_HEIGHT = 28;

--- a/cypress/e2e/example3b-editing-with-undo.cy.ts
+++ b/cypress/e2e/example3b-editing-with-undo.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 describe('Example3 Editing', () => {
   const titles = ['Title', 'Description', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
   const GRID_ROW_HEIGHT = 25;

--- a/cypress/e2e/example4-model-esm.cy.ts
+++ b/cypress/e2e/example4-model-esm.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 describe('Example 4 - Model (ESM)', () => {
   const titles = ['#', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
 

--- a/cypress/e2e/example4-model.cy.ts
+++ b/cypress/e2e/example4-model.cy.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 describe('Example 4 - Model', () => {
   const titles = ['#', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -26,6 +26,19 @@
 import '@4tw/cypress-drag-drop';
 import { convertPosition } from './common';
 
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Cypress {
+    interface Chainable {
+      // triggerHover: (elements: NodeListOf<HTMLElement>) => void;
+      convertPosition(viewport: string): Chainable<HTMLElement | JQuery<HTMLElement> | { x: string; y: string; }>;
+      getCell(row: number, col: number, viewport?: string, options?: { parentSelector?: string, rowHeight?: number; }): Chainable<HTMLElement | JQuery<HTMLElement>>;
+      restoreLocalStorage(): Chainable<HTMLElement | JQuery<HTMLElement>>;
+      saveLocalStorage(): Chainable<HTMLElement | JQuery<HTMLElement>>;
+    }
+  }
+}
+
 // convert position like 'topLeft' to the object { x: 'left|right', y: 'top|bottom' }
 Cypress.Commands.add('convertPosition', (viewport = 'topLeft') => cy.wrap(convertPosition(viewport)))
 
@@ -37,7 +50,7 @@ Cypress.Commands.add('getCell', (row, col, viewport = 'topLeft', { parentSelecto
   return cy.get(`${parentSelector} ${canvasSelectorX}${canvasSelectorY} [style="top:${row * rowHeight}px"] > .slick-cell:nth(${col})`);
 });
 
-let LOCAL_STORAGE_MEMORY = {};
+const LOCAL_STORAGE_MEMORY = {};
 
 Cypress.Commands.add('saveLocalStorage', () => {
   Object.keys(localStorage).forEach(key => {

--- a/cypress/support/drag.ts
+++ b/cypress/support/drag.ts
@@ -5,14 +5,15 @@ declare global {
   namespace Cypress {
     interface Chainable {
       // triggerHover: (elements: NodeListOf<HTMLElement>) => void;
-      dragOutside(viewport?: string, ms?: number, px?: number, options?: { parentSelector?: string, scrollbarDimension?: number; }): Chainable<HTMLElement>;
-      dragStart(options?: { cellWidth?: number; cellHeight?: number; prevSubject: boolean; }): Chainable<HTMLElement>;
+      dragOutside(viewport?: string, ms?: number, px?: number, options?: { parentSelector?: string, scrollbarDimension?: number; rowHeight?: number; }): Chainable<HTMLElement>;
+      dragStart(options?: { cellWidth?: number; cellHeight?: number; }): Chainable<HTMLElement>;
       dragCell(addRow: number, addCell: number, options?: { cellWidth?: number; cellHeight?: number; }): Chainable<HTMLElement>;
       dragEnd(gridSelector?: string): Chainable<HTMLElement>;
     }
   }
 }
 
+// @ts-ignore
 Cypress.Commands.add('dragStart', { prevSubject: true }, (subject, { cellWidth = 80, cellHeight = 25 } = {}) => {
   return cy.wrap(subject).click({ force: true })
     .trigger('mousedown', { which: 1 })
@@ -20,6 +21,7 @@ Cypress.Commands.add('dragStart', { prevSubject: true }, (subject, { cellWidth =
 })
 
 // use a different command name than "drag" so that it doesn't conflict with the "@4tw/cypress-drag-drop" lib
+// @ts-ignore
 Cypress.Commands.add('dragCell', { prevSubject: true }, (subject, addRow, addCell, { cellWidth = 80, cellHeight = 25 } = {}) => {
   return cy.wrap(subject).trigger('mousemove', cellWidth * (addCell + 0.5), cellHeight * (addRow + 0.5), { force: true });
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "copyfiles": "^2.4.1",
         "cssnano": "^6.0.1",
         "cssnano-preset-lite": "^3.0.0",
-        "cypress": "^12.17.4",
+        "cypress": "^13.1.0",
         "dotenv": "^16.3.1",
         "esbuild": "^0.19.2",
         "eslint": "^8.48.0",
@@ -244,9 +244,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -262,7 +262,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -3007,13 +3007,13 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.17.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
-      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "2.88.12",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -3061,7 +3061,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/cypress/node_modules/fs-extra": {
@@ -9713,9 +9713,9 @@
       "optional": true
     },
     "@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -9731,7 +9731,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -11635,12 +11635,12 @@
       }
     },
     "cypress": {
-      "version": "12.17.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
-      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
-        "@cypress/request": "2.88.12",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -291,342 +291,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.2.tgz",
-      "integrity": "sha512-tM8yLeYVe7pRyAu9VMi/Q7aunpLwD139EY1S99xbQkT4/q2qa6eA4ige/WJQYdJ8GBL1K33pPFhPfPdJ/WzT8Q==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.2.tgz",
-      "integrity": "sha512-lsB65vAbe90I/Qe10OjkmrdxSX4UJDjosDgb8sZUKcg3oefEuW2OT2Vozz8ef7wrJbMcmhvCC+hciF8jY/uAkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.2.tgz",
-      "integrity": "sha512-qK/TpmHt2M/Hg82WXHRc/W/2SGo/l1thtDHZWqFq7oi24AjZ4O/CpPSu6ZuYKFkEgmZlFoa7CooAyYmuvnaG8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.2.tgz",
-      "integrity": "sha512-Ora8JokrvrzEPEpZO18ZYXkH4asCdc1DLdcVy8TGf5eWtPO1Ie4WroEJzwI52ZGtpODy3+m0a2yEX9l+KUn0tA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.2.tgz",
-      "integrity": "sha512-tP+B5UuIbbFMj2hQaUr6EALlHOIOmlLM2FK7jeFBobPy2ERdohI4Ka6ZFjZ1ZYsrHE/hZimGuU90jusRE0pwDw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.2.tgz",
-      "integrity": "sha512-YbPY2kc0acfzL1VPVK6EnAlig4f+l8xmq36OZkU0jzBVHcOTyQDhnKQaLzZudNJQyymd9OqQezeaBgkTGdTGeQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.2.tgz",
-      "integrity": "sha512-nSO5uZT2clM6hosjWHAsS15hLrwCvIWx+b2e3lZ3MwbYSaXwvfO528OF+dLjas1g3bZonciivI8qKR/Hm7IWGw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.2.tgz",
-      "integrity": "sha512-Odalh8hICg7SOD7XCj0YLpYCEc+6mkoq63UnExDCiRA2wXEmGlK5JVrW50vZR9Qz4qkvqnHcpH+OFEggO3PgTg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.2.tgz",
-      "integrity": "sha512-ig2P7GeG//zWlU0AggA3pV1h5gdix0MA3wgB+NsnBXViwiGgY77fuN9Wr5uoCrs2YzaYfogXgsWZbm+HGr09xg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.2.tgz",
-      "integrity": "sha512-mLfp0ziRPOLSTek0Gd9T5B8AtzKAkoZE70fneiiyPlSnUKKI4lp+mGEnQXcQEHLJAcIYDPSyBvsUbKUG2ri/XQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.2.tgz",
-      "integrity": "sha512-hn28+JNDTxxCpnYjdDYVMNTR3SKavyLlCHHkufHV91fkewpIyQchS1d8wSbmXhs1fiYDpNww8KTFlJ1dHsxeSw==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.2.tgz",
-      "integrity": "sha512-KbXaC0Sejt7vD2fEgPoIKb6nxkfYW9OmFUK9XQE4//PvGIxNIfPk1NmlHmMg6f25x57rpmEFrn1OotASYIAaTg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.2.tgz",
-      "integrity": "sha512-dJ0kE8KTqbiHtA3Fc/zn7lCd7pqVr4JcT0JqOnbj4LLzYnp+7h8Qi4yjfq42ZlHfhOCM42rBh0EwHYLL6LEzcw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.2.tgz",
-      "integrity": "sha512-7Z/jKNFufZ/bbu4INqqCN6DDlrmOTmdw6D0gH+6Y7auok2r02Ur661qPuXidPOJ+FSgbEeQnnAGgsVynfLuOEw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.2.tgz",
-      "integrity": "sha512-U+RinR6aXXABFCcAY4gSlv4CL1oOVvSSCdseQmGO66H+XyuQGZIUdhG56SZaDJQcLmrSfRmx5XZOWyCJPRqS7g==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.2.tgz",
-      "integrity": "sha512-oxzHTEv6VPm3XXNaHPyUTTte+3wGv7qVQtqaZCrgstI16gCuhNOtBXLEBkBREP57YTd68P0VgDgG73jSD8bwXQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.2.tgz",
-      "integrity": "sha512-WNa5zZk1XpTTwMDompZmvQLHszDDDN7lYjEHCUmAGB83Bgs20EMs7ICD+oKeT6xt4phV4NDdSi/8OfjPbSbZfQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.2.tgz",
-      "integrity": "sha512-S6kI1aT3S++Dedb7vxIuUOb3oAxqxk2Rh5rOXOTYnzN8JzW1VzBd+IqPiSpgitu45042SYD3HCoEyhLKQcDFDw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.2.tgz",
-      "integrity": "sha512-VXSSMsmb+Z8LbsQGcBMiM+fYObDNRm8p7tkUDMPG/g4fhFX5DEFmjxIEa3N8Zr96SjsJ1woAhF0DUnS3MF3ARw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.2.tgz",
-      "integrity": "sha512-5NayUlSAyb5PQYFAU9x3bHdsqB88RC3aM9lKDAz4X1mo/EchMIT1Q+pSeBXNgkfNmRecLXA0O8xP+x8V+g/LKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.2.tgz",
-      "integrity": "sha512-47gL/ek1v36iN0wL9L4Q2MFdujR0poLZMJwhO2/N3gA89jgHp4MR8DKCmwYtGNksbfJb9JoTtbkoe6sDhg2QTA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.2.tgz",
@@ -4411,20 +4075,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -9565,7 +9215,8 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@4tw/cypress-drag-drop/-/cypress-drag-drop-2.2.4.tgz",
       "integrity": "sha512-6mmjJ0SHjciI0JNofdVcN1LYLbvUcUT3oY2O+1HaTlQlpKPlX9kBc040Sik6RYFK7cgWvUNwoDoDoGSKA4IS/g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -9757,153 +9408,6 @@
           }
         }
       }
-    },
-    "@esbuild/android-arm": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.2.tgz",
-      "integrity": "sha512-tM8yLeYVe7pRyAu9VMi/Q7aunpLwD139EY1S99xbQkT4/q2qa6eA4ige/WJQYdJ8GBL1K33pPFhPfPdJ/WzT8Q==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/android-arm64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.2.tgz",
-      "integrity": "sha512-lsB65vAbe90I/Qe10OjkmrdxSX4UJDjosDgb8sZUKcg3oefEuW2OT2Vozz8ef7wrJbMcmhvCC+hciF8jY/uAkw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/android-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.2.tgz",
-      "integrity": "sha512-qK/TpmHt2M/Hg82WXHRc/W/2SGo/l1thtDHZWqFq7oi24AjZ4O/CpPSu6ZuYKFkEgmZlFoa7CooAyYmuvnaG8w==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/darwin-arm64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.2.tgz",
-      "integrity": "sha512-Ora8JokrvrzEPEpZO18ZYXkH4asCdc1DLdcVy8TGf5eWtPO1Ie4WroEJzwI52ZGtpODy3+m0a2yEX9l+KUn0tA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/darwin-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.2.tgz",
-      "integrity": "sha512-tP+B5UuIbbFMj2hQaUr6EALlHOIOmlLM2FK7jeFBobPy2ERdohI4Ka6ZFjZ1ZYsrHE/hZimGuU90jusRE0pwDw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/freebsd-arm64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.2.tgz",
-      "integrity": "sha512-YbPY2kc0acfzL1VPVK6EnAlig4f+l8xmq36OZkU0jzBVHcOTyQDhnKQaLzZudNJQyymd9OqQezeaBgkTGdTGeQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/freebsd-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.2.tgz",
-      "integrity": "sha512-nSO5uZT2clM6hosjWHAsS15hLrwCvIWx+b2e3lZ3MwbYSaXwvfO528OF+dLjas1g3bZonciivI8qKR/Hm7IWGw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-arm": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.2.tgz",
-      "integrity": "sha512-Odalh8hICg7SOD7XCj0YLpYCEc+6mkoq63UnExDCiRA2wXEmGlK5JVrW50vZR9Qz4qkvqnHcpH+OFEggO3PgTg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-arm64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.2.tgz",
-      "integrity": "sha512-ig2P7GeG//zWlU0AggA3pV1h5gdix0MA3wgB+NsnBXViwiGgY77fuN9Wr5uoCrs2YzaYfogXgsWZbm+HGr09xg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-ia32": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.2.tgz",
-      "integrity": "sha512-mLfp0ziRPOLSTek0Gd9T5B8AtzKAkoZE70fneiiyPlSnUKKI4lp+mGEnQXcQEHLJAcIYDPSyBvsUbKUG2ri/XQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-loong64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.2.tgz",
-      "integrity": "sha512-hn28+JNDTxxCpnYjdDYVMNTR3SKavyLlCHHkufHV91fkewpIyQchS1d8wSbmXhs1fiYDpNww8KTFlJ1dHsxeSw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-mips64el": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.2.tgz",
-      "integrity": "sha512-KbXaC0Sejt7vD2fEgPoIKb6nxkfYW9OmFUK9XQE4//PvGIxNIfPk1NmlHmMg6f25x57rpmEFrn1OotASYIAaTg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-ppc64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.2.tgz",
-      "integrity": "sha512-dJ0kE8KTqbiHtA3Fc/zn7lCd7pqVr4JcT0JqOnbj4LLzYnp+7h8Qi4yjfq42ZlHfhOCM42rBh0EwHYLL6LEzcw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-riscv64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.2.tgz",
-      "integrity": "sha512-7Z/jKNFufZ/bbu4INqqCN6DDlrmOTmdw6D0gH+6Y7auok2r02Ur661qPuXidPOJ+FSgbEeQnnAGgsVynfLuOEw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-s390x": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.2.tgz",
-      "integrity": "sha512-U+RinR6aXXABFCcAY4gSlv4CL1oOVvSSCdseQmGO66H+XyuQGZIUdhG56SZaDJQcLmrSfRmx5XZOWyCJPRqS7g==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.2.tgz",
-      "integrity": "sha512-oxzHTEv6VPm3XXNaHPyUTTte+3wGv7qVQtqaZCrgstI16gCuhNOtBXLEBkBREP57YTd68P0VgDgG73jSD8bwXQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/netbsd-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.2.tgz",
-      "integrity": "sha512-WNa5zZk1XpTTwMDompZmvQLHszDDDN7lYjEHCUmAGB83Bgs20EMs7ICD+oKeT6xt4phV4NDdSi/8OfjPbSbZfQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/openbsd-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.2.tgz",
-      "integrity": "sha512-S6kI1aT3S++Dedb7vxIuUOb3oAxqxk2Rh5rOXOTYnzN8JzW1VzBd+IqPiSpgitu45042SYD3HCoEyhLKQcDFDw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/sunos-x64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.2.tgz",
-      "integrity": "sha512-VXSSMsmb+Z8LbsQGcBMiM+fYObDNRm8p7tkUDMPG/g4fhFX5DEFmjxIEa3N8Zr96SjsJ1woAhF0DUnS3MF3ARw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-arm64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.2.tgz",
-      "integrity": "sha512-5NayUlSAyb5PQYFAU9x3bHdsqB88RC3aM9lKDAz4X1mo/EchMIT1Q+pSeBXNgkfNmRecLXA0O8xP+x8V+g/LKg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-ia32": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.2.tgz",
-      "integrity": "sha512-47gL/ek1v36iN0wL9L4Q2MFdujR0poLZMJwhO2/N3gA89jgHp4MR8DKCmwYtGNksbfJb9JoTtbkoe6sDhg2QTA==",
-      "dev": true,
-      "optional": true
     },
     "@esbuild/win32-x64": {
       "version": "0.19.2",
@@ -10176,7 +9680,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.2.1",
@@ -10484,7 +9989,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "add-stream": {
       "version": "1.0.0",
@@ -11500,7 +11006,8 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
       "integrity": "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "css-select": {
       "version": "5.1.0",
@@ -11600,7 +11107,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.0.tgz",
       "integrity": "sha512-Z39TLP+1E0KUcd7LGyF4qMfu8ZufI0rDzhdyAMsa/8UyNUU8wpS0fhdBxbQbv32r64ea00h4878gommRVg2BHw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "5.0.5",
@@ -12714,13 +12222,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -14605,25 +14106,29 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.0.tgz",
       "integrity": "sha512-p2skSGqzPMZkEQvJsgnkBhCn8gI7NzRH2683EEjrIkoMiwRELx68yoUJ3q3DGSGuQ8Ug9Gsn+OuDr46yfO+eFw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.0.tgz",
       "integrity": "sha512-bU1SXIizMLtDW4oSsi5C/xHKbhLlhek/0/yCnoMQany9k3nPBq+Ctsv/9oMmyqbR96HYHxZcHyK2HR5P/mqoGA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.0.tgz",
       "integrity": "sha512-b+h1S1VT6dNhpcg+LpyiUrdnEZfICF0my7HAKgJixJLW7BnNmpRH34+uw/etf5AhOlIhIAuXApSzzDzMI9K/gQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.0.tgz",
       "integrity": "sha512-4VELwssYXDFigPYAZ8vL4yX4mUepF/oCBeeIT4OXsJPYOtvJumyz9WflmJWTfDwCUcpDR+z0zvCWBXgTx35SVw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-load-config": {
       "version": "4.0.1",
@@ -14701,7 +14206,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.0.tgz",
       "integrity": "sha512-cqundwChbu8yO/gSWkuFDmKrCZ2vJzDAocheT2JTd0sFNA4HMGoKMfbk2B+J0OmO0t5GUkiAkSM5yF2rSLUjgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "6.0.0",
@@ -15955,7 +15461,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
       "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "tsconfig-paths": {
       "version": "3.14.2",
@@ -16331,7 +15838,8 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
       "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xmlhttprequest-ssl": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9565,8 +9565,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@4tw/cypress-drag-drop/-/cypress-drag-drop-2.2.4.tgz",
       "integrity": "sha512-6mmjJ0SHjciI0JNofdVcN1LYLbvUcUT3oY2O+1HaTlQlpKPlX9kBc040Sik6RYFK7cgWvUNwoDoDoGSKA4IS/g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -10177,8 +10176,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.2.1",
@@ -10486,8 +10484,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "add-stream": {
       "version": "1.0.0",
@@ -11503,8 +11500,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
       "integrity": "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-select": {
       "version": "5.1.0",
@@ -11604,8 +11600,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.0.tgz",
       "integrity": "sha512-Z39TLP+1E0KUcd7LGyF4qMfu8ZufI0rDzhdyAMsa/8UyNUU8wpS0fhdBxbQbv32r64ea00h4878gommRVg2BHw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "5.0.5",
@@ -14610,29 +14605,25 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.0.tgz",
       "integrity": "sha512-p2skSGqzPMZkEQvJsgnkBhCn8gI7NzRH2683EEjrIkoMiwRELx68yoUJ3q3DGSGuQ8Ug9Gsn+OuDr46yfO+eFw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.0.tgz",
       "integrity": "sha512-bU1SXIizMLtDW4oSsi5C/xHKbhLlhek/0/yCnoMQany9k3nPBq+Ctsv/9oMmyqbR96HYHxZcHyK2HR5P/mqoGA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.0.tgz",
       "integrity": "sha512-b+h1S1VT6dNhpcg+LpyiUrdnEZfICF0my7HAKgJixJLW7BnNmpRH34+uw/etf5AhOlIhIAuXApSzzDzMI9K/gQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.0.tgz",
       "integrity": "sha512-4VELwssYXDFigPYAZ8vL4yX4mUepF/oCBeeIT4OXsJPYOtvJumyz9WflmJWTfDwCUcpDR+z0zvCWBXgTx35SVw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-load-config": {
       "version": "4.0.1",
@@ -14710,8 +14701,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.0.tgz",
       "integrity": "sha512-cqundwChbu8yO/gSWkuFDmKrCZ2vJzDAocheT2JTd0sFNA4HMGoKMfbk2B+J0OmO0t5GUkiAkSM5yF2rSLUjgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "6.0.0",
@@ -15965,8 +15955,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
       "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "tsconfig-paths": {
       "version": "3.14.2",
@@ -16342,8 +16331,7 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
       "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "copyfiles": "^2.4.1",
     "cssnano": "^6.0.1",
     "cssnano-preset-lite": "^3.0.0",
-    "cypress": "^12.17.4",
+    "cypress": "^13.1.0",
     "dotenv": "^16.3.1",
     "esbuild": "^0.19.2",
     "eslint": "^8.48.0",

--- a/package.json
+++ b/package.json
@@ -115,5 +115,10 @@
   "engines": {
     "node": ">=16.0.0",
     "npm": ">=8.0.0"
+  },
+  "overrides": {
+    "@4tw/cypress-drag-drop@": {
+      "cypress": "*"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -117,8 +117,8 @@
     "npm": ">=8.0.0"
   },
   "overrides": {
-    "@4tw/cypress-drag-drop@": {
-      "cypress": "*"
+    "@4tw/cypress-drag-drop": {
+      "cypress": "$cypress"
     }
   }
 }


### PR DESCRIPTION
- looks like `@4tw/cypress-drag-drop` as a peer dependency on previous Cypress v12, to get over this we can use an npm overrides which could be removed in the future whenever the project supports v13