### PR TITLE
feat: add option to cancel Row Detail opening, closes #378

### DIFF
--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -223,7 +223,10 @@
     }
 
     function hookAssigneeOnClick(itemId) {
-      document.querySelector("#who-is-assignee_" + itemId).addEventListener("click", assigneHandler.bind(this, itemId));
+      const assigneeElm = document.querySelector("#who-is-assignee_" + itemId);
+      if (assigneeElm) {
+        assigneeElm.addEventListener("click", assigneHandler.bind(this, itemId));
+      }
     }
 
     function assigneHandler(itemId) {
@@ -415,6 +418,11 @@
       grid.registerPlugin(detailView);
 
       detailView.onBeforeRowDetailToggle.subscribe(function(e, args) {
+        // you coud cancel opening certain rows
+        // if (args.item.id === 1) {
+        //   e.preventDefault();
+        //   return false;
+        // }
         console.log('before toggling row detail', args.item);
       });
 

--- a/src/plugins/slick.rowdetailview.ts
+++ b/src/plugins/slick.rowdetailview.ts
@@ -257,10 +257,10 @@ export class SlickRowDetailView {
       }
 
       // trigger an event before toggling
-      this.onBeforeRowDetailToggle.notify({
-        grid: this._grid,
-        item: dataContext
-      }, e, this);
+      // user could cancel the Row Detail opening when event is returning false
+      if (this.onBeforeRowDetailToggle.notify({ grid: this._grid, item: dataContext }, e, this).getReturnValue() === false) {
+        return;
+      }
 
       this.toggleRowSelection(args.row, dataContext);
 


### PR DESCRIPTION
- closes #378

user can now prevent event and return false on `onBeforeRowDetailToggle` event to cancel opening certain Row Detail, for example the code below would block opening Row Detail when its id is `1`

```ts
detailView.onBeforeRowDetailToggle.subscribe(function(e, args) {
  // you coud cancel opening certain rows
  if (args.item.id === 1) {
    e.preventDefault();
    return false;
  }
  console.log('before toggling row detail', args.item);
});
```

![Code_OXS6TTs2AJ](https://github.com/6pac/SlickGrid/assets/643976/c19d3f57-aa64-4a0d-83a0-bb0983396701)
