### PR TITLE
fix: add `containerCssClass` to RowMove to fix cell styling issue with icons

### DIFF
--- a/examples/example-drag-row-between-grids.html
+++ b/examples/example-drag-row-between-grids.html
@@ -109,7 +109,8 @@ var columns = [
     behavior: "selectAndMove",
     selectable: false,
     resizable: false,
-    cssClass: "cell-drag-cross-grid dnd sgi sgi-drag"
+    cssClass: "cell-drag-cross-grid dnd",
+    formatter: () => `<span class="sgi sgi-drag"></span>`
   },
   {
     id: "name",

--- a/examples/example-frozen-row-reordering.html
+++ b/examples/example-frozen-row-reordering.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css"/>
   <link rel="stylesheet" href="../dist/styles/css/slick-icons.css" type="text/css"/>
   <style>
+    .slick-cell {
+      user-select: none;
+    }
     .cell-title {
       zfont-weight: bold;
     }
@@ -110,7 +113,8 @@ var columns = [
     behavior: "selectAndMove",
     selectable: false,
     resizable: false,
-    cssClass: "cell-reorder dnd sgi sgi-drag sgi-12px"
+    cssClass: "cell-reorder dnd",
+    formatter: () => `<span class="sgi sgi-drag"></span>`
   },
   {
     id: "name",
@@ -213,7 +217,6 @@ $(function () {
   });
 
   moveRowsPlugin.onMoveRows.subscribe(function (e, args) {
-    console.log(args)
     var extractedRows = [], left, right;
     var rows = args.rows;
     var insertBefore = args.insertBefore;
@@ -328,13 +331,13 @@ $(function () {
 
   $.drop({mode: "mouse"});
   $("#dropzone")
-    .bind("dropstart", function (e, dd) {
+    .on("dropstart", function (e, dd) {
       $(this).css("background", "yellow");
     })
-    .bind("dropend", function (e, dd) {
+    .on("dropend", function (e, dd) {
       $(dd.available).css("background", "pink");
     })
-    .bind("drop", function (e, dd) {
+    .on("drop", function (e, dd) {
       var rowsToDelete = (dd.rows || []).sort().reverse();
       for (var i = 0; i < rowsToDelete.length; i++) {
         data.splice(rowsToDelete[i], 1);

--- a/examples/example-row-detail-selection-and-move.html
+++ b/examples/example-row-detail-selection-and-move.html
@@ -256,7 +256,7 @@
       columns.splice(columnIndex, 0, checkboxSelectorPlugin.getColumnDefinition());
 
       rowMovePlugin = new Slick.RowMoveManager({
-        cssClass: 'sgi sgi-drag sgi-10px',
+        cssClass: 'sgi sgi-drag',
         cancelEditOnDrag: true,
         singleRowMove: true,
         disableRowSelection: true,

--- a/examples/example9-row-reordering-simple.html
+++ b/examples/example9-row-reordering-simple.html
@@ -66,7 +66,8 @@ var columns = [
     behavior: "selectAndMove",
     selectable: false,
     resizable: false,
-    cssClass: "slickgrid-cell-reorder sgi sgi-drag sgi-12px"
+    cssClass: "slickgrid-cell-reorder",
+    formatter: () => `<span class="sgi sgi-drag"></span>`
   },
   {
     id: "name",

--- a/examples/example9-row-reordering.html
+++ b/examples/example9-row-reordering.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css"/>
   <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css"/>
   <style>
+    .slick-cell {
+      user-select: none;
+    }
     .cell-effort-driven {
       justify-content: center;
     }
@@ -110,7 +113,8 @@ var columns = [
     behavior: "selectAndMove",
     selectable: false,
     resizable: false,
-    cssClass: "cell-reorder dnd sgi sgi-drag sgi-12px"
+    cssClass: "cell-reorder dnd",
+    formatter: () => `<span class="sgi sgi-drag"></span>`
   },
   {
     id: "name",

--- a/src/models/formatterResultObject.interface.ts
+++ b/src/models/formatterResultObject.interface.ts
@@ -1,13 +1,13 @@
 export interface FormatterResultObject {
-  /** Optional CSS classes to add to the cell div */
+  /** Optional CSS classes to add to the cell div container. */
   addClasses?: string;
 
-  /** Optional CSS classes to remove from the cell div */
+  /** Optional CSS classes to remove from the cell div container. */
   removeClasses?: string;
 
-  /** Text to be displayed in the cell, basically the formatter output */
+  /** Text to be displayed in the cell, basically the formatter output. */
   text: string;
 
-  /** Optional tooltip text */
+  /** Optional tooltip text when hovering the cell div container. */
   toolTip?: string;
 }

--- a/src/models/rowMoveManagerOption.interface.ts
+++ b/src/models/rowMoveManagerOption.interface.ts
@@ -18,8 +18,11 @@ export interface RowMoveManagerOption {
    */
   cellRangeSelector?: SlickCellRangeSelector;
 
-  /**  A CSS class to be added to the menu item container. */
+  /** A CSS class to be added to the div of the cell formatter. */
   cssClass?: string;
+
+  /** A CSS class to be added to the cell container. */
+  cellContainerCssClass?: string;
 
   /**  Column definition id(defaults to "_move") */
   columnId?: string;

--- a/src/models/rowMoveManagerOption.interface.ts
+++ b/src/models/rowMoveManagerOption.interface.ts
@@ -22,7 +22,7 @@ export interface RowMoveManagerOption {
   cssClass?: string;
 
   /** A CSS class to be added to the cell container. */
-  cellContainerCssClass?: string;
+  containerCssClass?: string;
 
   /**  Column definition id(defaults to "_move") */
   columnId?: string;

--- a/src/plugins/slick.rowmovemanager.ts
+++ b/src/plugins/slick.rowmovemanager.ts
@@ -9,7 +9,8 @@ const Utils = IIFE_ONLY ? Slick.Utils : Utils_;
 
 /**
  * Row Move Manager options:
- *    cssClass:                 A CSS class to be added to the menu item container.
+ *    cellContainerCssClass:    A CSS class to be added to the cell container.
+ *    cssClass:                 A CSS class to be added to the div of the cell formatter.
  *    columnId:                 Column definition id (defaults to "_move")
  *    cancelEditOnDrag:         Do we want to cancel any Editing while dragging a row (defaults to false)
  *    disableRowSelection:      Do we want to disable the row selection? (defaults to false)
@@ -250,7 +251,10 @@ export class SlickRowMoveManager {
     if (!this.checkUsabilityOverride(row, dataContext, grid)) {
       return '';
     } else {
-      return { addClasses: `cell-reorder dnd ${this._options.cssClass || ''}`, text: '' };
+      return {
+        addClasses: `cell-reorder dnd ${this._options.cellContainerCssClass || ''}`,
+        text: `<div class="${this._options.cssClass}"></div>`
+      };
     }
   }
 

--- a/src/plugins/slick.rowmovemanager.ts
+++ b/src/plugins/slick.rowmovemanager.ts
@@ -9,7 +9,7 @@ const Utils = IIFE_ONLY ? Slick.Utils : Utils_;
 
 /**
  * Row Move Manager options:
- *    cellContainerCssClass:    A CSS class to be added to the cell container.
+ *    containerCssClass:        A CSS class to be added to the cell container.
  *    cssClass:                 A CSS class to be added to the div of the cell formatter.
  *    columnId:                 Column definition id (defaults to "_move")
  *    cancelEditOnDrag:         Do we want to cancel any Editing while dragging a row (defaults to false)
@@ -252,7 +252,7 @@ export class SlickRowMoveManager {
       return '';
     } else {
       return {
-        addClasses: `cell-reorder dnd ${this._options.cellContainerCssClass || ''}`,
+        addClasses: `cell-reorder dnd ${this._options.containerCssClass || ''}`,
         text: `<div class="${this._options.cssClass}"></div>`
       };
     }


### PR DESCRIPTION
- prior to this PR we only had a `cssClass` option but that was adding the CSS classes directly on the `.slick-cell` container and this was maybe ok before we added SlickGrid icons (SVG) but it's causing issue now as per attached printscreens. To address this, let's add a `cellContainerCssClass` that will keep "cell-reorder dnd" CSS classes on the cell container, but let's use the `cssClass` as a new `<div>` inside the slick-cell container, so this way our icon is totally separate from the slick-cell container and won't affect/conflict with its styling

in print screens below, we can see that the border under each Row Move (drag) icon is being removed for some reason, that was a styling conflict as described above

#### before
![image](https://github.com/6pac/SlickGrid/assets/643976/d1b9a189-beea-4300-b98d-961f857cdb35)

#### after
![image](https://github.com/6pac/SlickGrid/assets/643976/e89b0e71-d8f8-4ae9-b89a-bc08dfcc9b79)
