### PR TITLE
feat: add sub-menu(s) to CellMenu & ContextMenu plugins

### DIFF
--- a/cypress/e2e/example-plugin-contextmenu.cy.ts
+++ b/cypress/e2e/example-plugin-contextmenu.cy.ts
@@ -65,7 +65,7 @@ describe('Example - Context Menu & Cell Menu', () => {
   });
 
   it('should expect the Context Menu to not have the "Help" menu when there is Effort Driven set to True', () => {
-    const commands = ['Copy Cell Value', 'Delete Row', '', 'Command (always disabled)', '', 'Export'];
+    const commands = ['Copy Cell Value', 'Delete Row', '', 'Command (always disabled)', '', 'Export', 'Feedback'];
 
     cy.get('#myGrid')
       .find('.slick-row .slick-cell:nth(1)')
@@ -84,7 +84,7 @@ describe('Example - Context Menu & Cell Menu', () => {
   });
 
   it('should expect the Context Menu to not have the "Help" menu when there is Effort Driven set to True', () => {
-    const commands = ['Copy Cell Value', 'Delete Row', '', 'Command (always disabled)', '', 'Export'];
+    const commands = ['Copy Cell Value', 'Delete Row', '', 'Command (always disabled)', '', 'Export', 'Feedback'];
 
     cy.get('#myGrid')
       .find('.slick-row .slick-cell:nth(1)')
@@ -240,7 +240,7 @@ describe('Example - Context Menu & Cell Menu', () => {
   });
 
   it('should expect the Context Menu now have the "Help" menu when Effort Driven is set to False', () => {
-    const commands = ['Copy Cell Value', 'Delete Row', '', 'Help', 'Command (always disabled)', '', 'Export'];
+    const commands = ['Copy Cell Value', 'Delete Row', '', 'Help', 'Command (always disabled)', '', 'Export', 'Feedback'];
 
     cy.get('#myGrid')
       .find('.slick-row .slick-cell:nth(1)')
@@ -430,6 +430,64 @@ describe('Example - Context Menu & Cell Menu', () => {
       .each(($option, index) => expect($option.text()).to.eq(subOptions[index]));
   });
 
+  it('should open Export->Excel sub-menu then open Feedback->ContactUs sub-menus and expect previous Export menu to no longer exists', () => {
+    const subCommands1 = ['Text', 'Excel'];
+    const subCommands2 = ['Request update from shipping team', '', 'Contact Us'];
+    const subCommands2_1 = ['Email us', 'Chat with us', 'Book an appointment'];
+
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(7)')
+      .contains('Action')
+      .click({ force: true });
+
+    cy.get('.slick-cell-menu.slick-menu-level-0 .slick-cell-menu-command-list')
+      .find('.slick-cell-menu-item')
+      .contains('Export')
+      .click();
+
+    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-command-list')
+      .should('exist')
+      .find('.slick-cell-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands1[index]));
+
+    // click different sub-menu
+    cy.get('.slick-cell-menu.slick-menu-level-0')
+      .find('.slick-cell-menu-item')
+      .contains('Feedback')
+      .should('exist')
+      .click();
+
+    cy.get('.slick-submenu').should('have.length', 1);
+    cy.get('.slick-cell-menu.slick-menu-level-1')
+      .should('exist')
+      .find('.slick-cell-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands2[index]));
+
+    // click on Feedback->ContactUs
+    cy.get('.slick-cell-menu.slick-menu-level-1.dropleft') // left align
+      .find('.slick-cell-menu-item')
+      .contains('Contact Us')
+      .should('exist')
+      .click();
+
+    cy.get('.slick-submenu').should('have.length', 2);
+    cy.get('.slick-cell-menu.slick-menu-level-2.dropright') // right align
+      .should('exist')
+      .find('.slick-cell-menu-item')
+      .each(($command, index) => expect($command.text()).to.eq(subCommands2_1[index]));
+
+    cy.get('.slick-cell-menu.slick-menu-level-2');
+
+    cy.get('.slick-cell-menu.slick-menu-level-2 .slick-cell-menu-command-list')
+      .find('.slick-cell-menu-item')
+      .contains('Chat with us')
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Command: contact-chat'));
+  });
+
   it('should click on the "Show Commands & Priority Options" button and see both list when opening Context Menu', () => {
     cy.get('button')
       .contains('Show Commands & Priority Options')
@@ -585,7 +643,7 @@ describe('Example - Context Menu & Cell Menu', () => {
   });
 
   it('should click on the "Show Action Commands Only" button and see both list when opening Cell Menu', () => {
-    const commands = ['Command 1', 'Command 2', 'Delete Row', '', 'Help', 'Disabled Command', '', 'Export'];
+    const commands = ['Command 1', 'Command 2', 'Delete Row', '', 'Help', 'Disabled Command', '', 'Export', 'Feedback'];
 
     cy.get('button')
       .contains('Show Action Commands Only')
@@ -797,5 +855,64 @@ describe('Example - Context Menu & Cell Menu', () => {
       .should('exist')
       .find('.slick-context-menu-item')
       .each(($option, index) => expect($option.text()).to.contain(subOptions[index]));
+  });
+
+  it('should open Export->Excel context sub-menu then open Feedback->ContactUs sub-menus and expect previous Export menu to no longer exists', () => {
+    const subCommands1 = ['Text', 'Excel'];
+    const subCommands2 = ['Request update from shipping team', '', 'Contact Us'];
+    const subCommands2_1 = ['Email us', 'Chat with us', 'Book an appointment'];
+
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(2)')
+      .rightclick();
+
+    cy.get('.slick-context-menu.slick-menu-level-0 .slick-context-menu-command-list')
+      .find('.slick-context-menu-item')
+      .contains('Export')
+      .click();
+
+    cy.get('.slick-context-menu.slick-menu-level-1 .slick-context-menu-command-list')
+      .should('exist')
+      .find('.slick-context-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands1[index]));
+
+    // click different sub-menu
+    cy.get('.slick-context-menu.slick-menu-level-0')
+      .find('.slick-context-menu-item')
+      .contains('Feedback')
+      .should('exist')
+      .click();
+
+    cy.get('.slick-submenu').should('have.length', 1);
+    cy.get('.slick-context-menu.slick-menu-level-1')
+      .should('exist')
+      .find('.slick-context-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands2[index]));
+
+    // click on Feedback->ContactUs
+    cy.get('.slick-context-menu.slick-menu-level-1.dropright') // right align
+      .find('.slick-context-menu-item')
+      .contains('Contact Us')
+      .should('exist')
+      .click();
+
+    cy.get('.slick-submenu').should('have.length', 2);
+    cy.get('.slick-context-menu.slick-menu-level-2.dropleft') // left align
+      .should('exist')
+      .find('.slick-context-menu-item')
+      .each(($command, index) => expect($command.text()).to.eq(subCommands2_1[index]));
+
+    cy.get('.slick-context-menu.slick-menu-level-2');
+
+    cy.get('.slick-context-menu.slick-menu-level-2 .slick-context-menu-command-list')
+      .find('.slick-context-menu-item')
+      .contains('Chat with us')
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Command: contact-chat'));
+
+    cy.get('.slick-submenu').should('have.length', 0);
   });
 });

--- a/cypress/e2e/example-plugin-contextmenu.cy.ts
+++ b/cypress/e2e/example-plugin-contextmenu.cy.ts
@@ -65,7 +65,7 @@ describe('Example - Context Menu & Cell Menu', () => {
   });
 
   it('should expect the Context Menu to not have the "Help" menu when there is Effort Driven set to True', () => {
-    const commands = ['Copy Cell Value', 'Delete Row', '', 'Command (always disabled)'];
+    const commands = ['Copy Cell Value', 'Delete Row', '', 'Command (always disabled)', '', 'Export'];
 
     cy.get('#myGrid')
       .find('.slick-row .slick-cell:nth(1)')
@@ -78,13 +78,13 @@ describe('Example - Context Menu & Cell Menu', () => {
     cy.get('.slick-context-menu.dropright .slick-context-menu-command-list')
       .find('.slick-context-menu-item')
       .each(($command, index) => {
-        expect($command.text()).to.eq(commands[index]);
+        expect($command.text()).to.contain(commands[index]);
         expect($command.text()).not.include('Help');
       });
   });
 
   it('should expect the Context Menu to not have the "Help" menu when there is Effort Driven set to True', () => {
-    const commands = ['Copy Cell Value', 'Delete Row', '', 'Command (always disabled)'];
+    const commands = ['Copy Cell Value', 'Delete Row', '', 'Command (always disabled)', '', 'Export'];
 
     cy.get('#myGrid')
       .find('.slick-row .slick-cell:nth(1)')
@@ -97,7 +97,7 @@ describe('Example - Context Menu & Cell Menu', () => {
     cy.get('.slick-context-menu.dropright .slick-context-menu-command-list')
       .find('.slick-context-menu-item')
       .each(($command, index) => {
-        expect($command.text()).to.eq(commands[index]);
+        expect($command.text()).to.contain(commands[index]);
         expect($command.text()).not.include('Help');
       });
   });
@@ -240,7 +240,7 @@ describe('Example - Context Menu & Cell Menu', () => {
   });
 
   it('should expect the Context Menu now have the "Help" menu when Effort Driven is set to False', () => {
-    const commands = ['Copy Cell Value', 'Delete Row', '', 'Help', 'Command (always disabled)'];
+    const commands = ['Copy Cell Value', 'Delete Row', '', 'Help', 'Command (always disabled)', '', 'Export'];
 
     cy.get('#myGrid')
       .find('.slick-row .slick-cell:nth(1)')
@@ -252,7 +252,7 @@ describe('Example - Context Menu & Cell Menu', () => {
 
     cy.get('.slick-context-menu.dropleft .slick-context-menu-command-list')
       .find('.slick-context-menu-item')
-      .each(($command, index) => expect($command.text()).to.eq(commands[index]));
+      .each(($command, index) => expect($command.text()).to.contain(commands[index]));
 
     cy.get('.slick-context-menu button.close')
       .click();
@@ -391,7 +391,13 @@ describe('Example - Context Menu & Cell Menu', () => {
       .contains('Sub-Options')
       .click();
 
-    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-option-list')
+    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-option-list').as('optionSubList2');
+
+    cy.get('@optionSubList2')
+      .find('.slick-menu-title')
+      .contains('Set Effort Driven');
+
+    cy.get('@optionSubList2')
       .should('exist')
       .find('.slick-cell-menu-item')
       .each(($option, index) => expect($option.text()).to.eq(subOptions[index]));
@@ -420,7 +426,7 @@ describe('Example - Context Menu & Cell Menu', () => {
       .click();
   });
 
-  it('should click on the "Show Priority Options Only" button and see both list when opening Context Menu', () => {
+  it('should click on the "Show Priority Options Only" button and see both list when opening Context Menu & selecting "Medium" option should be reflected in the grid cell and expect "Action" cell menu to be disabled', () => {
     cy.get('button')
       .contains('Show Priority Options Only')
       .click();
@@ -429,15 +435,62 @@ describe('Example - Context Menu & Cell Menu', () => {
       .find('.slick-row .slick-cell:nth(5)')
       .rightclick();
 
-    cy.get('.slick-context-menu .slick-context-menu-option-list')
-      .should('exist')
-      .contains('High');
-
     cy.get('.slick-context-menu-command-list')
       .should('not.exist');
 
-    cy.get('.slick-context-menu button.close')
+    cy.get('.slick-context-menu .slick-context-menu-option-list')
+      .should('exist')
+      .contains('Medium')
       .click();
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(5)')
+      .contains('Medium');
+
+    cy.get('.slick-row .slick-cell:nth(7)')
+      .find('.cell-menu-dropdown.disabled')
+      .should('exist');
+  });
+
+  it('should reopen Context Menu then select "High" option from sub-menu and expect "Action" cell menu to be reenabled', () => {
+    const subOptions = ['Low', 'Medium', 'High'];
+
+    cy.get('button')
+      .contains('Show Priority Options Only')
+      .click();
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(5)')
+      .rightclick();
+
+    cy.get('.slick-context-menu.slick-menu-level-0 .slick-context-menu-option-list')
+      .find('.slick-context-menu-item')
+      .contains('Sub-Options (demo)')
+      .click();
+
+    cy.get('.slick-context-menu.slick-menu-level-1 .slick-context-menu-option-list').as('subMenuList');
+
+    cy.get('@subMenuList')
+      .find('.slick-menu-title')
+      .contains('Set Priority');
+
+    cy.get('@subMenuList')
+      .should('exist')
+      .find('.slick-context-menu-item')
+      .each(($command, index) => expect($command.text()).to.eq(subOptions[index]));
+
+    cy.get('@subMenuList')
+      .find('.slick-context-menu-item')
+      .contains('High')
+      .click();
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(5)')
+      .contains('High');
+
+    cy.get('.slick-row .slick-cell:nth(7)')
+      .find('.cell-menu-dropdown.disabled')
+      .should('not.exist');
   });
 
   it('should click on the "Show Actions Commands & Effort Options" button and see both list when opening Action Cell Menu', () => {
@@ -598,5 +651,98 @@ describe('Example - Context Menu & Cell Menu', () => {
 
     cy.get('.slick-context-menu button.close')
       .click();
+  });
+
+  it('should be able to open Context Menu and click on Export->Excel-> sub-commands to see 1 context menu + 1 sub-menu then clicking on PDF should call alert action', () => {
+    const subCommands1 = ['PDF', 'Excel'];
+    const subCommands2 = ['Excel (csv)', 'Excel (xls)'];
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(1)')
+      .rightclick();
+
+    cy.get('.slick-context-menu.slick-menu-level-0 .slick-context-menu-command-list')
+      .find('.slick-context-menu-item')
+      .contains('Export')
+      .click();
+
+    cy.get('.slick-context-menu.slick-menu-level-1 .slick-context-menu-command-list')
+      .should('exist')
+      .find('.slick-context-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands1[index]));
+
+    cy.get('.slick-context-menu.slick-menu-level-1 .slick-context-menu-command-list')
+      .find('.slick-context-menu-item')
+      .contains('Excel')
+      .click();
+
+    cy.get('.slick-context-menu.slick-menu-level-2 .slick-context-menu-command-list').as('subMenuList2');
+
+    cy.get('@subMenuList2')
+      .find('.slick-menu-title')
+      .contains('available formats');
+
+    cy.get('@subMenuList2')
+      .should('exist')
+      .find('.slick-context-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands2[index]));
+
+    cy.get('.slick-context-menu.slick-menu-level-2 .slick-context-menu-command-list')
+      .find('.slick-context-menu-item')
+      .contains('Excel (xls)')
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Exporting as Excel (xls)'));
+  });
+
+  it('should open Export->Excel sub-menu & open again Sub-Options on top and expect sub-menu to be recreated with that Sub-Options list instead of the Export->Excel list', () => {
+    const subCommands1 = ['PDF', 'Excel'];
+    const subCommands2 = ['Excel (csv)', 'Excel (xls)'];
+    const subOptions = ['Low', 'Medium', 'High'];
+
+    cy.get('button')
+      .contains('Show Commands & Priority Options')
+      .click();
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(5)')
+      .rightclick();
+
+    cy.get('.slick-context-menu.slick-menu-level-0 .slick-context-menu-command-list')
+      .find('.slick-context-menu-item')
+      .contains('Export')
+      .click();
+
+    cy.get('.slick-context-menu.slick-menu-level-1 .slick-context-menu-command-list')
+      .should('exist')
+      .find('.slick-context-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands1[index]));
+
+    cy.get('.slick-context-menu.slick-menu-level-1 .slick-context-menu-command-list')
+      .find('.slick-context-menu-item')
+      .contains('Excel')
+      .click();
+
+    cy.get('.slick-context-menu.slick-menu-level-2 .slick-context-menu-command-list')
+      .should('exist')
+      .find('.slick-context-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands2[index]));
+
+    cy.get('.slick-context-menu.slick-menu-level-0 .slick-context-menu-option-list')
+      .find('.slick-context-menu-item')
+      .contains('Sub-Options')
+      .click();
+
+    cy.get('.slick-context-menu.slick-menu-level-1 .slick-context-menu-option-list').as('optionSubList2');
+
+    cy.get('@optionSubList2')
+      .find('.slick-menu-title')
+      .contains('Set Priority');
+
+    cy.get('@optionSubList2')
+      .should('exist')
+      .find('.slick-context-menu-item')
+      .each(($option, index) => expect($option.text()).to.contain(subOptions[index]));
   });
 });

--- a/cypress/e2e/example-plugin-contextmenu.cy.ts
+++ b/cypress/e2e/example-plugin-contextmenu.cy.ts
@@ -184,7 +184,7 @@ describe('Example - Context Menu & Cell Menu', () => {
     cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-option-list').as('subMenuList');
 
     cy.get('@subMenuList')
-      .find('.title')
+      .find('.slick-menu-title')
       .contains('Set Effort Driven');
 
     cy.get('@subMenuList')
@@ -341,7 +341,7 @@ describe('Example - Context Menu & Cell Menu', () => {
     cy.get('.slick-cell-menu.slick-menu-level-2 .slick-cell-menu-command-list').as('subMenuList2');
 
     cy.get('@subMenuList2')
-      .find('.title')
+      .find('.slick-menu-title')
       .contains('available formats');
 
     cy.get('@subMenuList2')

--- a/cypress/e2e/example-plugin-contextmenu.cy.ts
+++ b/cypress/e2e/example-plugin-contextmenu.cy.ts
@@ -285,8 +285,8 @@ describe('Example - Context Menu & Cell Menu', () => {
       .should('not.exist');
   });
 
-  it('should be able to open Cell Menu and click on Export->PDF sub-commands to see 1 cell menu + 1 sub-menu then clicking on PDF should call alert action', () => {
-    const subCommands = ['PDF', 'Excel'];
+  it('should be able to open Cell Menu and click on Export->Text sub-commands to see 1 cell menu + 1 sub-menu then clicking on Text should call alert action', () => {
+    const subCommands = ['Text', 'Excel'];
     const stub = cy.stub();
     cy.on('window:alert', stub);
 
@@ -307,13 +307,13 @@ describe('Example - Context Menu & Cell Menu', () => {
 
     cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-command-list')
       .find('.slick-cell-menu-item')
-      .contains('PDF')
+      .contains('Text')
       .click()
-      .then(() => expect(stub.getCall(0)).to.be.calledWith('Exporting as PDF'));
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Exporting as Text'));
   });
 
-  it('should be able to open Cell Menu and click on Export->Excel-> sub-commands to see 1 cell menu + 1 sub-menu then clicking on PDF should call alert action', () => {
-    const subCommands1 = ['PDF', 'Excel'];
+  it('should be able to open Cell Menu and click on Export->Excel-> sub-commands to see 1 cell menu + 1 sub-menu then clicking on Text should call alert action', () => {
+    const subCommands1 = ['Text', 'Excel'];
     const subCommands2 = ['Excel (csv)', 'Excel (xls)'];
     const stub = cy.stub();
     cy.on('window:alert', stub);
@@ -357,7 +357,7 @@ describe('Example - Context Menu & Cell Menu', () => {
   });
 
   it('should open Export->Excel sub-menu & open again Sub-Options on top and expect sub-menu to be recreated with that Sub-Options list instead of the Export->Excel list', () => {
-    const subCommands1 = ['PDF', 'Excel'];
+    const subCommands1 = ['Text', 'Excel'];
     const subCommands2 = ['Excel (csv)', 'Excel (xls)'];
     const subOptions = ['True', 'False'];
 
@@ -653,8 +653,8 @@ describe('Example - Context Menu & Cell Menu', () => {
       .click();
   });
 
-  it('should be able to open Context Menu and click on Export->Excel-> sub-commands to see 1 context menu + 1 sub-menu then clicking on PDF should call alert action', () => {
-    const subCommands1 = ['PDF', 'Excel'];
+  it('should be able to open Context Menu and click on Export->Excel-> sub-commands to see 1 context menu + 1 sub-menu then clicking on Text should call alert action', () => {
+    const subCommands1 = ['Text', 'Excel'];
     const subCommands2 = ['Excel (csv)', 'Excel (xls)'];
     const stub = cy.stub();
     cy.on('window:alert', stub);
@@ -697,7 +697,7 @@ describe('Example - Context Menu & Cell Menu', () => {
   });
 
   it('should open Export->Excel sub-menu & open again Sub-Options on top and expect sub-menu to be recreated with that Sub-Options list instead of the Export->Excel list', () => {
-    const subCommands1 = ['PDF', 'Excel'];
+    const subCommands1 = ['Text', 'Excel'];
     const subCommands2 = ['Excel (csv)', 'Excel (xls)'];
     const subOptions = ['Low', 'Medium', 'High'];
 

--- a/cypress/e2e/example-plugin-contextmenu.cy.ts
+++ b/cypress/e2e/example-plugin-contextmenu.cy.ts
@@ -151,7 +151,7 @@ describe('Example - Context Menu & Cell Menu', () => {
     const stub = cy.stub();
     cy.on('window:alert', stub);
 
-    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-option-list')
+    cy.get('.slick-cell-menu.slick-menu-level-0 .slick-cell-menu-option-list')
       .find('.slick-cell-menu-item')
       .contains('False')
       .click();
@@ -176,12 +176,18 @@ describe('Example - Context Menu & Cell Menu', () => {
       .contains('Action')
       .click({ force: true });
 
-    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-option-list')
+    cy.get('.slick-cell-menu.slick-menu-level-0 .slick-cell-menu-option-list')
       .find('.slick-cell-menu-item')
       .contains('Sub-Options')
       .click();
 
-    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-option-list')
+    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-option-list').as('subMenuList');
+
+    cy.get('@subMenuList')
+      .find('.title')
+      .contains('Set Effort Driven');
+
+    cy.get('@subMenuList')
       .find('.slick-cell-menu-item')
       .contains('True')
       .click();
@@ -208,12 +214,12 @@ describe('Example - Context Menu & Cell Menu', () => {
       .contains('Action')
       .click({ force: true });
 
-    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-option-list')
+    cy.get('.slick-cell-menu.slick-menu-level-0 .slick-cell-menu-option-list')
       .find('.slick-cell-menu-item')
       .contains('Sub-Options')
       .click();
 
-    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-option-list')
+    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-option-list')
       .find('.slick-cell-menu-item')
       .contains('False')
       .click();
@@ -289,17 +295,17 @@ describe('Example - Context Menu & Cell Menu', () => {
       .contains('Action')
       .click({ force: true });
 
-    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-command-list')
+    cy.get('.slick-cell-menu.slick-menu-level-0 .slick-cell-menu-command-list')
       .find('.slick-cell-menu-item')
       .contains('Export')
       .click();
 
-    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-command-list')
+    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-command-list')
       .should('exist')
       .find('.slick-cell-menu-item')
       .each(($command, index) => expect($command.text()).to.eq(subCommands[index]));
 
-    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-command-list')
+    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-command-list')
       .find('.slick-cell-menu-item')
       .contains('PDF')
       .click()
@@ -317,27 +323,33 @@ describe('Example - Context Menu & Cell Menu', () => {
       .contains('Action')
       .click({ force: true });
 
-    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-command-list')
+    cy.get('.slick-cell-menu.slick-menu-level-0 .slick-cell-menu-command-list')
       .find('.slick-cell-menu-item')
       .contains('Export')
       .click();
 
-    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-command-list')
+    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-command-list')
       .should('exist')
       .find('.slick-cell-menu-item')
       .each(($command, index) => expect($command.text()).to.eq(subCommands1[index]));
 
-    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-command-list')
+    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-command-list')
       .find('.slick-cell-menu-item')
       .contains('Excel')
       .click();
 
-    cy.get('.slick-cell-menu.level-2 .slick-cell-menu-command-list')
+    cy.get('.slick-cell-menu.slick-menu-level-2 .slick-cell-menu-command-list').as('subMenuList2');
+
+    cy.get('@subMenuList2')
+      .find('.title')
+      .contains('available formats');
+
+    cy.get('@subMenuList2')
       .should('exist')
       .find('.slick-cell-menu-item')
       .each(($command, index) => expect($command.text()).to.eq(subCommands2[index]));
 
-    cy.get('.slick-cell-menu.level-2 .slick-cell-menu-command-list')
+    cy.get('.slick-cell-menu.slick-menu-level-2 .slick-cell-menu-command-list')
       .find('.slick-cell-menu-item')
       .contains('Excel (xls)')
       .click()
@@ -354,32 +366,32 @@ describe('Example - Context Menu & Cell Menu', () => {
       .contains('Action')
       .click({ force: true });
 
-    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-command-list')
+    cy.get('.slick-cell-menu.slick-menu-level-0 .slick-cell-menu-command-list')
       .find('.slick-cell-menu-item')
       .contains('Export')
       .click();
 
-    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-command-list')
+    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-command-list')
       .should('exist')
       .find('.slick-cell-menu-item')
       .each(($command, index) => expect($command.text()).to.eq(subCommands1[index]));
 
-    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-command-list')
+    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-command-list')
       .find('.slick-cell-menu-item')
       .contains('Excel')
       .click();
 
-    cy.get('.slick-cell-menu.level-2 .slick-cell-menu-command-list')
+    cy.get('.slick-cell-menu.slick-menu-level-2 .slick-cell-menu-command-list')
       .should('exist')
       .find('.slick-cell-menu-item')
       .each(($command, index) => expect($command.text()).to.eq(subCommands2[index]));
 
-    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-option-list')
+    cy.get('.slick-cell-menu.slick-menu-level-0 .slick-cell-menu-option-list')
       .find('.slick-cell-menu-item')
       .contains('Sub-Options')
       .click();
 
-    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-option-list')
+    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-option-list')
       .should('exist')
       .find('.slick-cell-menu-item')
       .each(($option, index) => expect($option.text()).to.eq(subOptions[index]));

--- a/cypress/e2e/example-plugin-contextmenu.cy.ts
+++ b/cypress/e2e/example-plugin-contextmenu.cy.ts
@@ -312,6 +312,33 @@ describe('Example - Context Menu & Cell Menu', () => {
       .then(() => expect(stub.getCall(0)).to.be.calledWith('Exporting as Text'));
   });
 
+  it('should be able to open Cell Menu and click on Export->Text and expect alert triggered with Text Export', () => {
+    const subCommands1 = ['Text', 'Excel'];
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(7)')
+      .contains('Action')
+      .click({ force: true });
+
+    cy.get('.slick-cell-menu.slick-menu-level-0 .slick-cell-menu-command-list')
+      .find('.slick-cell-menu-item')
+      .contains('Export')
+      .click();
+
+    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-command-list')
+      .should('exist')
+      .find('.slick-cell-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands1[index]));
+
+    cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-command-list')
+      .find('.slick-cell-menu-item')
+      .contains('Text')
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Exporting as Text'));
+  });
+
   it('should be able to open Cell Menu and click on Export->Excel-> sub-commands to see 1 cell menu + 1 sub-menu then clicking on Text should call alert action', () => {
     const subCommands1 = ['Text', 'Excel'];
     const subCommands2 = ['Excel (csv)', 'Excel (xls)'];
@@ -651,6 +678,32 @@ describe('Example - Context Menu & Cell Menu', () => {
 
     cy.get('.slick-context-menu button.close')
       .click();
+  });
+
+  it('should be able to open Context Menu and click on Export->Text and expect alert triggered with Text Export', () => {
+    const subCommands1 = ['Text', 'Excel'];
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(1)')
+      .rightclick();
+
+    cy.get('.slick-context-menu.slick-menu-level-0 .slick-context-menu-command-list')
+      .find('.slick-context-menu-item')
+      .contains('Export')
+      .click();
+
+    cy.get('.slick-context-menu.slick-menu-level-1 .slick-context-menu-command-list')
+      .should('exist')
+      .find('.slick-context-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands1[index]));
+
+    cy.get('.slick-context-menu.slick-menu-level-1 .slick-context-menu-command-list')
+      .find('.slick-context-menu-item')
+      .contains('Text')
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Exporting as Text'));
   });
 
   it('should be able to open Context Menu and click on Export->Excel-> sub-commands to see 1 context menu + 1 sub-menu then clicking on Text should call alert action', () => {

--- a/cypress/e2e/example-plugin-contextmenu.cy.ts
+++ b/cypress/e2e/example-plugin-contextmenu.cy.ts
@@ -39,7 +39,7 @@ describe('Example - Context Menu & Cell Menu', () => {
       .contains('Action');
 
     cy.get('.slick-cell-menu')
-      .should('not.exist')
+      .should('not.exist');
   });
 
   it('should open the Context Menu and expect onBeforeMenuShow then onAfterMenuShow to show in the console log', () => {
@@ -147,11 +147,11 @@ describe('Example - Context Menu & Cell Menu', () => {
       .should('exist');
   });
 
-  it('should change the Effort Driven to "False" in that same Action and then expect the "Command 2" to enabled and clickable', () => {
+  it('should change the Effort Driven to "False" in that same Action and then expect the "Command 2" to be enabled and clickable', () => {
     const stub = cy.stub();
     cy.on('window:alert', stub);
 
-    cy.get('.slick-cell-menu .slick-cell-menu-option-list')
+    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-option-list')
       .find('.slick-cell-menu-item')
       .contains('False')
       .click();
@@ -160,6 +160,72 @@ describe('Example - Context Menu & Cell Menu', () => {
       .find('.slick-row .slick-cell:nth(7)')
       .contains('Action')
       .click({ force: true });
+
+    cy.get('.slick-cell-menu .slick-cell-menu-item')
+      .contains('Command 2')
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Command 2'));
+  });
+
+  it('should change the Effort Driven to "True" by using sub-options in that same Action and then expect the "Command 2" to be disabled and not clickable and "Delete Row" to not be shown', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(7)')
+      .contains('Action')
+      .click({ force: true });
+
+    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-option-list')
+      .find('.slick-cell-menu-item')
+      .contains('Sub-Options')
+      .click();
+
+    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-option-list')
+      .find('.slick-cell-menu-item')
+      .contains('True')
+      .click();
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(7)')
+      .contains('Action')
+      .click({ force: true });
+
+    cy.get('.slick-cell-menu .slick-cell-menu-item.slick-cell-menu-item-disabled')
+      .contains('Command 2');
+
+    cy.get('.slick-cell-menu .slick-cell-menu-item')
+      .contains('Delete Row')
+      .should('not.exist');
+  });
+
+  it('should change the Effort Driven back to "False" by using sub-options in that same Action and then expect the "Command 2" to enabled and clickable and also show "Delete Row" command', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(7)')
+      .contains('Action')
+      .click({ force: true });
+
+    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-option-list')
+      .find('.slick-cell-menu-item')
+      .contains('Sub-Options')
+      .click();
+
+    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-option-list')
+      .find('.slick-cell-menu-item')
+      .contains('False')
+      .click();
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(7)')
+      .contains('Action')
+      .click({ force: true });
+
+    cy.get('.slick-cell-menu .slick-cell-menu-item')
+      .contains('Delete Row')
+      .should('exist');
 
     cy.get('.slick-cell-menu .slick-cell-menu-item')
       .contains('Command 2')
@@ -211,6 +277,112 @@ describe('Example - Context Menu & Cell Menu', () => {
 
     cy.get('.slick-cell-menu.dropleft')
       .should('not.exist');
+  });
+
+  it('should be able to open Cell Menu and click on Export->PDF sub-commands to see 1 cell menu + 1 sub-menu then clicking on PDF should call alert action', () => {
+    const subCommands = ['PDF', 'Excel'];
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(7)')
+      .contains('Action')
+      .click({ force: true });
+
+    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-command-list')
+      .find('.slick-cell-menu-item')
+      .contains('Export')
+      .click();
+
+    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-command-list')
+      .should('exist')
+      .find('.slick-cell-menu-item')
+      .each(($command, index) => expect($command.text()).to.eq(subCommands[index]));
+
+    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-command-list')
+      .find('.slick-cell-menu-item')
+      .contains('PDF')
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Exporting as PDF'));
+  });
+
+  it('should be able to open Cell Menu and click on Export->Excel-> sub-commands to see 1 cell menu + 1 sub-menu then clicking on PDF should call alert action', () => {
+    const subCommands1 = ['PDF', 'Excel'];
+    const subCommands2 = ['Excel (csv)', 'Excel (xls)'];
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(7)')
+      .contains('Action')
+      .click({ force: true });
+
+    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-command-list')
+      .find('.slick-cell-menu-item')
+      .contains('Export')
+      .click();
+
+    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-command-list')
+      .should('exist')
+      .find('.slick-cell-menu-item')
+      .each(($command, index) => expect($command.text()).to.eq(subCommands1[index]));
+
+    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-command-list')
+      .find('.slick-cell-menu-item')
+      .contains('Excel')
+      .click();
+
+    cy.get('.slick-cell-menu.level-2 .slick-cell-menu-command-list')
+      .should('exist')
+      .find('.slick-cell-menu-item')
+      .each(($command, index) => expect($command.text()).to.eq(subCommands2[index]));
+
+    cy.get('.slick-cell-menu.level-2 .slick-cell-menu-command-list')
+      .find('.slick-cell-menu-item')
+      .contains('Excel (xls)')
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Exporting as Excel (xls)'));
+  });
+
+  it('should open Export->Excel sub-menu & open again Sub-Options on top and expect sub-menu to be recreated with that Sub-Options list instead of the Export->Excel list', () => {
+    const subCommands1 = ['PDF', 'Excel'];
+    const subCommands2 = ['Excel (csv)', 'Excel (xls)'];
+    const subOptions = ['True', 'False'];
+
+    cy.get('#myGrid')
+      .find('.slick-row .slick-cell:nth(7)')
+      .contains('Action')
+      .click({ force: true });
+
+    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-command-list')
+      .find('.slick-cell-menu-item')
+      .contains('Export')
+      .click();
+
+    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-command-list')
+      .should('exist')
+      .find('.slick-cell-menu-item')
+      .each(($command, index) => expect($command.text()).to.eq(subCommands1[index]));
+
+    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-command-list')
+      .find('.slick-cell-menu-item')
+      .contains('Excel')
+      .click();
+
+    cy.get('.slick-cell-menu.level-2 .slick-cell-menu-command-list')
+      .should('exist')
+      .find('.slick-cell-menu-item')
+      .each(($command, index) => expect($command.text()).to.eq(subCommands2[index]));
+
+    cy.get('.slick-cell-menu.level-0 .slick-cell-menu-option-list')
+      .find('.slick-cell-menu-item')
+      .contains('Sub-Options')
+      .click();
+
+    cy.get('.slick-cell-menu.level-1 .slick-cell-menu-option-list')
+      .should('exist')
+      .find('.slick-cell-menu-item')
+      .each(($option, index) => expect($option.text()).to.eq(subOptions[index]));
   });
 
   it('should click on the "Show Commands & Priority Options" button and see both list when opening Context Menu', () => {
@@ -320,8 +492,8 @@ describe('Example - Context Menu & Cell Menu', () => {
       .click();
   });
 
-  it('should click on the "Show Action Commands Only" button and see both list when opening Context Menu', () => {
-    const commands = ['Command 1', 'Command 2', 'Delete Row', '', 'Help', 'Disabled Command'];
+  it('should click on the "Show Action Commands Only" button and see both list when opening Cell Menu', () => {
+    const commands = ['Command 1', 'Command 2', 'Delete Row', '', 'Help', 'Disabled Command', '', 'Export'];
 
     cy.get('button')
       .contains('Show Action Commands Only')

--- a/examples/example-plugin-contextmenu.html
+++ b/examples/example-plugin-contextmenu.html
@@ -84,10 +84,10 @@
 <body>
   <table width="100%">
     <tr>
-      <td valign="top" width="50%">
+      <td valign="top" width="50%" style="padding-left: 0px">
         <div id="myGrid" class="slick-container" style="width:650px;height:700px;"></div>
       </td>
-      <td valign="top">
+      <td valign="top" style="display: block">
         <h2>
           <h2>
             <a href="/examples/index.html" style="text-decoration: none; font-size: 22px">&#x2302;</a>
@@ -285,10 +285,13 @@
 
       switch (command) {
         case "command1":
-          alert('Command 1');
-          break;
         case "command2":
-          alert('Command 2');
+          alert(args.item.title);
+          break;
+        case "export-csv":
+        case "export-pdf":
+        case "export-xls":
+          alert("Exporting as " + args.item.title);
           break;
         case "copy-text":
           copyCellValue(args.value);
@@ -352,7 +355,22 @@
             "divider",
             // { divider: true },
             { command: "help", title: "Help", iconCssClass: "sgi sgi-help-circle-outline" },
-            { command: "something", title: "Disabled Command", disabled: true }
+            { command: "something", title: "Disabled Command", disabled: true },
+            "divider",
+            {
+              // we can also have multiple sub-items
+              command: 'export', title: 'Export',
+              commandItems: [
+                { command: "export-pdf", title: "PDF" },
+                {
+                  command: 'sub-menu', title: 'Excel', cssClass: "green",
+                  commandItems: [
+                    { command: "export-csv", title: "Excel (csv)" },
+                    { command: "export-xls", title: "Excel (xls)" },
+                  ]
+                }
+              ]
+            }
           ],
           optionTitle: "Change Effort Driven",
           optionItems: [
@@ -373,6 +391,13 @@
                 return (!args.dataContext.effortDriven);
               }
             },
+            {
+              // we can also have multiple sub-items
+              option: null, title: "Sub-Options (demo)", optionItems: [
+                { option: true, title: "True", iconCssClass: 'sgi sgi-checkbox-marked-outline green' },
+                { option: false, title: "False", iconCssClass: 'sgi sgi-checkbox-blank-outline pink' },
+              ]
+            }
           ]
         }
       }
@@ -450,7 +475,7 @@
     document.addEventListener("DOMContentLoaded", function() {
       dataView = new Slick.Data.DataView();
       grid = new Slick.Grid("#myGrid", dataView, columns, gridOptions);
-      cellMenuPlugin = new Slick.Plugins.CellMenu({ hideMenuOnScroll: true });
+      cellMenuPlugin = new Slick.Plugins.CellMenu({ hideMenuOnScroll: true, subItemChevronClass: 'sgi sgi-chevron-right' });
       contextMenuPlugin = new Slick.Plugins.ContextMenu(contextMenuOptions);
       var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, gridOptions);
 
@@ -542,6 +567,7 @@
 
       // subscribe to Cell Menu onOptionSelected event (or use the action callback on each option)
       cellMenuPlugin.onOptionSelected.subscribe(function (e, args) {
+        console.log('onOptionSelected', args)
         // e.preventDefault(); // you could do if you wish to keep the menu open
         var dataContext = args && args.dataContext;
 

--- a/examples/example-plugin-contextmenu.html
+++ b/examples/example-plugin-contextmenu.html
@@ -310,6 +310,9 @@
             dataView.deleteItem(dataContext.id);
           }
           break;
+        default:
+          alert("Command: " + args.command);
+          break;
       }
     }
 
@@ -364,7 +367,7 @@
             { command: "something", title: "Disabled Command", disabled: true },
             "divider",
             {
-              // we can also have multiple sub-items
+              // we can also have multiple nested sub-menus
               command: 'export', title: 'Export',
               commandItems: [
                 { command: "export-txt", title: "Text" },
@@ -373,6 +376,21 @@
                   commandItems: [
                     { command: "export-csv", title: "Excel (csv)" },
                     { command: "export-xls", title: "Excel (xls)" },
+                  ]
+                }
+              ]
+            },
+            {
+              command: 'feedback', title: 'Feedback',
+              commandItems: [
+                { command: "request-update", title: "Request update from shipping team", iconCssClass: "sgi sgi-star", tooltip: "this will automatically send an alert to the shipping team to contact the user for an update" },
+                "divider",
+                {
+                  command: 'sub-menu', title: 'Contact Us', iconCssClass: "sgi sgi-user", subMenuTitle: "contact us...", subMenuTitleCssClass: "italic",
+                  commandItems: [
+                    { command: "contact-email", title: "Email us", iconCssClass: "sgi sgi-pencil-outline" },
+                    { command: "contact-chat", title: "Chat with us", iconCssClass: "sgi sgi-message-outline" },
+                    { command: "contact-meeting", title: "Book an appointment", iconCssClass: "sgi sgi-coffee-outline" },
                   ]
                 }
               ]
@@ -398,7 +416,7 @@
               }
             },
             {
-              // we can also have multiple sub-items
+              // we can also have multiple nested sub-menus
               option: null, title: "Sub-Options (demo)", subMenuTitle: "Set Effort Driven", optionItems: [
                 { option: true, title: "True", iconCssClass: 'sgi sgi-checkbox-marked-outline green' },
                 { option: false, title: "False", iconCssClass: 'sgi sgi-checkbox-blank-outline pink' },
@@ -447,7 +465,7 @@
         { command: "something", title: "Command (always disabled)", disabled: true },
         "divider",
         {
-          // we can also have multiple sub-items
+          // we can also have multiple nested sub-menus
           command: 'export', title: 'Export',
           commandItems: [
             { command: "export-txt", title: "Text" },
@@ -456,6 +474,21 @@
               commandItems: [
                 { command: "export-csv", title: "Excel (csv)" },
                 { command: "export-xls", title: "Excel (xls)" },
+              ]
+            }
+          ]
+        },
+        {
+          command: 'feedback', title: 'Feedback',
+          commandItems: [
+            { command: "column-love", title: "Request update from shipping team", iconCssClass: "sgi sgi-tag-outline", tooltip: "this will automatically send an alert to the shipping team to contact the user for an update" },
+            "divider",
+            {
+              command: 'sub-menu', title: 'Contact Us', iconCssClass: "sgi sgi-user", subMenuTitle: "contact us...", subMenuTitleCssClass: "italic",
+              commandItems: [
+                { command: "contact-email", title: "Email us", iconCssClass: "sgi sgi-pencil-outline" },
+                { command: "contact-chat", title: "Chat with us", iconCssClass: "sgi sgi-message-outline" },
+                { command: "contact-meeting", title: "Book an appointment", iconCssClass: "sgi sgi-coffee-outline" },
               ]
             }
           ]
@@ -494,7 +527,7 @@
         },
         "divider",
         {
-          // we can also have multiple sub-items
+          // we can also have multiple nested sub-menus
           option: null, title: "Sub-Options (demo)", subMenuTitle: "Set Priority", optionItems: [
             { option: 1, iconCssClass: "sgi sgi-star-outline", title: "Low" },
             { option: 2, iconCssClass: "sgi sgi-star orange", title: "Medium" },

--- a/examples/example-plugin-contextmenu.html
+++ b/examples/example-plugin-contextmenu.html
@@ -363,7 +363,7 @@
               commandItems: [
                 { command: "export-pdf", title: "PDF" },
                 {
-                  command: 'sub-menu', title: 'Excel', cssClass: "green",
+                  command: 'sub-menu', title: 'Excel', cssClass: "green", subMenuTitle: "available formats",
                   commandItems: [
                     { command: "export-csv", title: "Excel (csv)" },
                     { command: "export-xls", title: "Excel (xls)" },
@@ -393,7 +393,7 @@
             },
             {
               // we can also have multiple sub-items
-              option: null, title: "Sub-Options (demo)", optionItems: [
+              option: null, title: "Sub-Options (demo)", subMenuTitle: "Set Effort Driven", optionItems: [
                 { option: true, title: "True", iconCssClass: 'sgi sgi-checkbox-marked-outline green' },
                 { option: false, title: "False", iconCssClass: 'sgi sgi-checkbox-blank-outline pink' },
               ]
@@ -567,7 +567,6 @@
 
       // subscribe to Cell Menu onOptionSelected event (or use the action callback on each option)
       cellMenuPlugin.onOptionSelected.subscribe(function (e, args) {
-        console.log('onOptionSelected', args)
         // e.preventDefault(); // you could do if you wish to keep the menu open
         var dataContext = args && args.dataContext;
 

--- a/examples/example-plugin-contextmenu.html
+++ b/examples/example-plugin-contextmenu.html
@@ -418,6 +418,8 @@
     };
 
     var contextMenuOptions = {
+      // subItemChevronClass: 'sgi sgi-chevron-right',
+
       // optionally and conditionally define when the the menu is usable,
       // this should be used with a custom formatter to show/hide/disable the menu
       menuUsabilityOverride: function (args) {
@@ -442,6 +444,21 @@
           }
         },
         { command: "something", title: "Command (always disabled)", disabled: true },
+        "divider",
+        {
+          // we can also have multiple sub-items
+          command: 'export', title: 'Export',
+          commandItems: [
+            { command: "export-pdf", title: "PDF" },
+            {
+              command: 'sub-menu', title: 'Excel', cssClass: "green", subMenuTitle: "available formats", subMenuTitleCssClass: "italic orange",
+              commandItems: [
+                { command: "export-csv", title: "Excel (csv)" },
+                { command: "export-xls", title: "Excel (xls)" },
+              ]
+            }
+          ]
+        }
       ],
 
       // Options allows you to edit a column from an option chose a list
@@ -474,6 +491,15 @@
             return (!args.dataContext.effortDriven);
           }
         },
+        "divider",
+        {
+          // we can also have multiple sub-items
+          option: null, title: "Sub-Options (demo)", subMenuTitle: "Set Priority", optionItems: [
+            { option: 1, iconCssClass: "sgi sgi-star-outline", title: "Low" },
+            { option: 2, iconCssClass: "sgi sgi-star orange", title: "Medium" },
+            { option: 3, iconCssClass: "sgi sgi-star red", title: "High" },
+          ]
+        }
       ]
     };
 

--- a/examples/example-plugin-contextmenu.html
+++ b/examples/example-plugin-contextmenu.html
@@ -294,7 +294,7 @@
           alert(args.item.title);
           break;
         case "export-csv":
-        case "export-pdf":
+        case "export-txt":
         case "export-xls":
           alert("Exporting as " + args.item.title);
           break;
@@ -366,7 +366,7 @@
               // we can also have multiple sub-items
               command: 'export', title: 'Export',
               commandItems: [
-                { command: "export-pdf", title: "PDF" },
+                { command: "export-txt", title: "Text" },
                 {
                   command: 'sub-menu', title: 'Excel', cssClass: "green", subMenuTitle: "available formats", subMenuTitleCssClass: "italic orange",
                   commandItems: [
@@ -449,7 +449,7 @@
           // we can also have multiple sub-items
           command: 'export', title: 'Export',
           commandItems: [
-            { command: "export-pdf", title: "PDF" },
+            { command: "export-txt", title: "Text" },
             {
               command: 'sub-menu', title: 'Excel', cssClass: "green", subMenuTitle: "available formats", subMenuTitleCssClass: "italic orange",
               commandItems: [

--- a/examples/example-plugin-contextmenu.html
+++ b/examples/example-plugin-contextmenu.html
@@ -78,6 +78,11 @@
       border: 1px solid #718BB7;
       box-shadow: 2px 2px 2px silver;
     }
+    .slick-submenu {
+      background-color: #fbfbfb;
+      /* border-width: 2px; */
+      box-shadow: 0 2px 4px 2px rgba(146, 152, 163, 0.4);
+    }
   </style>
 </head>
 

--- a/examples/example-plugin-contextmenu.html
+++ b/examples/example-plugin-contextmenu.html
@@ -76,12 +76,13 @@
 
     .slick-context-menu {
       border: 1px solid #718BB7;
-      box-shadow: 2px 2px 2px silver;
     }
-    .slick-submenu {
+    .slick-cell-menu.slick-submenu,
+    .slick-context-menu.slick-submenu {
       background-color: #fbfbfb;
       /* border-width: 2px; */
       box-shadow: 0 2px 4px 2px rgba(146, 152, 163, 0.4);
+      min-width: 150px;
     }
   </style>
 </head>

--- a/examples/example-plugin-contextmenu.html
+++ b/examples/example-plugin-contextmenu.html
@@ -368,7 +368,7 @@
               commandItems: [
                 { command: "export-pdf", title: "PDF" },
                 {
-                  command: 'sub-menu', title: 'Excel', cssClass: "green", subMenuTitle: "available formats",
+                  command: 'sub-menu', title: 'Excel', cssClass: "green", subMenuTitle: "available formats", subMenuTitleCssClass: "italic orange",
                   commandItems: [
                     { command: "export-csv", title: "Excel (csv)" },
                     { command: "export-xls", title: "Excel (xls)" },

--- a/src/models/cellMenuOption.interface.ts
+++ b/src/models/cellMenuOption.interface.ts
@@ -59,6 +59,9 @@ export interface CellMenuOption {
   /** Optional Title of the Option section, it will be hidden when nothing is provided */
   optionTitle?: string;
 
+  /** CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon) */
+  subItemChevronClass?: string;
+
   // --
   // action/override callbacks
 

--- a/src/models/contextMenuOption.interface.ts
+++ b/src/models/contextMenuOption.interface.ts
@@ -65,6 +65,9 @@ export interface ContextMenuOption {
   /** Optional Title of the Option section, it will be hidden when nothing is provided */
   optionTitle?: string;
 
+  /** CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon) */
+  subItemChevronClass?: string;
+
   // --
   // action/override callbacks
 

--- a/src/models/menuCommandItem.interface.ts
+++ b/src/models/menuCommandItem.interface.ts
@@ -7,6 +7,9 @@ export interface MenuCommandItem<A = MenuCommandItemCallbackArgs, R = MenuCallba
   /** A command identifier to be passed to the onCommand event callback handler (when using "commandItems"). */
   command: string;
 
+  /** Array of Command Items (title, command, disabled, ...) */
+  commandItems?: Array<MenuCommandItem | 'divider'>;
+
   // --
   // action/override callbacks
 

--- a/src/models/menuItem.interface.ts
+++ b/src/models/menuItem.interface.ts
@@ -22,6 +22,9 @@ export interface MenuItem<O = MenuCallbackArgs> {
   /** position order in the list, a lower number will make it on top of the list. Internal commands starts at 50. */
   positionOrder?: number;
 
+  /** Optional sub-menu title that will shows up when sub-menu commmands/options list is opened */
+  subMenuTitle?: string;
+
   /** CSS class to be added to the menu item text. */
   textCssClass?: string;
 

--- a/src/models/menuItem.interface.ts
+++ b/src/models/menuItem.interface.ts
@@ -1,5 +1,7 @@
 import type { MenuCallbackArgs } from './menuCallbackArgs.interface';
 
+export type MenuType = 'command' | 'option';
+
 export interface MenuItem<O = MenuCallbackArgs> {
   /** A CSS class to be added to the menu item container. */
   cssClass?: string;

--- a/src/models/menuItem.interface.ts
+++ b/src/models/menuItem.interface.ts
@@ -25,6 +25,9 @@ export interface MenuItem<O = MenuCallbackArgs> {
   /** Optional sub-menu title that will shows up when sub-menu commmands/options list is opened */
   subMenuTitle?: string;
 
+  /** Optional sub-menu title CSS class to use with `subMenuTitle` */
+  subMenuTitleCssClass?: string;
+
   /** CSS class to be added to the menu item text. */
   textCssClass?: string;
 

--- a/src/models/menuOptionItem.interface.ts
+++ b/src/models/menuOptionItem.interface.ts
@@ -5,6 +5,9 @@ export interface MenuOptionItem extends MenuItem {
   /** An option returned by the onOptionSelected (or action) event callback handler. */
   option: any;
 
+  /** Array of Option Items (title, command, disabled, ...) */
+  optionItems?: Array<MenuOptionItem | 'divider'>;
+
   // --
   // action/override callbacks
 

--- a/src/plugins/slick.cellmenu.ts
+++ b/src/plugins/slick.cellmenu.ts
@@ -378,7 +378,12 @@ export class SlickCellMenu implements SlickPlugin {
     if (item !== 'divider' && item?.subMenuTitle) {
       const subMenuTitleElm = document.createElement('div');
       subMenuTitleElm.className = 'slick-menu-title';
-      subMenuTitleElm.textContent = (item as MenuCommandItem | MenuOptionItem).subMenuTitle as string;
+      subMenuTitleElm.textContent = item.subMenuTitle as string;
+      const subMenuTitleClass = item.subMenuTitleCssClass as string;
+      if (subMenuTitleClass) {
+        subMenuTitleElm.classList.add(...subMenuTitleClass.split(' '));
+      }
+
       commandOrOptionMenu.appendChild(subMenuTitleElm);
     }
   }

--- a/src/plugins/slick.cellmenu.ts
+++ b/src/plugins/slick.cellmenu.ts
@@ -377,7 +377,7 @@ export class SlickCellMenu implements SlickPlugin {
   protected addSubMenuTitleWhenExists(item: MenuCommandItem  | MenuOptionItem | 'divider', commandOrOptionMenu: HTMLDivElement) {
     if (item !== 'divider' && item?.subMenuTitle) {
       const subMenuTitleElm = document.createElement('div');
-      subMenuTitleElm.className = 'title';
+      subMenuTitleElm.className = 'slick-menu-title';
       subMenuTitleElm.textContent = (item as MenuCommandItem | MenuOptionItem).subMenuTitle as string;
       commandOrOptionMenu.appendChild(subMenuTitleElm);
     }
@@ -571,7 +571,7 @@ export class SlickCellMenu implements SlickPlugin {
     const isSubMenu = args.level > 0;
     if (cellMenu?.[`${itemType}Title`] && !isSubMenu) {
       this[`_${itemType}TitleElm`] = document.createElement('div');
-      this[`_${itemType}TitleElm`]!.className = 'title';
+      this[`_${itemType}TitleElm`]!.className = 'slick-menu-title';
       this[`_${itemType}TitleElm`]!.textContent = cellMenu[`${itemType}Title`] as string;
       commandOrOptionMenuElm.appendChild(this[`_${itemType}TitleElm`]!);
     }

--- a/src/plugins/slick.cellmenu.ts
+++ b/src/plugins/slick.cellmenu.ts
@@ -421,8 +421,8 @@ export class SlickCellMenu implements SlickPlugin {
    * @param {*} event
    */
   repositionMenu(menuElm: HTMLElement, e: DOMMouseOrTouchEvent<HTMLDivElement>) {
-    const isFromSubMenu = menuElm.classList.contains('slick-submenu');
-    const parentElm = isFromSubMenu
+    const isSubMenu = menuElm.classList.contains('slick-submenu');
+    const parentElm = isSubMenu
       ? e.target.closest('.slick-cell-menu-item') as HTMLDivElement
       : e.target.closest('.slick-cell') as HTMLDivElement;
 
@@ -434,8 +434,8 @@ export class SlickCellMenu implements SlickPlugin {
       const menuHeight = menuElm?.offsetHeight ?? 0;
       const menuWidth = menuElm?.offsetWidth ?? this._cellMenuProperties.width ?? 0;
       const rowHeight = this._gridOptions.rowHeight;
-      const dropOffset = +(this._cellMenuProperties.autoAdjustDropOffset || 0);
-      const sideOffset = +(this._cellMenuProperties.autoAlignSideOffset || 0);
+      const dropOffset = Number(this._cellMenuProperties.autoAdjustDropOffset || 0);
+      const sideOffset = Number(this._cellMenuProperties.autoAlignSideOffset || 0);
 
       // if autoAdjustDrop is enable, we first need to see what position the drop will be located (defaults to bottom)
       // without necessary toggling it's position just yet, we just want to know the future position for calculation
@@ -449,15 +449,15 @@ export class SlickCellMenu implements SlickPlugin {
         if (dropPosition === 'top') {
           menuElm.classList.remove('dropdown');
           menuElm.classList.add('dropup');
-          if (isFromSubMenu) {
-            menuOffsetTop -= (menuHeight - dropOffset + parentElm.clientHeight);
+          if (isSubMenu) {
+            menuOffsetTop -= (menuHeight - dropOffset - parentElm.clientHeight);
           } else {
             menuOffsetTop -= menuHeight - dropOffset;
           }
         } else {
           menuElm.classList.remove('dropup');
           menuElm.classList.add('dropdown');
-          if (isFromSubMenu) {
+          if (isSubMenu) {
             menuOffsetTop += dropOffset;
           } else {
             menuOffsetTop += rowHeight! + dropOffset;
@@ -470,19 +470,21 @@ export class SlickCellMenu implements SlickPlugin {
       // to simulate an align left, we actually need to know the width of the drop menu
       if (this._cellMenuProperties.autoAlignSide) {
         const gridPos = this._grid.getGridPosition();
-        const dropSide = ((menuOffsetLeft + (+menuWidth)) >= gridPos.width) ? 'left' : 'right';
+        const subMenuPosCalc = menuOffsetLeft + parentElm.clientWidth + Number(menuWidth); // calculate coordinate at caller element far right
+        const browserWidth = document.documentElement.clientWidth;
+        const dropSide = (subMenuPosCalc >= gridPos.width || subMenuPosCalc >= browserWidth) ? 'left' : 'right';
         if (dropSide === 'left') {
           menuElm.classList.remove('dropright');
           menuElm.classList.add('dropleft');
-          if (isFromSubMenu) {
+          if (isSubMenu) {
             menuOffsetLeft -= menuWidth - sideOffset;
           } else {
-            menuOffsetLeft -= (+menuWidth - parentCellWidth) - sideOffset;
+            menuOffsetLeft -= Number(menuWidth) - parentCellWidth - sideOffset;
           }
         } else {
           menuElm.classList.remove('dropleft');
           menuElm.classList.add('dropright');
-          if (isFromSubMenu) {
+          if (isSubMenu) {
             menuOffsetLeft += sideOffset + parentElm.offsetWidth;
           } else {
             menuOffsetLeft += sideOffset;

--- a/src/plugins/slick.cellmenu.ts
+++ b/src/plugins/slick.cellmenu.ts
@@ -489,7 +489,10 @@ export class SlickCellMenu implements SlickPlugin {
       // to simulate an align left, we actually need to know the width of the drop menu
       if (this._cellMenuProperties.autoAlignSide) {
         const gridPos = this._grid.getGridPosition();
-        const subMenuPosCalc = menuOffsetLeft + parentElm.clientWidth + menuWidth; // calculate coordinate at caller element far right
+        let subMenuPosCalc = menuOffsetLeft + Number(menuWidth); // calculate coordinate at caller element far right
+        if (isSubMenu) {
+          subMenuPosCalc += parentElm.clientWidth;
+        }
         const browserWidth = document.documentElement.clientWidth;
         const dropSide = (subMenuPosCalc >= gridPos.width || subMenuPosCalc >= browserWidth) ? 'left' : 'right';
         if (dropSide === 'left') {

--- a/src/plugins/slick.cellmenu.ts
+++ b/src/plugins/slick.cellmenu.ts
@@ -216,7 +216,7 @@ export class SlickCellMenu implements SlickPlugin {
     this._menuElm = null as any;
   }
 
-  protected createMenu(e: DOMMouseOrTouchEvent<HTMLDivElement>) {
+  protected createParentMenu(e: DOMMouseOrTouchEvent<HTMLDivElement>) {
     const cell = this._grid.getCellFromEvent(e);
     this._currentCell = cell?.cell ?? 0;
     this._currentRow = cell?.row ?? 0;
@@ -244,7 +244,7 @@ export class SlickCellMenu implements SlickPlugin {
     }
 
     // create 1st parent menu container & reposition it
-    this._menuElm = this.createCellMenu(commandItems, optionItems);
+    this._menuElm = this.createMenu(commandItems, optionItems);
     this._menuElm.style.top = `${e.pageY + 5}px`;
     this._menuElm.style.left = `${e.pageX}px`;
 
@@ -270,7 +270,7 @@ export class SlickCellMenu implements SlickPlugin {
    * @param item - command, option or divider
    * @returns menu DOM element
    */
-  protected createCellMenu(commandItems: Array<MenuCommandItem | 'divider'>, optionItems: Array<MenuOptionItem | 'divider'>, level = 0, item?: MenuCommandItem  | MenuOptionItem | 'divider') {
+  protected createMenu(commandItems: Array<MenuCommandItem | 'divider'>, optionItems: Array<MenuOptionItem | 'divider'>, level = 0, item?: MenuCommandItem  | MenuOptionItem | 'divider') {
     const columnDef = this._grid.getColumns()[this._currentCell];
     const dataContext = this._grid.getDataItem(this._currentRow);
 
@@ -524,7 +524,7 @@ export class SlickCellMenu implements SlickPlugin {
       }
 
       // create the DOM element
-      this._menuElm = this.createMenu(e);
+      this._menuElm = this.createParentMenu(e);
 
       // reposition the menu to where the user clicked
       if (this._menuElm) {
@@ -675,7 +675,7 @@ export class SlickCellMenu implements SlickPlugin {
     }
 
     // creating sub-menu, we'll also pass level & the item object since we might have "subMenuTitle" to show
-    const subMenuElm = this.createCellMenu((item as MenuCommandItem)?.commandItems || [], (item as MenuOptionItem)?.optionItems || [], level + 1, item);
+    const subMenuElm = this.createMenu((item as MenuCommandItem)?.commandItems || [], (item as MenuOptionItem)?.optionItems || [], level + 1, item);
     this._subMenuElms.push(subMenuElm);
     subMenuElm.style.display = 'block';
     document.body.appendChild(subMenuElm);

--- a/src/plugins/slick.contextmenu.ts
+++ b/src/plugins/slick.contextmenu.ts
@@ -735,7 +735,10 @@ export class SlickContextMenu implements SlickPlugin {
       // to simulate an align left, we actually need to know the width of the drop menu
       if (this._contextMenuProperties.autoAlignSide) {
         const gridPos = this._grid.getGridPosition();
-        const subMenuPosCalc = menuOffsetLeft + parentElm.clientWidth + menuWidth; // calculate coordinate at caller element far right
+        let subMenuPosCalc = menuOffsetLeft + Number(menuWidth); // calculate coordinate at caller element far right
+        if (isSubMenu) {
+          subMenuPosCalc += parentElm.clientWidth;
+        }
         const browserWidth = document.documentElement.clientWidth;
         const dropSide = (subMenuPosCalc >= gridPos.width || subMenuPosCalc >= browserWidth) ? 'left' : 'right';
         if (dropSide === 'left') {

--- a/src/plugins/slick.contextmenu.ts
+++ b/src/plugins/slick.contextmenu.ts
@@ -6,6 +6,7 @@ import {
   Utils as Utils_
 } from '../slick.core';
 import type {
+  Column,
   ContextMenuOption,
   DOMMouseOrTouchEvent,
   GridOption,
@@ -14,6 +15,7 @@ import type {
   MenuFromCellCallbackArgs,
   MenuOptionItem,
   MenuOptionItemCallbackArgs,
+  MenuType,
   SlickPlugin
 } from '../models/index';
 import type { SlickGrid } from '../slick.grid';
@@ -88,6 +90,7 @@ const Utils = IIFE_ONLY ? Slick.Utils : Utils_;
  *    autoAlignSide:              Auto-align drop menu to the left or right depending on grid viewport available space (defaults to true)
  *    autoAlignSideOffset:        Optionally add an offset to the left/right side auto-align (defaults to 0)
  *    menuUsabilityOverride:      Callback method that user can override the default behavior of enabling/disabling the menu from being usable (must be combined with a custom formatter)
+ *    subItemChevronClass:        CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon)
  *
  *
  * Available menu Command/Option item properties:
@@ -98,6 +101,8 @@ const Utils = IIFE_ONLY ? Slick.Utils : Utils_;
  *    divider:                    Boolean which tell if the current item is a divider, not an actual command. You could also pass "divider" instead of an object
  *    disabled:                   Whether the item/command is disabled.
  *    hidden:                     Whether the item/command is hidden.
+ *    subMenuTitle:               Optional sub-menu title that will shows up when sub-menu commmands/options list is opened
+ *    subMenuTitleCssClass:       Optional sub-menu title CSS class to use with `subMenuTitle`
  *    tooltip:                    Item tooltip.
  *    cssClass:                   A CSS class to be added to the menu item container.
  *    iconCssClass:               A CSS class to be added to the menu item icon.
@@ -173,7 +178,9 @@ export class SlickContextMenu implements SlickPlugin {
   protected _handler = new EventHandler();
   protected _commandTitleElm?: HTMLSpanElement;
   protected _optionTitleElm?: HTMLSpanElement;
+  protected _lastMenuTypeClicked = '';
   protected _menuElm?: HTMLDivElement | null;
+  protected _subMenuElms: HTMLDivElement[] = [];
   protected _bindingEventService = new BindingEventService();
   protected _defaults: ContextMenuOption = {
     autoAdjustDrop: true,     // dropup/dropdown
@@ -227,14 +234,13 @@ export class SlickContextMenu implements SlickPlugin {
     this._menuElm = null as any;
   }
 
-  protected createMenu(evt: SlickEventData_ | MouseEvent) {
+  protected createParentMenu(evt: SlickEventData_ | MouseEvent) {
     const e = evt instanceof SlickEventData ? evt.getNativeEvent<MouseEvent | TouchEvent>() : evt;
     const targetEvent = (e as TouchEvent).touches?.[0] ?? e;
     const cell = this._grid.getCellFromEvent(e);
     this._currentCell = cell?.cell ?? 0;
     this._currentRow = cell?.row ?? 0;
     const columnDef = this._grid.getColumns()[this._currentCell];
-    const dataContext = this._grid.getDataItem(this._currentRow);
 
     const isColumnOptionAllowed = this.checkIsColumnAllowed(this._contextMenuProperties.optionShownOverColumnIds ?? [], columnDef.id);
     const isColumnCommandAllowed = this.checkIsColumnAllowed(this._contextMenuProperties.commandShownOverColumnIds ?? [], columnDef.id);
@@ -259,75 +265,10 @@ export class SlickContextMenu implements SlickPlugin {
       return;
     }
 
-    // create a new context menu
-    const maxHeight = isNaN(this._contextMenuProperties.maxHeight as number) ? this._contextMenuProperties.maxHeight : `${this._contextMenuProperties.maxHeight ?? 0}px`;
-    const width = isNaN(this._contextMenuProperties.width as number) ? this._contextMenuProperties.width : `${this._contextMenuProperties.maxWidth ?? 0}px`;
-
-    this._menuElm = document.createElement('div');
-    this._menuElm.className = `slick-context-menu ${this._gridUid}`;
-    this._menuElm.role = 'menu';
-    if (width) {
-      this._menuElm.style.width = width as string;
-    }
-    if (maxHeight) {
-      this._menuElm.style.maxHeight = maxHeight as string;
-    }
+    // create 1st parent menu container & reposition it
+    this._menuElm = this.createMenu(commandItems, optionItems);
     this._menuElm.style.top = `${targetEvent.pageY}px`;
     this._menuElm.style.left = `${targetEvent.pageX}px`;
-    this._menuElm.style.display = 'none';
-
-    const closeButtonElm = document.createElement('button');
-    closeButtonElm.type = 'button';
-    closeButtonElm.className = 'close';
-    closeButtonElm.dataset.dismiss = 'slick-context-menu';
-    closeButtonElm.ariaLabel = 'Close';
-
-    const spanCloseElm = document.createElement('span');
-    spanCloseElm.className = 'close';
-    spanCloseElm.ariaHidden = 'true';
-    spanCloseElm.innerHTML = '&times;';
-    closeButtonElm.appendChild(spanCloseElm);
-
-    // -- Option List section
-    if (!this._contextMenuProperties.hideOptionSection && isColumnOptionAllowed && optionItems.length > 0) {
-      const optionMenuElm = document.createElement('div');
-      optionMenuElm.className = 'slick-context-menu-option-list';
-      optionMenuElm.role = 'menu';
-
-      if (!this._contextMenuProperties.hideCloseButton) {
-        this._bindingEventService.bind(closeButtonElm, 'click', this.handleCloseButtonClicked.bind(this) as EventListener);
-        this._menuElm.appendChild(closeButtonElm);
-      }
-      this._menuElm.appendChild(optionMenuElm);
-
-      this.populateOptionItems(
-        this._contextMenuProperties,
-        optionMenuElm,
-        optionItems,
-        { cell: this._currentCell, row: this._currentRow, column: columnDef, dataContext, grid: this._grid }
-      );
-    }
-
-    // -- Command List section
-    if (!this._contextMenuProperties.hideCommandSection && isColumnCommandAllowed && commandItems.length > 0) {
-      const commandMenuElm = document.createElement('div');
-      commandMenuElm.className = 'slick-context-menu-command-list';
-      commandMenuElm.role = 'menu';
-
-      if (!this._contextMenuProperties.hideCloseButton && (!isColumnOptionAllowed || optionItems.length === 0 || this._contextMenuProperties.hideOptionSection)) {
-        this._bindingEventService.bind(closeButtonElm, 'click', this.handleCloseButtonClicked.bind(this) as EventListener);
-        this._menuElm.appendChild(closeButtonElm);
-      }
-
-      this._menuElm.appendChild(commandMenuElm);
-      this.populateCommandItems(
-        this._contextMenuProperties,
-        commandMenuElm,
-        commandItems,
-        { cell: this._currentCell, row: this._currentRow, column: columnDef, dataContext, grid: this._grid }
-      );
-    }
-
     this._menuElm.style.display = 'block';
     document.body.appendChild(this._menuElm);
 
@@ -340,6 +281,126 @@ export class SlickContextMenu implements SlickPlugin {
     }
 
     return this._menuElm;
+  }
+
+  protected createMenu(commandItems: Array<MenuCommandItem | 'divider'>, optionItems: Array<MenuOptionItem | 'divider'>, level = 0, item?: MenuCommandItem  | MenuOptionItem | 'divider') {
+    const columnDef = this._grid.getColumns()[this._currentCell];
+    const dataContext = this._grid.getDataItem(this._currentRow);
+    const isColumnOptionAllowed = this.checkIsColumnAllowed(this._contextMenuProperties.optionShownOverColumnIds ?? [], columnDef.id);
+    const isColumnCommandAllowed = this.checkIsColumnAllowed(this._contextMenuProperties.commandShownOverColumnIds ?? [], columnDef.id);
+
+    // create a new context menu
+    const maxHeight = isNaN(this._contextMenuProperties.maxHeight as number) ? this._contextMenuProperties.maxHeight : `${this._contextMenuProperties.maxHeight ?? 0}px`;
+    const width = isNaN(this._contextMenuProperties.width as number) ? this._contextMenuProperties.width : `${this._contextMenuProperties.maxWidth ?? 0}px`;
+
+    const menuClasses = `slick-context-menu ${this._gridUid} slick-menu-level-${level}`;
+    const bodyMenuElm = document.body.querySelector<HTMLDivElement>(`.slick-context-menu.${this._gridUid}.slick-menu-level-${level}`);
+
+    // if menu/sub-menu already exist, then no need to recreate, just return it
+    if (bodyMenuElm) {
+      return bodyMenuElm;
+    }
+
+    const menuElm = document.createElement('div');
+    menuElm.className = menuClasses;
+    if (level > 0) {
+      menuElm.classList.add('slick-submenu');
+    }
+    menuElm.role = 'menu';
+    if (width) {
+      menuElm.style.width = width as string;
+    }
+    if (maxHeight) {
+      menuElm.style.maxHeight = maxHeight as string;
+    }
+
+    menuElm.style.display = 'none';
+
+    let closeButtonElm: HTMLButtonElement | null = null;
+    if (level === 0) {
+      closeButtonElm = document.createElement('button');
+      closeButtonElm.type = 'button';
+      closeButtonElm.className = 'close';
+      closeButtonElm.dataset.dismiss = 'slick-context-menu';
+      closeButtonElm.ariaLabel = 'Close';
+
+      const spanCloseElm = document.createElement('span');
+      spanCloseElm.className = 'close';
+      spanCloseElm.ariaHidden = 'true';
+      spanCloseElm.innerHTML = '&times;';
+      closeButtonElm.appendChild(spanCloseElm);
+    }
+
+    // -- Option List section
+    if (!this._contextMenuProperties.hideOptionSection && isColumnOptionAllowed && optionItems.length > 0) {
+      const optionMenuElm = document.createElement('div');
+      optionMenuElm.className = 'slick-context-menu-option-list';
+      optionMenuElm.role = 'menu';
+
+      // when creating sub-menu add its sub-menu title when exists
+      if (item && level > 0) {
+        this.addSubMenuTitleWhenExists(item, optionMenuElm); // add sub-menu title when exists
+      }
+
+      if (closeButtonElm && !this._contextMenuProperties.hideCloseButton) {
+        this._bindingEventService.bind(closeButtonElm, 'click', this.handleCloseButtonClicked.bind(this) as EventListener);
+        menuElm.appendChild(closeButtonElm);
+      }
+      menuElm.appendChild(optionMenuElm);
+
+      this.populateCommandOrOptionItems(
+        'option',
+        this._contextMenuProperties,
+        optionMenuElm,
+        optionItems,
+        { cell: this._currentCell, row: this._currentRow, column: columnDef, dataContext, grid: this._grid, level }
+      );
+    }
+
+    // -- Command List section
+    if (!this._contextMenuProperties.hideCommandSection && isColumnCommandAllowed && commandItems.length > 0) {
+      const commandMenuElm = document.createElement('div');
+      commandMenuElm.className = 'slick-context-menu-command-list';
+      commandMenuElm.role = 'menu';
+
+      // when creating sub-menu add its sub-menu title when exists
+      if (item && level > 0) {
+        this.addSubMenuTitleWhenExists(item, commandMenuElm); // add sub-menu title when exists
+      }
+
+      if (closeButtonElm && !this._contextMenuProperties.hideCloseButton && (!isColumnOptionAllowed || optionItems.length === 0 || this._contextMenuProperties.hideOptionSection)) {
+        this._bindingEventService.bind(closeButtonElm, 'click', this.handleCloseButtonClicked.bind(this) as EventListener);
+        menuElm.appendChild(closeButtonElm);
+      }
+
+      menuElm.appendChild(commandMenuElm);
+      this.populateCommandOrOptionItems(
+        'command',
+        this._contextMenuProperties,
+        commandMenuElm,
+        commandItems,
+        { cell: this._currentCell, row: this._currentRow, column: columnDef, dataContext, grid: this._grid, level }
+      );
+    }
+
+    // increment level for possible next sub-menus if exists
+    level++;
+
+    return menuElm;
+  }
+
+  protected addSubMenuTitleWhenExists(item: MenuCommandItem  | MenuOptionItem | 'divider', commandOrOptionMenu: HTMLDivElement) {
+    if (item !== 'divider' && item?.subMenuTitle) {
+      const subMenuTitleElm = document.createElement('div');
+      subMenuTitleElm.className = 'slick-menu-title';
+      subMenuTitleElm.textContent = item.subMenuTitle as string;
+      const subMenuTitleClass = item.subMenuTitleCssClass as string;
+      if (subMenuTitleClass) {
+        subMenuTitleElm.classList.add(...subMenuTitleClass.split(' '));
+      }
+
+      commandOrOptionMenu.appendChild(subMenuTitleElm);
+    }
   }
 
   protected handleCloseButtonClicked(e: MouseEvent | TouchEvent) {
@@ -361,6 +422,18 @@ export class SlickContextMenu implements SlickPlugin {
       }
       this._menuElm.remove();
       this._menuElm = null;
+    }
+    this.destroySubMenus();
+  }
+
+  /** Close and destroy all previously opened sub-menus */
+  destroySubMenus() {
+    if (this._subMenuElms.length) {
+      let subElm = this._subMenuElms.pop();
+      while (subElm) {
+        subElm.remove();
+        subElm = this._subMenuElms.pop();
+      }
     }
   }
 
@@ -402,135 +475,64 @@ export class SlickContextMenu implements SlickPlugin {
       }
 
       // create the DOM element
-      this._menuElm = this.createMenu(e as MouseEvent);
+      this._menuElm = this.createParentMenu(e as MouseEvent);
 
       // reposition the menu to where the user clicked
       if (this._menuElm) {
-        this.repositionMenu(e);
+        this.repositionMenu(e, this._menuElm);
         this._menuElm.style.display = 'block';
       }
 
-      this._bindingEventService.bind(document.body, 'click', (e) => {
-        if (!e.defaultPrevented) {
-          this.destroyMenu(e, { cell: this._currentCell, row: this._currentRow });
-        }
-      });
+      // Hide the menu on outside click.
+      this._bindingEventService.bind(document.body, 'mousedown', this.handleBodyMouseDown.bind(this) as EventListener);
     }
   }
 
-  /** Construct the Option Items section. */
-  protected populateOptionItems(contextMenu: ContextMenuOption, optionMenuElm: HTMLElement, optionItems: Array<MenuOptionItem | 'divider'>, args: any) {
-    if (!args || !optionItems || !contextMenu) {
-      return;
+  /** When users click outside the Cell Menu, we will typically close the Cell Menu (and any sub-menus) */
+  protected handleBodyMouseDown(e: DOMMouseOrTouchEvent<HTMLDivElement>) {
+    let isMenuClicked = false;
+    this._subMenuElms.forEach(subElm => {
+      if (subElm.contains(e.target)) {
+        isMenuClicked = true;
+      }
+    });
+    if (this._menuElm?.contains(e.target)) {
+      isMenuClicked = true;
     }
 
-    // user could pass a title on top of the Options section
-    if (contextMenu?.optionTitle) {
-      this._optionTitleElm = document.createElement('div');
-      this._optionTitleElm.className = 'title';
-      this._optionTitleElm.textContent = contextMenu.optionTitle;
-      optionMenuElm.appendChild(this._optionTitleElm);
-    }
-
-    for (let i = 0, ln = optionItems.length; i < ln; i++) {
-      let addClickListener = true;
-      const item = optionItems[i];
-
-      // run each override functions to know if the item is visible and usable
-      const isItemVisible = this.runOverrideFunctionWhenExists<typeof args>((item as MenuOptionItem).itemVisibilityOverride, args);
-      const isItemUsable = this.runOverrideFunctionWhenExists<typeof args>((item as MenuOptionItem).itemUsabilityOverride, args);
-
-      // if the result is not visible then there's no need to go further
-      if (!isItemVisible) {
-        continue;
-      }
-
-      // when the override is defined, we need to use its result to update the disabled property
-      // so that "handleMenuItemOptionClick" has the correct flag and won't trigger an option clicked event
-      if (Object.prototype.hasOwnProperty.call(item, 'itemUsabilityOverride')) {
-        (item as MenuOptionItem).disabled = isItemUsable ? false : true;
-      }
-
-      const liElm = document.createElement('div');
-      liElm.className = 'slick-context-menu-item';
-      liElm.role = 'menuitem';
-
-      if ((item as MenuOptionItem).divider || item === 'divider') {
-        liElm.classList.add('slick-context-menu-item-divider');
-        addClickListener = false;
-      }
-
-      // if the item is disabled then add the disabled css class
-      if ((item as MenuOptionItem).disabled || !isItemUsable) {
-        liElm.classList.add('slick-context-menu-item-disabled');
-      }
-
-      // if the item is hidden then add the hidden css class
-      if ((item as MenuOptionItem).hidden) {
-        liElm.classList.add('slick-context-menu-item-hidden');
-      }
-
-      if ((item as MenuOptionItem).cssClass) {
-        liElm.classList.add(...(item as MenuOptionItem).cssClass!.split(' '));
-      }
-
-      if ((item as MenuOptionItem).tooltip) {
-        liElm.title = (item as MenuOptionItem).tooltip || '';
-      }
-
-      const iconElm = document.createElement('div');
-      iconElm.role = 'button';
-      iconElm.className = 'slick-context-menu-icon';
-
-      liElm.appendChild(iconElm);
-
-      if ((item as MenuOptionItem).iconCssClass) {
-        iconElm.classList.add(...(item as MenuOptionItem).iconCssClass!.split(' '));
-      }
-
-      if ((item as MenuOptionItem).iconImage) {
-        iconElm.style.backgroundImage = `url(${(item as MenuOptionItem).iconImage})`;
-      }
-
-      const textElm = document.createElement('span');
-      textElm.className = 'slick-context-menu-content';
-      textElm.textContent = (item as MenuOptionItem).title || '';
-
-      liElm.appendChild(textElm);
-
-      if ((item as MenuOptionItem).textCssClass) {
-        textElm.classList.add(...(item as MenuOptionItem).textCssClass!.split(' '));
-      }
-
-      optionMenuElm.appendChild(liElm);
-
-      if (addClickListener) {
-        this._bindingEventService.bind(liElm, 'click', this.handleMenuItemOptionClick.bind(this, item) as EventListener);
-      }
+    if (this._menuElm !== e.target && !isMenuClicked && !e.defaultPrevented) {
+      this.destroyMenu(e, { cell: this._currentCell, row: this._currentRow });
     }
   }
 
   /** Construct the Command Items section. */
-  protected populateCommandItems(contextMenu: ContextMenuOption, commandMenuElm: HTMLElement, commandItems: Array<MenuCommandItem | 'divider'>, args: any) {
-    if (!args || !commandItems || !contextMenu) {
+  protected populateCommandOrOptionItems(
+    itemType: MenuType,
+    contextMenu: ContextMenuOption,
+    commandOrOptionMenuElm: HTMLElement,
+    commandOrOptionItems: Array<MenuCommandItem | 'divider'> | Array<MenuOptionItem | 'divider'>,
+    args: { cell: number, row: number, column: Column, dataContext: any, grid: SlickGrid, level: number }
+  ) {
+    if (!args || !commandOrOptionItems || !contextMenu) {
       return;
     }
 
-    // user could pass a title on top of the Commands section
-    if (contextMenu?.commandTitle) {
-      this._commandTitleElm = document.createElement('div');
-      this._commandTitleElm.className = 'title';
-      this._commandTitleElm.textContent = contextMenu.commandTitle;
-      commandMenuElm.appendChild(this._commandTitleElm);
+    // user could pass a title on top of the Commands/Options section
+    const isSubMenu = args.level > 0;
+    if (contextMenu?.[`${itemType}Title`] && !isSubMenu) {
+      this[`_${itemType}TitleElm`] = document.createElement('div');
+      this[`_${itemType}TitleElm`]!.className = 'slick-menu-title';
+      this[`_${itemType}TitleElm`]!.textContent = contextMenu[`${itemType}Title`] as string;
+      commandOrOptionMenuElm.appendChild(this[`_${itemType}TitleElm`]!);
     }
 
-    for (let i = 0, ln = commandItems.length; i < ln; i++) {
+    for (let i = 0, ln = commandOrOptionItems.length; i < ln; i++) {
       let addClickListener = true;
-      const item = commandItems[i];
+      const item = commandOrOptionItems[i];
 
       // run each override functions to know if the item is visible and usable
-      const isItemVisible = this.runOverrideFunctionWhenExists<typeof args>((item as MenuCommandItem).itemVisibilityOverride, args);
-      const isItemUsable = this.runOverrideFunctionWhenExists<typeof args>((item as MenuCommandItem).itemUsabilityOverride, args);
+      const isItemVisible = this.runOverrideFunctionWhenExists<typeof args>((item as MenuCommandItem | MenuOptionItem).itemVisibilityOverride, args);
+      const isItemUsable = this.runOverrideFunctionWhenExists<typeof args>((item as MenuCommandItem | MenuOptionItem).itemUsabilityOverride, args);
 
       // if the result is not visible then there's no need to go further
       if (!isItemVisible) {
@@ -538,36 +540,36 @@ export class SlickContextMenu implements SlickPlugin {
       }
 
       // when the override is defined, we need to use its result to update the disabled property
-      // so that "handleMenuItemCommandClick" has the correct flag and won't trigger a command clicked event
+      // so that "handleMenuItemClick" has the correct flag and won't trigger a command clicked event
       if (Object.prototype.hasOwnProperty.call(item, 'itemUsabilityOverride')) {
-        (item as MenuCommandItem).disabled = isItemUsable ? false : true;
+        (item as MenuCommandItem | MenuOptionItem).disabled = isItemUsable ? false : true;
       }
 
       const liElm = document.createElement('div');
       liElm.className = 'slick-context-menu-item';
       liElm.role = 'menuitem';
 
-      if ((item as MenuCommandItem).divider || item === 'divider') {
+      if ((item as MenuCommandItem | MenuOptionItem).divider || item === 'divider') {
         liElm.classList.add('slick-context-menu-item-divider');
         addClickListener = false;
       }
 
       // if the item is disabled then add the disabled css class
-      if ((item as MenuCommandItem).disabled || !isItemUsable) {
+      if ((item as MenuCommandItem | MenuOptionItem).disabled || !isItemUsable) {
         liElm.classList.add('slick-context-menu-item-disabled');
       }
 
       // if the item is hidden then add the hidden css class
-      if ((item as MenuCommandItem).hidden) {
+      if ((item as MenuCommandItem | MenuOptionItem).hidden) {
         liElm.classList.add('slick-context-menu-item-hidden');
       }
 
-      if ((item as MenuCommandItem).cssClass) {
-        liElm.classList.add(...(item as MenuCommandItem).cssClass!.split(' '));
+      if ((item as MenuCommandItem | MenuOptionItem).cssClass) {
+        liElm.classList.add(...(item as MenuCommandItem | MenuOptionItem).cssClass!.split(' '));
       }
 
-      if ((item as MenuCommandItem).tooltip) {
-        liElm.title = (item as MenuCommandItem).tooltip || '';
+      if ((item as MenuCommandItem | MenuOptionItem).tooltip) {
+        liElm.title = (item as MenuCommandItem | MenuOptionItem).tooltip || '';
       }
 
       const iconElm = document.createElement('div');
@@ -575,121 +577,130 @@ export class SlickContextMenu implements SlickPlugin {
 
       liElm.appendChild(iconElm);
 
-      if ((item as MenuCommandItem).iconCssClass) {
-        iconElm.classList.add(...(item as MenuCommandItem).iconCssClass!.split(' '));
+      if ((item as MenuCommandItem | MenuOptionItem).iconCssClass) {
+        iconElm.classList.add(...(item as MenuCommandItem | MenuOptionItem).iconCssClass!.split(' '));
       }
 
-      if ((item as MenuCommandItem).iconImage) {
-        iconElm.style.backgroundImage = `url(${(item as MenuCommandItem).iconImage})`;
+      if ((item as MenuCommandItem | MenuOptionItem).iconImage) {
+        iconElm.style.backgroundImage = `url(${(item as MenuCommandItem | MenuOptionItem).iconImage})`;
       }
 
       const textElm = document.createElement('span');
       textElm.className = 'slick-context-menu-content';
-      textElm.textContent = (item as MenuCommandItem).title || '';
+      textElm.textContent = (item as MenuCommandItem | MenuOptionItem).title || '';
 
       liElm.appendChild(textElm);
 
-      if ((item as MenuCommandItem).textCssClass) {
-        textElm.classList.add(...(item as MenuCommandItem).textCssClass!.split(' '));
+      if ((item as MenuCommandItem | MenuOptionItem).textCssClass) {
+        textElm.classList.add(...(item as MenuCommandItem | MenuOptionItem).textCssClass!.split(' '));
       }
 
-      commandMenuElm.appendChild(liElm);
+      commandOrOptionMenuElm.appendChild(liElm);
 
       if (addClickListener) {
-        this._bindingEventService.bind(liElm, 'click', this.handleMenuItemCommandClick.bind(this, item) as EventListener);
+        this._bindingEventService.bind(liElm, 'click', this.handleMenuItemClick.bind(this, item, itemType, args.level) as EventListener);
+      }
+
+      // the option/command item could be a sub-menu if it has another list of commands/options
+      if ((item as MenuCommandItem).commandItems || (item as MenuOptionItem).optionItems) {
+        const chevronElm = document.createElement('span');
+        chevronElm.className = 'sub-item-chevron';
+        if (this._contextMenuProperties.subItemChevronClass) {
+          chevronElm.classList.add(...this._contextMenuProperties.subItemChevronClass.split(' '));
+        } else {
+          chevronElm.textContent = '⮞'; // ⮞ or ▸
+        }
+
+        liElm.classList.add('slick-submenu-item');
+        liElm.appendChild(chevronElm);
+        continue;
       }
     }
   }
 
-  protected handleMenuItemCommandClick(item: MenuCommandItem | 'divider', e: DOMMouseOrTouchEvent<HTMLDivElement>) {
-    if (!item || (item as MenuCommandItem).disabled || (item as MenuCommandItem).divider) {
-      return;
-    }
-
-    const command = (item as MenuCommandItem).command || '';
-    const row = this._currentRow;
-    const cell = this._currentCell;
-    const columnDef = this._grid.getColumns()[cell];
-    const dataContext = this._grid.getDataItem(row);
-    let cellValue;
-
-    if (Object.prototype.hasOwnProperty.call(dataContext, columnDef?.field)) {
-      cellValue = dataContext[columnDef.field];
-    }
-
-    if (command !== null && command !== '') {
-      // user could execute a callback through 2 ways
-      // via the onCommand event and/or an action callback
-      const callbackArgs = {
-        cell,
-        row,
-        grid: this._grid,
-        command,
-        item: item as MenuCommandItem,
-        column: columnDef,
-        dataContext,
-        value: cellValue
-      };
-      this.onCommand.notify(callbackArgs, e, this);
-
-      // execute action callback when defined
-      if (typeof (item as MenuCommandItem).action === 'function') {
-        (item as any).action.call(this, e, callbackArgs);
+  protected handleMenuItemClick(item: MenuCommandItem | MenuOptionItem | 'divider', type: MenuType, level = 0, e: DOMMouseOrTouchEvent<HTMLDivElement>) {
+    if ((item as never)?.[type] !== undefined && item !== 'divider' && !item.disabled && !(item as MenuCommandItem | MenuOptionItem).divider && this._currentCell !== undefined && this._currentRow !== undefined) {
+      if (type === 'option' && !this._grid.getEditorLock().commitCurrentEdit()) {
+        return;
       }
+      const optionOrCommand = (item as any)[type] !== undefined ? (item as any)[type] : '';
+      const row = this._currentRow;
+      const cell = this._currentCell;
+      const columnDef = this._grid.getColumns()[cell];
+      const dataContext = this._grid.getDataItem(row);
+      let cellValue;
+
+      if (Object.prototype.hasOwnProperty.call(dataContext, columnDef?.field)) {
+        cellValue = dataContext[columnDef.field];
+      }
+
+      if (optionOrCommand !== undefined && !(item as any)[`${type}Items`]) {
+        // user could execute a callback through 2 ways
+        // via the onCommand event and/or an action callback
+        const callbackArgs = {
+          cell,
+          row,
+          grid: this._grid,
+          [type]: optionOrCommand,
+          item,
+          column: columnDef,
+          dataContext,
+          value: cellValue
+        };
+        const eventType = type === 'command' ? 'onCommand' : 'onOptionSelected';
+        this[eventType].notify(callbackArgs as any, e, this);
+
+        // execute action callback when defined
+        if (typeof (item as MenuCommandItem).action === 'function') {
+          (item as any).action.call(this, e, callbackArgs);
+        }
+
+        if (!e.defaultPrevented) {
+          this.destroyMenu(e, { cell, row });
+        }
+      } else if ((item as MenuCommandItem).commandItems || (item as MenuOptionItem).optionItems) {
+        this.repositionSubMenu(item, type, level, e);
+      } else {
+        this.destroySubMenus();
+      }
+      this._lastMenuTypeClicked = type;
     }
   }
 
-  protected handleMenuItemOptionClick(item: MenuOptionItem | 'divider', e: DOMMouseOrTouchEvent<HTMLDivElement>) {
-    if ((item as MenuOptionItem).disabled || (item as MenuOptionItem).divider) {
-      return;
-    }
-    if (!this._grid.getEditorLock().commitCurrentEdit()) {
-      return;
+  protected repositionSubMenu(item: MenuCommandItem  | MenuOptionItem | 'divider', type: MenuType, level: number, e: DOMMouseOrTouchEvent<HTMLDivElement>) {
+    // when we're clicking a grid cell OR our last menu type (command/option) differs then we know that we need to start fresh and close any sub-menus that might still be open
+    if (e.target.classList.contains('slick-cell') || this._lastMenuTypeClicked !== type) {
+      this.destroySubMenus();
     }
 
-    const option = (item as MenuOptionItem).option !== undefined ? (item as MenuOptionItem).option : '';
-    const row = this._currentRow;
-    const cell = this._currentCell;
-    const columnDef = this._grid.getColumns()[cell];
-    const dataContext = this._grid.getDataItem(row);
-
-    if (option !== undefined) {
-      // user could execute a callback through 2 ways
-      // via the onOptionSelected event and/or an action callback
-      const callbackArgs = {
-        cell,
-        row,
-        grid: this._grid,
-        option,
-        item: item as MenuOptionItem,
-        column: columnDef,
-        dataContext,
-      };
-      this.onOptionSelected.notify(callbackArgs, e, this);
-
-      // execute action callback when defined
-      if (typeof (item as MenuOptionItem).action === 'function') {
-        (item as any).action.call(this, e, callbackArgs);
-      }
-    }
+    // creating sub-menu, we'll also pass level & the item object since we might have "subMenuTitle" to show
+    const subMenuElm = this.createMenu((item as MenuCommandItem)?.commandItems || [], (item as MenuOptionItem)?.optionItems || [], level + 1, item);
+    this._subMenuElms.push(subMenuElm);
+    subMenuElm.style.display = 'block';
+    document.body.appendChild(subMenuElm);
+    this.repositionMenu(e, subMenuElm);
   }
 
   /**
    * Reposition the menu drop (up/down) and the side (left/right)
    * @param {*} event
    */
-  protected repositionMenu(e: DOMMouseOrTouchEvent<HTMLDivElement>) {
-    if (this._menuElm && e.target) {
-      const targetEvent = (e as TouchEvent).touches?.[0] ?? e;
-      const parentElm = e.target.closest('.slick-cell') as HTMLDivElement;
-      const parentOffset = (parentElm && Utils.offset(parentElm));
-      let menuOffsetLeft = targetEvent.pageX;
+  protected repositionMenu(e: DOMMouseOrTouchEvent<HTMLDivElement>, menuElm: HTMLElement) {
+    const isSubMenu = menuElm.classList.contains('slick-submenu');
+    const targetEvent = (e as TouchEvent).touches?.[0] ?? e;
+    const parentElm = isSubMenu
+      ? e.target.closest('.slick-context-menu-item') as HTMLDivElement
+      : e.target.closest('.slick-cell') as HTMLDivElement;
+
+    if (menuElm && parentElm) {
+      const parentOffset = Utils.offset(parentElm);
+      let menuOffsetLeft = (isSubMenu && parentElm) ? parentOffset?.left ?? 0 : targetEvent.pageX;
       let menuOffsetTop = parentElm ? parentOffset?.top ?? 0 : targetEvent.pageY;
-      const menuHeight = this._menuElm?.offsetHeight || 0;
-      const menuWidth = this._menuElm?.offsetWidth || this._contextMenuProperties.width || 0;
+      const menuHeight = menuElm?.offsetHeight || 0;
+      const menuWidth = Number(menuElm?.offsetWidth || this._contextMenuProperties.width || 0);
       const rowHeight = this._gridOptions.rowHeight;
-      const dropOffset = this._contextMenuProperties.autoAdjustDropOffset;
-      const sideOffset = this._contextMenuProperties.autoAlignSideOffset;
+      const dropOffset = Number(this._contextMenuProperties.autoAdjustDropOffset || 0);
+      const sideOffset = Number(this._contextMenuProperties.autoAlignSideOffset || 0);
 
       // if autoAdjustDrop is enable, we first need to see what position the drop will be located
       // without necessary toggling it's position just yet, we just want to know the future position for calculation
@@ -697,17 +708,25 @@ export class SlickContextMenu implements SlickPlugin {
         // since we reposition menu below slick cell, we need to take it in consideration and do our calculation from that element
         const spaceBottom = Utils.calculateAvailableSpace(parentElm).bottom;
         const spaceTop = Utils.calculateAvailableSpace(parentElm).top;
-        const spaceBottomRemaining = spaceBottom + (dropOffset || 0) - rowHeight!;
-        const spaceTopRemaining = spaceTop - (dropOffset || 0) + rowHeight!;
+        const spaceBottomRemaining = spaceBottom + dropOffset - rowHeight!;
+        const spaceTopRemaining = spaceTop - dropOffset + rowHeight!;
         const dropPosition = (spaceBottomRemaining < menuHeight && spaceTopRemaining > spaceBottomRemaining) ? 'top' : 'bottom';
         if (dropPosition === 'top') {
-          this._menuElm.classList.remove('dropdown');
-          this._menuElm.classList.add('dropup');
-          menuOffsetTop = menuOffsetTop - menuHeight - (dropOffset || 0);
+          menuElm.classList.remove('dropdown');
+          menuElm.classList.add('dropup');
+          if (isSubMenu) {
+            menuOffsetTop -= (menuHeight - dropOffset - parentElm.clientHeight);
+          } else {
+            menuOffsetTop -= menuHeight - dropOffset;
+          }
         } else {
-          this._menuElm.classList.remove('dropup');
-          this._menuElm.classList.add('dropdown');
-          menuOffsetTop = menuOffsetTop + rowHeight! + (dropOffset || 0);
+          menuElm.classList.remove('dropup');
+          menuElm.classList.add('dropdown');
+          if (isSubMenu) {
+            menuOffsetTop += dropOffset;
+          } else {
+            menuOffsetTop += rowHeight! + dropOffset;
+          }
         }
       }
 
@@ -716,21 +735,27 @@ export class SlickContextMenu implements SlickPlugin {
       // to simulate an align left, we actually need to know the width of the drop menu
       if (this._contextMenuProperties.autoAlignSide) {
         const gridPos = this._grid.getGridPosition();
-        const dropSide = ((menuOffsetLeft + (+menuWidth)) >= gridPos.width) ? 'left' : 'right';
+        const subMenuPosCalc = menuOffsetLeft + parentElm.clientWidth + menuWidth; // calculate coordinate at caller element far right
+        const browserWidth = document.documentElement.clientWidth;
+        const dropSide = (subMenuPosCalc >= gridPos.width || subMenuPosCalc >= browserWidth) ? 'left' : 'right';
         if (dropSide === 'left') {
-          this._menuElm.classList.remove('dropright');
-          this._menuElm.classList.add('dropleft');
-          menuOffsetLeft = (menuOffsetLeft - (+menuWidth) - (sideOffset || 0));
+          menuElm.classList.remove('dropright');
+          menuElm.classList.add('dropleft');
+          menuOffsetLeft -= menuWidth - sideOffset;
         } else {
-          this._menuElm.classList.remove('dropleft');
-          this._menuElm.classList.add('dropright');
-          menuOffsetLeft = menuOffsetLeft + (sideOffset || 0);
+          menuElm.classList.remove('dropleft');
+          menuElm.classList.add('dropright');
+          if (isSubMenu) {
+            menuOffsetLeft += sideOffset + parentElm.offsetWidth;
+          } else {
+            menuOffsetLeft += sideOffset;
+          }
         }
       }
 
       // ready to reposition the menu
-      this._menuElm.style.top = `${menuOffsetTop}px`;
-      this._menuElm.style.left = `${menuOffsetLeft}px`;
+      menuElm.style.top = `${menuOffsetTop}px`;
+      menuElm.style.left = `${menuOffsetLeft}px`;
     }
   }
 

--- a/src/styles/slick.cellmenu.scss
+++ b/src/styles/slick.cellmenu.scss
@@ -80,6 +80,10 @@
   border: 1px solid transparent;
   border-radius: 3px;
   display: block;
+
+  .sub-item-chevron {
+    float: right;
+  }
 }
 .slick-cell-menu-item:hover {
   border-color: silver;

--- a/src/styles/slick.cellmenu.scss
+++ b/src/styles/slick.cellmenu.scss
@@ -30,7 +30,7 @@
   float: right;
 }
 
-.slick-cell-menu .title {
+.slick-cell-menu .slick-menu-title {
   font-size: 16px;
   width: calc(100% - 30px);
   border-bottom: solid 1px #d6d6d6;

--- a/src/styles/slick.cellmenu.scss
+++ b/src/styles/slick.cellmenu.scss
@@ -11,6 +11,9 @@
   z-index: 2000;
 	overflow:auto;
   resize: both;
+  &.slick-submenu {
+    min-width: 100px;
+  }
 }
 
 .slick-cell-menu-button {

--- a/src/styles/slick.contextmenu.scss
+++ b/src/styles/slick.contextmenu.scss
@@ -11,6 +11,9 @@
   z-index: 2000;
 	overflow:auto;
   resize: both;
+  &.slick-submenu {
+    min-width: 100px;
+  }
 }
 
 .slick-context-menu-button {

--- a/src/styles/slick.contextmenu.scss
+++ b/src/styles/slick.contextmenu.scss
@@ -30,7 +30,7 @@
   float: right;
 }
 
-.slick-context-menu .title {
+.slick-context-menu .slick-menu-title {
   font-size: 16px;
   width: calc(100% - 30px);
   border-bottom: solid 1px #d6d6d6;
@@ -85,6 +85,10 @@
   padding: 2px 4px;
   border: 1px solid transparent;
   border-radius: 3px;
+
+  .sub-item-chevron {
+    float: right;
+  }
 }
 .slick-context-menu-item:hover {
   border-color: silver;


### PR DESCRIPTION
- also merge command/option code since we had a lot of duplicate code to do roughly the same thing but with different list (command/options)
- currently only works by `click` event on sub-menus, I tried to implement it with `mouseover`/`mouseout` but it's a lot more complex (we need to know if we are mousing over the correct sub-menu or over something else and this and that... wow just too much work)... so `click` should be enough for now, even though it's slightly less user friendly
- this is the 1st PR but in theory it should be easy enough to replicate for other menu plugins (GridMenu, HeaderMenu)

#### TODOS
- [x] add sub-menus to Cell Menu plugin
  - [x] add Cypress E2E tests
- [x] add sub-menus to Context Menu plugin
  - [x] add Cypress E2E tests
- [x] add `slick-submenu` class when it's a sub-menu
- [x] add sub-menu level number for optional custom styling
   - i.e. Grouping does it in 2 ways: 1-add `slick-group-level-2` & 2-add `level="2"` attribute
- [x] verify that sub-menu(s) is always at an expected position, it seems incorrect for some sub-menus
- [x] add `subMenuTitle` & `subMenuTitleCssClass` to optionally add sub-menu title & custom styling
- [x] opening a sub-menu then open a sub-menu from another tree doesn't close previous sub-menu that becomes orphan

![image](https://github.com/6pac/SlickGrid/assets/643976/d8c9ff83-8ad2-4fb1-b447-e75fe3f75780)

![image](https://github.com/6pac/SlickGrid/assets/643976/327f1956-ea10-4e30-a74e-2e98cb87971f)
