### PR TITLE
fix: add `autoEditNewRow` option to disable auto-edit new row, fix #445

### DIFF
--- a/examples/example-excel-compatible-spreadsheet.html
+++ b/examples/example-excel-compatible-spreadsheet.html
@@ -113,7 +113,8 @@
     enableAddRow: true,
     enableCellNavigation: true,
     asyncEditorLoading: false,
-    autoEdit: false
+    autoEdit: false,
+    autoEditNewRow: false
   };
 
   var undoRedoBuffer = {

--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -43,11 +43,20 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   // TODO: not sure what that option does?
   auto?: boolean;
 
-  /** Defaults to false, when enabled will try to commit the current edit without focusing on the next row. If a custom editor is implemented and the grid cannot auto commit, you must use this option to implement it yourself */
+  /**
+   * Defaults to false, when enabled will try to commit the current edit without focusing on the next row.
+   * If a custom editor is implemented and the grid cannot auto commit, you must use this option to implement it yourself
+   */
   autoCommitEdit?: boolean;
 
-  /** Defaults to false, when enabled will automatically open the inlined editor as soon as there is a focus on the cell (can be combined with "enableCellNavigation: true"). */
+  /** Defaults to false, when enabled it will automatically open the inlined editor as soon as there is a focus on the cell (can be combined with "enableCellNavigation: true"). */
   autoEdit?: boolean;
+
+  /**
+   * Defaults to true, when enabled it will automatically open the editor when clicking on cell that has a defined editor.
+   * When using CellExternalCopyManager, this option could be useful to avoid opening the cell editor automatically on empty new row and we wish to paste our cell selection range.
+   */
+  autoEditNewRow?: boolean;
 
   /** Defaults to false, which leads to automatically adjust the size (height) of the grid to display the entire content without any scrolling in the grid. */
   autoHeight?: boolean;

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -213,6 +213,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     leaveSpaceForNewRows: false,
     editable: false,
     autoEdit: true,
+    autoEditNewRow: true,
     autoCommitEdit: false,
     suppressActiveCellChangeOnEdit: false,
     enableCellNavigation: true,
@@ -5540,7 +5541,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.activeRow = cell.row;
       this.activeCell = this.activePosX = this.activeCell = this.activePosX = this.getCellFromNode(this.activeCellNode);
 
-      if (opt_editMode == null) {
+      if (opt_editMode == null && this._options.autoEditNewRow) {
         opt_editMode = (this.activeRow == this.getDataLength()) || this._options.autoEdit;
       }
 


### PR DESCRIPTION
- fixes #445
- when using CellExternalCopyManager and user wants to paste cell selection range, it could be useful to not automatically open the cell that was clicked even if it has an editor defined