### PR TITLE
fix: CellSelectionModel calculate page row count only once

### DIFF
--- a/cypress/e2e/example-spreadsheet-dataview.cy.ts
+++ b/cypress/e2e/example-spreadsheet-dataview.cy.ts
@@ -25,7 +25,7 @@ describe('Example - Spreadsheet with DataView and Cell Selection', { retries: 0 
     it('should click on cell B10 and ArrowUp 3 times and ArrowDown 1 time and expect cell selection B8-B10', () => {
       cy.getCell(10, 2, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
         .as('cell_B10')
-        .click()
+        .click();
 
       cy.get('@cell_B10')
         .type('{shift}{uparrow}{uparrow}{uparrow}{downarrow}')
@@ -40,7 +40,7 @@ describe('Example - Spreadsheet with DataView and Cell Selection', { retries: 0 
     it('should click on cell D10 then PageDown 2 times w/selection D10-D46 ', () => {
       cy.getCell(10, 4, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
         .as('cell_D10')
-        .click()
+        .click();
 
       cy.get('@cell_D10')
         .type('{shift}{pagedown}{pagedown}');
@@ -52,7 +52,7 @@ describe('Example - Spreadsheet with DataView and Cell Selection', { retries: 0 
     it('should click on cell D10 then PageDown 3 times then PageUp 1 time w/selection D10-D46', () => {
       cy.getCell(10, 4, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
         .as('cell_D10')
-        .click()
+        .click();
 
       cy.get('@cell_D10')
         .type('{shift}{pagedown}{pagedown}{pagedown}{pageup}');
@@ -64,7 +64,7 @@ describe('Example - Spreadsheet with DataView and Cell Selection', { retries: 0 
     it('should click on cell E12 then End key w/selection E46-E99', () => {
       cy.getCell(46, 5, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
         .as('cell_E46')
-        .click()
+        .click();
 
       cy.get('@cell_E46')
         .type('{shift}{end}');
@@ -76,7 +76,7 @@ describe('Example - Spreadsheet with DataView and Cell Selection', { retries: 0 
     it('should click on cell C85 then End key w/selection C0-C85', () => {
       cy.getCell(85, 3, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
         .as('cell_C85')
-        .click()
+        .click();
 
       cy.get('@cell_C85')
         .type('{shift}{home}');
@@ -95,7 +95,7 @@ describe('Example - Spreadsheet with DataView and Cell Selection', { retries: 0 
     it('should click on cell B14 then Shift+End w/selection B14-24', () => {
       cy.getCell(14, 2, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
         .as('cell_B14')
-        .click()
+        .click();
 
       cy.get('@cell_B14')
         .type('{shift}{end}');
@@ -107,7 +107,7 @@ describe('Example - Spreadsheet with DataView and Cell Selection', { retries: 0 
     it('should click on cell C19 then Shift+End w/selection C0-19', () => {
       cy.getCell(19, 2, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
         .as('cell_C19')
-        .click()
+        .click();
 
       cy.get('@cell_C19')
         .type('{shift}{home}');
@@ -119,7 +119,7 @@ describe('Example - Spreadsheet with DataView and Cell Selection', { retries: 0 
     it('should click on cell E3 then Shift+PageDown multiple times with current page selection starting at E3 w/selection E3-24', () => {
       cy.getCell(3, 5, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
         .as('cell_E3')
-        .click()
+        .click();
 
       cy.get('@cell_E3')
         .type('{shift}{pagedown}{pagedown}{pagedown}');
@@ -133,7 +133,7 @@ describe('Example - Spreadsheet with DataView and Cell Selection', { retries: 0 
 
       cy.getCell(15, 4, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
         .as('cell_D41')
-        .click()
+        .click();
 
       cy.get('@cell_D41')
         .type('{shift}{pageup}{pageup}{pageup}');

--- a/cypress/e2e/example-spreadsheet.cy.ts
+++ b/cypress/e2e/example-spreadsheet.cy.ts
@@ -24,7 +24,7 @@ describe('Example - Spreadsheet and Cell Selection', { retries: 0 }, () => {
   it('should click on cell B10 and ArrowUp 3 times and ArrowDown 1 time and expect cell selection B8-B10', () => {
     cy.getCell(10, 2, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
       .as('cell_B10')
-      .click()
+      .click();
 
     cy.get('@cell_B10')
       .type('{shift}{uparrow}{uparrow}{uparrow}{downarrow}')
@@ -39,7 +39,7 @@ describe('Example - Spreadsheet and Cell Selection', { retries: 0 }, () => {
   it('should click on cell D10 then PageDown 2 times w/selection D10-D46 ', () => {
     cy.getCell(10, 4, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
       .as('cell_D10')
-      .click()
+      .click();
 
     cy.get('@cell_D10')
       .type('{shift}{pagedown}{pagedown}');
@@ -51,7 +51,7 @@ describe('Example - Spreadsheet and Cell Selection', { retries: 0 }, () => {
   it('should click on cell D10 then PageDown 3 times then PageUp 1 time w/selection D10-D46', () => {
     cy.getCell(10, 4, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
       .as('cell_D10')
-      .click()
+      .click();
 
     cy.get('@cell_D10')
       .type('{shift}{pagedown}{pagedown}{pagedown}{pageup}');
@@ -63,7 +63,7 @@ describe('Example - Spreadsheet and Cell Selection', { retries: 0 }, () => {
   it('should click on cell E12 then End key w/selection E46-E99', () => {
     cy.getCell(46, 5, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
       .as('cell_E46')
-      .click()
+      .click();
 
     cy.get('@cell_E46')
       .type('{shift}{end}');
@@ -75,7 +75,7 @@ describe('Example - Spreadsheet and Cell Selection', { retries: 0 }, () => {
   it('should click on cell C85 then End key w/selection C0-C85', () => {
     cy.getCell(85, 3, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
       .as('cell_C85')
-      .click()
+      .click();
 
     cy.get('@cell_C85')
       .type('{shift}{home}');


### PR DESCRIPTION
- for better perf, we shouldn't have to recalculate page row count on every key change (i.e. clicking PageDown multiple times will remain the same row count displayed in the page), we can cache the row count and just reuse it