### PR TITLE
feat: add pageUp/pageDown/home/end to SlickCellSelection, fixes #794

### DIFF
--- a/cypress/e2e/example-spreadsheet-dataview.cy.ts
+++ b/cypress/e2e/example-spreadsheet-dataview.cy.ts
@@ -1,0 +1,145 @@
+describe('Example - Spreadsheet with DataView and Cell Selection', { retries: 0 }, () => {
+  const cellHeight = 25;
+  const titles = [
+    '', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
+    'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y',
+    'Z', 'AA', 'AB', 'AC', 'AD', 'AE', 'AF', 'AG', 'AH', 'AI', 'AJ', 'AK'
+  ];
+
+  it('should load Example', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-spreadsheet-dataview.html`);
+  });
+
+  it('should have exact column titles on grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => {
+        if (index < titles.length) {
+          expect($child.text()).to.eq(titles[index])
+        }
+      });
+  });
+
+  describe('no Pagination - showing all', () => {
+    it('should click on cell B10 and ArrowUp 3 times and ArrowDown 1 time and expect cell selection B8-B10', () => {
+      cy.getCell(10, 2, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+        .as('cell_B10')
+        .click()
+
+      cy.get('@cell_B10')
+        .type('{shift}{uparrow}{uparrow}{uparrow}{downarrow}')
+
+      cy.get('.slick-cell.l2.r2.selected')
+        .should('have.length', 3);
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":8,"fromCell":2,"toCell":2,"toRow":10}');
+    });
+
+    it('should click on cell D10 then PageDown 2 times w/selection D10-D46 ', () => {
+      cy.getCell(10, 4, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+        .as('cell_D10')
+        .click()
+
+      cy.get('@cell_D10')
+        .type('{shift}{pagedown}{pagedown}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":10,"fromCell":4,"toCell":4,"toRow":46}');
+    });
+
+    it('should click on cell D10 then PageDown 3 times then PageUp 1 time w/selection D10-D46', () => {
+      cy.getCell(10, 4, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+        .as('cell_D10')
+        .click()
+
+      cy.get('@cell_D10')
+        .type('{shift}{pagedown}{pagedown}{pagedown}{pageup}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":10,"fromCell":4,"toCell":4,"toRow":46}');
+    });
+
+    it('should click on cell E12 then End key w/selection E46-E99', () => {
+      cy.getCell(46, 5, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+        .as('cell_E46')
+        .click()
+
+      cy.get('@cell_E46')
+        .type('{shift}{end}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":46,"fromCell":5,"toCell":5,"toRow":99}');
+    });
+
+    it('should click on cell C85 then End key w/selection C0-C85', () => {
+      cy.getCell(85, 3, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+        .as('cell_C85')
+        .click()
+
+      cy.get('@cell_C85')
+        .type('{shift}{home}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":0,"fromCell":3,"toCell":3,"toRow":85}');
+    });
+  });
+
+  describe('with Pagination', () => {
+    it('should show Page of size 25', () => {
+      cy.get('.slick-pager-settings .sgi-lightbulb').click();
+      cy.get('[data-val="25"]').click();
+    });
+
+    it('should click on cell B14 then Shift+End w/selection B14-24', () => {
+      cy.getCell(14, 2, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+        .as('cell_B14')
+        .click()
+
+      cy.get('@cell_B14')
+        .type('{shift}{end}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":14,"fromCell":2,"toCell":2,"toRow":24}');
+    });
+
+    it('should click on cell C19 then Shift+End w/selection C0-19', () => {
+      cy.getCell(19, 2, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+        .as('cell_C19')
+        .click()
+
+      cy.get('@cell_C19')
+        .type('{shift}{home}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":0,"fromCell":2,"toCell":2,"toRow":19}');
+    });
+
+    it('should click on cell E3 then Shift+PageDown multiple times with current page selection starting at E3 w/selection E3-24', () => {
+      cy.getCell(3, 5, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+        .as('cell_E3')
+        .click()
+
+      cy.get('@cell_E3')
+        .type('{shift}{pagedown}{pagedown}{pagedown}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":3,"fromCell":5,"toCell":5,"toRow":24}');
+    });
+
+    it('should click on cell D41 then Shift+PageUp multiple times with current page selection w/selection D25-41', () => {
+      cy.get('.slick-pager .sgi-chevron-right').click();
+
+      cy.getCell(15, 4, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+        .as('cell_D41')
+        .click()
+
+      cy.get('@cell_D41')
+        .type('{shift}{pageup}{pageup}{pageup}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":0,"fromCell":4,"toCell":4,"toRow":15}');
+    });
+  });
+});

--- a/cypress/e2e/example-spreadsheet.cy.ts
+++ b/cypress/e2e/example-spreadsheet.cy.ts
@@ -1,0 +1,86 @@
+describe('Example - Spreadsheet and Cell Selection', { retries: 0 }, () => {
+  const cellHeight = 25;
+  const titles = [
+    '', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
+    'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y',
+    'Z', 'AA', 'AB', 'AC', 'AD', 'AE', 'AF', 'AG', 'AH', 'AI', 'AJ', 'AK'
+  ];
+
+  it('should load Example', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-spreadsheet.html`);
+  });
+
+  it('should have exact column titles on grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => {
+        if (index < titles.length) {
+          expect($child.text()).to.eq(titles[index])
+        }
+      });
+  });
+
+  it('should click on cell B10 and ArrowUp 3 times and ArrowDown 1 time and expect cell selection B8-B10', () => {
+    cy.getCell(10, 2, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+      .as('cell_B10')
+      .click()
+
+    cy.get('@cell_B10')
+      .type('{shift}{uparrow}{uparrow}{uparrow}{downarrow}')
+
+    cy.get('.slick-cell.l2.r2.selected')
+      .should('have.length', 3);
+
+    cy.get('#selectionRange')
+      .should('have.text', '{"fromRow":8,"fromCell":2,"toCell":2,"toRow":10}');
+  });
+
+  it('should click on cell D10 then PageDown 2 times w/selection D10-D46 ', () => {
+    cy.getCell(10, 4, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+      .as('cell_D10')
+      .click()
+
+    cy.get('@cell_D10')
+      .type('{shift}{pagedown}{pagedown}');
+
+    cy.get('#selectionRange')
+      .should('have.text', '{"fromRow":10,"fromCell":4,"toCell":4,"toRow":46}');
+  });
+
+  it('should click on cell D10 then PageDown 3 times then PageUp 1 time w/selection D10-D46', () => {
+    cy.getCell(10, 4, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+      .as('cell_D10')
+      .click()
+
+    cy.get('@cell_D10')
+      .type('{shift}{pagedown}{pagedown}{pagedown}{pageup}');
+
+    cy.get('#selectionRange')
+      .should('have.text', '{"fromRow":10,"fromCell":4,"toCell":4,"toRow":46}');
+  });
+
+  it('should click on cell E12 then End key w/selection E46-E99', () => {
+    cy.getCell(46, 5, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+      .as('cell_E46')
+      .click()
+
+    cy.get('@cell_E46')
+      .type('{shift}{end}');
+
+    cy.get('#selectionRange')
+      .should('have.text', '{"fromRow":46,"fromCell":5,"toCell":5,"toRow":99}');
+  });
+
+  it('should click on cell C85 then End key w/selection C0-C85', () => {
+    cy.getCell(85, 3, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+      .as('cell_C85')
+      .click()
+
+    cy.get('@cell_C85')
+      .type('{shift}{home}');
+
+    cy.get('#selectionRange')
+      .should('have.text', '{"fromRow":0,"fromCell":3,"toCell":3,"toRow":85}');
+  });
+});

--- a/examples/example-spreadsheet-dataview.html
+++ b/examples/example-spreadsheet-dataview.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
-  <title>SlickGrid example 3: Editing</title>
+  <title>SlickGrid spreadsheet with DataView</title>
   <link rel="stylesheet" href="../dist/styles/css/slick-icons.css" type="text/css"/>
   <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css"/>
   <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css"/>
@@ -48,14 +48,16 @@
         <li>End</li>
       </ul>
     </ul>
-      <h2>View Source:</h2>
-      <ul>
-        <li>
-          <a href="https://github.com/6pac/SlickGrid/blob/master/examples/example-spreadsheet-dataview.html" target="_sourcewindow">
-            View the source for this example on Github
-          </a>
-        </li>
-      </ul>
+    <h2>View Source:</h2>
+    <ul>
+      <li>
+        <a href="https://github.com/6pac/SlickGrid/blob/master/examples/example-spreadsheet-dataview.html" target="_sourcewindow">
+          View the source for this example on Github
+        </a>
+      </li>
+    </ul>
+    <h2>Range Selection</h2>
+    <span id="selectionRange"></span>
   </div>
 </div>
 
@@ -76,6 +78,7 @@
 <script>
   var grid;
   var data = [];
+  let cellSelectionModel;
   var dataView;
   var options = {
     editable: true,
@@ -97,8 +100,9 @@
   for (var i = 0; i < 100; i++) {
     columns.push({
       id: i,
-      name: String.fromCharCode("A".charCodeAt(0) + (i / 26) | 0) +
-            String.fromCharCode("A".charCodeAt(0) + (i % 26)),
+      name: i < 26
+        ? String.fromCharCode("A".charCodeAt(0) + (i % 26))
+        : String.fromCharCode("A".charCodeAt(0) + ((i / 26) | 0) -1) + String.fromCharCode("A".charCodeAt(0) + (i % 26)),
       field: i,
       width: 60,
       editor: FormulaEditor
@@ -177,7 +181,8 @@
 
     var pager = new Slick.Controls.Pager(dataView, grid, "#pager");
 
-    grid.setSelectionModel(new Slick.CellSelectionModel());
+    cellSelectionModel = new Slick.CellSelectionModel();
+    grid.setSelectionModel(cellSelectionModel);
 
     // set keyboard focus on the grid
     grid.getCanvasNode().focus();
@@ -235,12 +240,21 @@
       dataView.addItem(item);
     });
 
+    cellSelectionModel.onSelectedRangesChanged.subscribe((e, args) => {
+      const targetRange = document.querySelector('#selectionRange');
+      targetRange.textContent = '';
+
+      for (let slickRange of args) {
+        targetRange.textContent += JSON.stringify(slickRange);
+      }
+    });
+
     // initialize the model after all the events have been hooked up
     dataView.beginUpdate();
     dataView.setItems(data);
     dataView.endUpdate();
     grid.render();
-  })
+  });
 </script>
 </body>
 </html>

--- a/examples/example-spreadsheet-dataview.html
+++ b/examples/example-spreadsheet-dataview.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
-  <title>SlickGrid Example: Spreadsheet with Frozen Rows and Columns</title>
+  <title>SlickGrid example 3: Editing</title>
   <link rel="stylesheet" href="../dist/styles/css/slick-icons.css" type="text/css"/>
   <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css"/>
   <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css"/>
@@ -11,7 +11,7 @@
     .slick-cell.copied {
       background: blue;
       background: rgba(0, 0, 255, 0.2);
-      -webkit-transition: 0.5s background;
+      transition: 0.5s background;
     }
     /** override slick-cell to make it look like Excel sheet */
     .slick-container {
@@ -26,6 +26,7 @@
 <div style="position:relative">
   <div style="width:600px;">
     <div id="myGrid" class="slick-container" style="width:100%;height:500px;"></div>
+    <div id="pager" style="width:100%;height:20px;"></div>
   </div>
 
   <div class="options-panel">
@@ -47,30 +48,41 @@
         <li>End</li>
       </ul>
     </ul>
+      <h2>View Source:</h2>
+      <ul>
+        <li>
+          <a href="https://github.com/6pac/SlickGrid/blob/master/examples/example-spreadsheet-dataview.html" target="_sourcewindow">
+            View the source for this example on Github
+          </a>
+        </li>
+      </ul>
   </div>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
+<script src="sortable-cdn-fallback.js"></script>
 
 <script src="../dist/browser/slick.core.js"></script>
 <script src="../dist/browser/slick.interactions.js"></script>
 <script src="../dist/browser/slick.grid.js"></script>
-<script src="../dist/browser/plugins/slick.autotooltips.js"></script>
+<script src="../dist/browser/slick.editors.js"></script>
 <script src="../dist/browser/plugins/slick.cellrangedecorator.js"></script>
 <script src="../dist/browser/plugins/slick.cellrangeselector.js"></script>
 <script src="../dist/browser/plugins/slick.cellcopymanager.js"></script>
 <script src="../dist/browser/plugins/slick.cellselectionmodel.js"></script>
-<script src="../dist/browser/slick.editors.js"></script>
+<script src="../dist/browser/slick.dataview.js"></script>
+<script src="../dist/browser/controls/slick.pager.js"></script>
 
 <script>
   var grid;
   var data = [];
+  var dataView;
   var options = {
     editable: true,
     enableAddRow: true,
     enableCellNavigation: true,
     asyncEditorLoading: false,
-    autoEdit: false, frozenColumn: 3, frozenRow: 7
+    autoEdit: false
   };
 
   var columns = [
@@ -85,9 +97,8 @@
   for (var i = 0; i < 100; i++) {
     columns.push({
       id: i,
-      //name: String.fromCharCode("A".charCodeAt(0) + (i / 26) | 0) +
-      //      String.fromCharCode("A".charCodeAt(0) + (i % 26)),
-      name: i,
+      name: String.fromCharCode("A".charCodeAt(0) + (i / 26) | 0) +
+            String.fromCharCode("A".charCodeAt(0) + (i % 26)),
       field: i,
       width: 60,
       editor: FormulaEditor
@@ -97,7 +108,7 @@
   /***
    * A proof-of-concept cell editor with Excel-like range selection and insertion.
    */
-   function FormulaEditor(args) {
+  function FormulaEditor(args) {
     var _self = this;
     var _editor = new Slick.Editors.Text(args);
     var _selector;
@@ -154,16 +165,19 @@
     init();
   }
 
-  document.addEventListener("DOMContentLoaded", () => {
+  document.addEventListener("DOMContentLoaded", function() {
     for (var i = 0; i < 100; i++) {
       var d = (data[i] = {});
+      d["id"] = i;
       d["num"] = i;
     }
 
-    grid = new Slick.Grid("#myGrid", data, columns, options);
+    dataView = new Slick.Data.DataView();
+    grid = new Slick.Grid("#myGrid", dataView, columns, options);
+
+    var pager = new Slick.Controls.Pager(dataView, grid, "#pager");
 
     grid.setSelectionModel(new Slick.CellSelectionModel());
-    grid.registerPlugin(new Slick.AutoTooltips());
 
     // set keyboard focus on the grid
     grid.getCanvasNode().focus();
@@ -191,15 +205,42 @@
       grid.render();
     });
 
-    grid.onAddNewRow.subscribe(function (e, args) {
-      var item = args.item;
-      var column = args.column;
-      grid.invalidateRow(data.length);
-      data.push(item);
+    dataView.onRowCountChanged.subscribe(function (e, args) {
       grid.updateRowCount();
       grid.render();
     });
-  });
+
+    dataView.onRowsChanged.subscribe(function (e, args) {
+      grid.invalidateRows(args.rows);
+      grid.render();
+    });
+
+    dataView.onPagingInfoChanged.subscribe(function (e, pagingInfo) {
+      grid.updatePagingStatusFromView( pagingInfo );
+
+      // show the pagingInfo but remove the dataView from the object, just for the Cypress E2E test
+      delete pagingInfo.dataView;
+      console.log('on After Paging Info Changed - New Paging:: ', pagingInfo);
+    });
+
+    dataView.onBeforePagingInfoChanged.subscribe(function (e, previousPagingInfo) {
+      // show the previous pagingInfo but remove the dataView from the object, just for the Cypress E2E test
+      delete previousPagingInfo.dataView;
+      console.log('on Before Paging Info Changed - Previous Paging:: ', previousPagingInfo);
+    });
+
+    grid.onAddNewRow.subscribe(function (e, args) {
+      var item = args.item;
+      Slick.Utils.extend(item, args.item);
+      dataView.addItem(item);
+    });
+
+    // initialize the model after all the events have been hooked up
+    dataView.beginUpdate();
+    dataView.setItems(data);
+    dataView.endUpdate();
+    grid.render();
+  })
 </script>
 </body>
 </html>

--- a/examples/example-spreadsheet.html
+++ b/examples/example-spreadsheet.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
-  <title>SlickGrid example 3: Editing</title>
+  <title>SlickGrid spreadsheet</title>
   <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css"/>
   <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css"/>
   <style>
@@ -46,14 +46,17 @@
         <li>End</li>
       </ul>
     </ul>
-      <h2>View Source:</h2>
-      <ul>
-        <li>
-          <a href="https://github.com/6pac/SlickGrid/blob/master/examples/example-spreadsheet.html" target="_sourcewindow">
-            View the source for this example on Github
-          </a>
-        </li>
-      </ul>
+    <h2>View Source:</h2>
+    <ul>
+      <li>
+        <a href="https://github.com/6pac/SlickGrid/blob/master/examples/example-spreadsheet.html" target="_sourcewindow">
+          View the source for this example on Github
+        </a>
+      </li>
+    </ul>
+
+    <h2>Range Selection</h2>
+    <span id="selectionRange"></span>
   </div>
 </div>
 
@@ -73,6 +76,7 @@
 <script>
   var grid;
   var data = [];
+  let cellSelectionModel;
   var options = {
     editable: true,
     enableAddRow: true,
@@ -93,8 +97,9 @@
   for (var i = 0; i < 100; i++) {
     columns.push({
       id: i,
-      name: String.fromCharCode("A".charCodeAt(0) + (i / 26) | 0) +
-            String.fromCharCode("A".charCodeAt(0) + (i % 26)),
+      name: i < 26
+        ? String.fromCharCode("A".charCodeAt(0) + (i % 26))
+        : String.fromCharCode("A".charCodeAt(0) + ((i / 26) | 0) -1) + String.fromCharCode("A".charCodeAt(0) + (i % 26)),
       field: i,
       width: 60,
       editor: FormulaEditor
@@ -169,7 +174,8 @@
 
     grid = new Slick.Grid("#myGrid", data, columns, options);
 
-    grid.setSelectionModel(new Slick.CellSelectionModel());
+    cellSelectionModel = new Slick.CellSelectionModel();
+    grid.setSelectionModel(cellSelectionModel);
     grid.registerPlugin(new Slick.AutoTooltips());
 
     // set keyboard focus on the grid
@@ -205,6 +211,15 @@
       data.push(item);
       grid.updateRowCount();
       grid.render();
+    });
+
+    cellSelectionModel.onSelectedRangesChanged.subscribe((e, args) => {
+      const targetRange = document.querySelector('#selectionRange');
+      targetRange.textContent = '';
+
+      for (let slickRange of args) {
+        targetRange.textContent += JSON.stringify(slickRange);
+      }
     });
   })
 </script>

--- a/examples/example-spreadsheet.html
+++ b/examples/example-spreadsheet.html
@@ -38,6 +38,13 @@
       <li>Use Ctrl-C and Ctrl-V keyboard shortcuts to cut and paste cells</li>
       <li>Use Esc to cancel a copy and paste operation</li>
       <li>Edit the cell and select a cell range to paste the range</li>
+      <li>Cell Selection using "Shift+{key}" where "key" can be any of:</li>
+      <ul>
+        <li>Arrow Up/Down/Left/Right</li>
+        <li>Page Up/Down</li>
+        <li>Home</li>
+        <li>End</li>
+      </ul>
     </ul>
       <h2>View Source:</h2>
       <ul>
@@ -97,7 +104,7 @@
   /***
    * A proof-of-concept cell editor with Excel-like range selection and insertion.
    */
-  function FormulaEditor(args) {
+   function FormulaEditor(args) {
     var _self = this;
     var _editor = new Slick.Editors.Text(args);
     var _selector;
@@ -120,6 +127,26 @@
       _editor.destroy();
     };
 
+    this.isValueChanged = function() {
+      return _editor.isValueChanged();
+    };
+
+    this.loadValue = function (item) {
+      _editor.loadValue(item);
+    };
+
+    this.applyValue = function(item, state) {
+      return _editor.applyValue(item, state);
+    };
+
+    this.serializeValue = function() {
+      return _editor.serializeValue();
+    };
+
+    this.validate = function() {
+      return _editor.validate();
+    };
+
     this.handleCellRangeSelected = function (e, args) {
       _editor.setValue(
           _editor.getValue() +
@@ -131,10 +158,8 @@
       );
     };
 
-
     init();
   }
-
 
   document.addEventListener("DOMContentLoaded", function() {
     for (var i = 0; i < 100; i++) {

--- a/examples/index.html
+++ b/examples/index.html
@@ -74,6 +74,7 @@
     <ul>
       <li><a href="./example8-alternative-display.html">Using pre-compiled micro-templates to render cells</a></li>
       <li><a href="./example-spreadsheet.html">Spreadsheet: cell range selection, copy’n’paste and Excel-style formula editor</a></li>
+      <li><a href="./example-spreadsheet-dataview.html">Spreadsheet using a DataView: cell range selection</a></li>
       <li><a href="./example-excel-compatible-spreadsheet.html">Spreadsheet: features of the previous example plus Excel compatible copy and paste</a></li>
       <li><a href="./example-excel-compatible-spreadsheet-dataview.html">Spreadsheet: features of the previous example but using a DataView</a></li>
       <li><a href="./example11-autoheight.html" title="autoHeight">No vertical scrolling</a></li>

--- a/src/plugins/slick.cellselectionmodel.ts
+++ b/src/plugins/slick.cellselectionmodel.ts
@@ -1,6 +1,7 @@
 import { SlickEvent as SlickEvent_, SlickEventData as SlickEventData_, SlickRange as SlickRange_, Utils as Utils_ } from '../slick.core';
 import { SlickCellRangeSelector as SlickCellRangeSelector_ } from './slick.cellrangeselector';
 import type { CellRange, OnActiveCellChangedEventArgs } from '../models/index';
+import type { SlickDataView } from '../slick.dataview';
 import type { SlickGrid } from '../slick.grid';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)
@@ -23,7 +24,10 @@ export class SlickCellSelectionModel {
 
   // --
   // protected props
+  protected _dataView?: SlickDataView;
   protected _grid!: SlickGrid;
+  protected _prevSelectedRow?: number;
+  protected _prevKeyDown = '';
   protected _ranges: CellRange[] = [];
   protected _selector: SlickCellRangeSelector_;
   protected _options?: CellSelectionModelOption;
@@ -42,6 +46,9 @@ export class SlickCellSelectionModel {
   init(grid: SlickGrid) {
     this._options = Utils.extend(true, {}, this._defaults, this._options);
     this._grid = grid;
+    if (grid.hasDataView()) {
+      this._dataView = grid.getData<SlickDataView>();
+    }
     this._grid.onActiveCellChanged.subscribe(this.handleActiveCellChange.bind(this));
     this._grid.onKeyDown.subscribe(this.handleKeyDown.bind(this));
     grid.registerPlugin(this._selector);
@@ -126,29 +133,31 @@ export class SlickCellSelectionModel {
   }
 
   protected handleActiveCellChange(_e: Event, args: OnActiveCellChangedEventArgs) {
+    this._prevSelectedRow = undefined;
     if (this._options?.selectActiveCell && args.row != null && args.cell != null) {
       this.setSelectedRanges([new SlickRange(args.row, args.cell)]);
-    }
-    else if (!this._options?.selectActiveCell) {
+    } else if (!this._options?.selectActiveCell) {
       // clear the previous selection once the cell changes
       this.setSelectedRanges([]);
     }
   }
 
+  protected isKeyAllowed(key: string) {
+    return ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageDown', 'PageUp', 'Home', 'End'].some(k => k === key);
+  }
+
   protected handleKeyDown(e: KeyboardEvent) {
-    /***
-     * Кey codes
-     * 37 left
-     * 38 up
-     * 39 right
-     * 40 down
-     */
     let ranges: CellRange[], last: SlickRange_;
     const active = this._grid.getActiveCell();
     const metaKey = e.ctrlKey || e.metaKey;
+    let dataLn = 0;
+    if (this._dataView) {
+      dataLn = this._dataView?.getPagingInfo().pageSize || this._dataView.getLength();
+    } else {
+      dataLn = this._grid.getDataLength();
+    }
 
-    if (active && e.shiftKey && !metaKey && !e.altKey &&
-      (e.which == 37 || e.which == 39 || e.which == 38 || e.which == 40)) {
+    if (active && e.shiftKey && !metaKey && !e.altKey && this.isKeyAllowed(e.key)) {
 
       ranges = this.getSelectedRanges().slice();
       if (!ranges.length)
@@ -158,42 +167,83 @@ export class SlickCellSelectionModel {
       last = ranges.pop() as SlickRange_;
 
       // can't handle selection out of active cell
-      if (!last.contains(active.row, active.cell))
+      if (!last.contains(active.row, active.cell)) {
         last = new SlickRange(active.row, active.cell);
+      }
 
-      let dRow = last.toRow - last.fromRow,
-        dCell = last.toCell - last.fromCell;
+      let dRow = last.toRow - last.fromRow;
+      let dCell = last.toCell - last.fromCell;
 
       // walking direction
       const dirRow = active.row == last.fromRow ? 1 : -1;
       const dirCell = active.cell == last.fromCell ? 1 : -1;
+      const pageRowCount = this._grid.getViewportRowCount();
+      const isSingleKeyMove = e.key.startsWith('Arrow');
+      let toRow = 0;
 
-      if (e.which == 37) {
-        dCell -= dirCell;
-      } else if (e.which == 39) {
-        dCell += dirCell;
-      } else if (e.which == 38) {
-        dRow -= dirRow;
-      } else if (e.which == 40) {
-        dRow += dirRow;
+      if (isSingleKeyMove) {
+        // single cell move: (Arrow{Up/ArrowDown/ArrowLeft/ArrowRight})
+        if (e.key === 'ArrowLeft') {
+          dCell -= dirCell;
+        } else if (e.key === 'ArrowRight') {
+          dCell += dirCell;
+        } else if (e.key === 'ArrowUp') {
+          dRow -= dirRow;
+        } else if (e.key === 'ArrowDown') {
+          dRow += dirRow;
+        }
+        toRow = active.row + dirRow * dRow;
+      } else {
+        // multiple cell moves: (Home, End, Page{Up/Down})
+        if (this._prevSelectedRow === undefined) {
+          this._prevSelectedRow = active.row;
+        }
+
+        if (e.key === 'Home') {
+          toRow = 0;
+        } else if (e.key === 'End') {
+          toRow = dataLn - 1;
+        } else if (e.key === 'PageUp') {
+          if (this._prevSelectedRow >= 0) {
+            toRow = this._prevSelectedRow - pageRowCount;
+          }
+          if (toRow < 0) {
+            toRow = 0;
+          }
+        } else if (e.key === 'PageDown') {
+          if (this._prevSelectedRow <= dataLn - 1) {
+            toRow = this._prevSelectedRow + pageRowCount;
+          }
+          if (toRow > dataLn - 1) {
+            toRow = dataLn - 1;
+          }
+        }
+        this._prevSelectedRow = toRow;
       }
 
       // define new selection range
-      const new_last = new SlickRange(active.row, active.cell, active.row + dirRow * dRow, active.cell + dirCell * dCell);
+      const new_last = new SlickRange(active.row, active.cell, toRow, active.cell + dirCell * dCell);
       if (this.removeInvalidRanges([new_last]).length) {
         ranges.push(new_last);
         const viewRow = dirRow > 0 ? new_last.toRow : new_last.fromRow;
         const viewCell = dirCell > 0 ? new_last.toCell : new_last.fromCell;
-        this._grid.scrollRowIntoView(viewRow);
-        this._grid.scrollCellIntoView(viewRow, viewCell);
-      }
-      else
+
+        if (isSingleKeyMove) {
+          this._grid.scrollRowIntoView(viewRow);
+          this._grid.scrollCellIntoView(viewRow, viewCell);
+        } else {
+          this._grid.scrollRowIntoView(toRow);
+          this._grid.scrollCellIntoView(toRow, viewCell);
+        }
+      } else {
         ranges.push(last);
+      }
 
       this.setSelectedRanges(ranges);
 
       e.preventDefault();
       e.stopPropagation();
+      this._prevKeyDown = e.key;
     }
   }
 }

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -3537,6 +3537,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return this._topPanels;
   }
 
+  /** Are we using a DataView? */
+  hasDataView() {
+    return !Array.isArray(this.data);
+  }
+
   protected togglePanelVisibility(option: 'showTopPanel' | 'showHeaderRow' | 'showColumnHeader' | 'showFooterRow' | 'showPreHeaderPanel', container: HTMLElement | HTMLElement[], visible?: boolean, animate?: boolean) {
     const animated = (animate === false) ? false : true;
 
@@ -4034,7 +4039,19 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.invalidatePostProcessingResults(row);
   }
 
-  protected getViewportHeight() {
+  /**
+   * Get the number of rows displayed in the viewport
+   * Note that the row count is an approximation because it is a calculated value using this formula (viewport / rowHeight = rowCount),
+   * the viewport must also be displayed for this calculation to work.
+   * @return {Number} rowCount
+   */
+  getViewportRowCount() {
+    const vh = this.getViewportHeight();
+    const scrollbarHeight = this.getScrollbarDimensions()?.height ?? 0;
+    return Math.floor((vh - scrollbarHeight) / this._options.rowHeight!);
+  }
+
+  getViewportHeight() {
     if (!this._options.autoHeight || this._options.frozenColumn !== -1) {
       this.topPanelH = (this._options.showTopPanel) ? this._options.topPanelHeight! + this.getVBoxDelta(this._topPanelScrollers[0]) : 0;
       this.headerRowH = (this._options.showHeaderRow) ? this._options.headerRowHeight! + this.getVBoxDelta(this._headerRowScroller[0]) : 0;
@@ -4069,7 +4086,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return this.viewportH;
   }
 
-  protected getViewportWidth() {
+  getViewportWidth() {
     this.viewportW = parseFloat(Utils.innerSize(this._container, 'width') as unknown as string);
     return this.viewportW;
   }

--- a/src/styles/example-demo.scss
+++ b/src/styles/example-demo.scss
@@ -22,7 +22,7 @@ h2 {
 
 ul {
   margin-left: 0;
-  padding: 0;
+  padding-left: 20px;
   cursor: default;
 }
 
@@ -37,13 +37,6 @@ ul {
   position: absolute;
   top: 0px;
   left: 700px;
-
-  li {
-    padding: 0 0 0 14px;
-
-    list-style: none;
-    margin: 0;
-  }
 
   button, input, textarea {
     font-family: var(--alpine-font-family, $alpine-font-family);


### PR DESCRIPTION
- fixes #794
- adding "pageUp/pageDown/home/end" to SlickCellSelection when using selection with "Shift+{key}"
- add `hasDataView()` and `getViewportRowCount()` methods to SlickGrid and also switch methods `getViewportHeight()` and `getViewportWidth()` from protected to public methods
- add new `example-spreadsheet-dataview.html` demo to manually test updated Cell Selection feature

### TODOs
- [x] tested manually, it should expect the following:
   - [x] doing pageDown twice then pageUp once should equal to 1 pageDown
   - [x] doing Shift+Home from anywhere should select all cells from current position to first row
   - [x] doing Shift+End from should select all cells from current position to last row
   - [x] using Pagination and doing Shift+{key} should select cells in current page only and not outside of it
- [x] add new spreadsheet Example to test Cell Selection with Pagination as detailed above
- [x] add Cypress E2E tests

#### basic SlickGrid example
![brave_jXaDZf7bB1](https://github.com/6pac/SlickGrid/assets/643976/fa5e6e89-245f-467b-8db4-b33ab9ab566b)

#### with DataView & Pagination example
![brave_LARcl6SVGz](https://github.com/6pac/SlickGrid/assets/643976/11816ade-9c12-4338-8f30-cfadda9a7431)
