### PR TITLE
fix: DataView `setFilter` had incorrect type, partial fix #848

### DIFF
--- a/src/slick.dataview.ts
+++ b/src/slick.dataview.ts
@@ -37,7 +37,7 @@ export interface DataViewOption {
   groupItemMetadataProvider: SlickGroupItemMetadataProvider_ | null;
   inlineFilters: boolean;
 }
-export type FilterFn<T> = (a: T, b: T) => boolean;
+export type FilterFn<T> = (item: T, args: any) => boolean;
 export type DataIdType = number | string;
 export type SlickDataItem = SlickNonDataItem | SlickGroup_ | SlickGroupTotals_ | any;
 
@@ -366,7 +366,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * Set a Filter that will be used by the DataView
    * @param {Function} fn - filter callback function
    */
-  setFilter(filterFn: (a: TData, b: TData) => boolean) {
+  setFilter(filterFn: FilterFn<TData>) {
     this.filter = filterFn;
     if (this._options.inlineFilters) {
       this.compiledFilter = this.compileFilter();


### PR DESCRIPTION
- fixes 1 problem with `setFilter` identified in issue #848
- `setFilter` had the incorrect type, it should be `filterFn: (item: T, args: any) => boolean` and that is inline with what `filter` callback is defined on MDN https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter#parameters
- the first argument is the item being evaluated as per MDN: 
   > The current element being processed in the array. 