### PR TITLE
feat: add sub-menu(s) to HeaderMenu plugin

### DIFF
--- a/cypress/e2e/example-plugin-headermenu.cy.ts
+++ b/cypress/e2e/example-plugin-headermenu.cy.ts
@@ -59,7 +59,7 @@ describe('Example - Header Menu', () => {
       .find('.slick-header-menucontent.blue')
       .contains('Help')
       .click()
-      .then(() => expect(alertStub.getCall(0)).to.be.calledWith('Command: help'))
+      .then(() => expect(alertStub.getCall(0)).to.be.calledWith('Command: help'));
 
     cy.window().then((win) => {
       expect(win.console.log).to.have.callCount(1);
@@ -170,5 +170,89 @@ describe('Example - Header Menu', () => {
     cy.get('.slick-header-menuitem.slick-header-menuitem-disabled')
       .contains('Hide')
       .should('exist');
+  });
+
+  it('should open Freeze/Pinning sub-menu with 2 options expect it to be aligned to left then trigger alert when command is clicked', () => {
+    const subCommands = ['Freeze Columns', 'Unfreeze all Columns'];
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('.slick-header-menuitem.slick-header-menuitem')
+      .contains('Freeze/Pinning')
+      .should('exist')
+      .click();
+
+    cy.get('.slick-header-menu.slick-menu-level-1.dropleft')
+      .should('exist')
+      .find('.slick-header-menuitem')
+      .each(($command, index) => expect($command.text()).to.eq(subCommands[index]));
+
+    cy.get('.slick-header-menu.slick-menu-level-1')
+      .find('.slick-header-menuitem')
+      .contains('Freeze Columns')
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Command: freeze-columns'));
+  });
+
+  it('should open Freeze/Pinning sub-menu and expect 2 options, then open Feedback->ContactUs sub-menus and expect previous Freeze menu to no longer exists', () => {
+    const subCommands1 = ['Freeze Columns', 'Unfreeze all Columns'];
+    const subCommands2 = ['Column is great', 'Column is not useful', '', 'Contact Us'];
+    const subCommands2_1 = ['Email us', 'Chat with us', 'Book an appointment'];
+
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('#myGrid')
+      .find('.slick-header-column:nth(5)')
+      .trigger('mouseover')
+      .children('.slick-header-menubutton')
+      .invoke('show')
+      .click();
+
+    cy.get('.slick-header-menu.slick-menu-level-0')
+      .find('.slick-header-menuitem.slick-header-menuitem')
+      .contains('Freeze/Pinning')
+      .should('exist')
+      .click();
+
+    cy.get('.slick-submenu').should('have.length', 1);
+    cy.get('.slick-header-menu.slick-menu-level-1.dropleft') // left align
+      .should('exist')
+      .find('.slick-header-menuitem')
+      .each(($command, index) => expect($command.text()).to.eq(subCommands1[index]));
+
+    // click different sub-menu
+    cy.get('.slick-header-menu.slick-menu-level-0')
+      .find('.slick-header-menuitem.slick-header-menuitem')
+      .contains('Feedback')
+      .should('exist')
+      .click();
+
+    cy.get('.slick-submenu').should('have.length', 1);
+    cy.get('.slick-header-menu.slick-menu-level-1')
+      .should('exist')
+      .find('.slick-header-menuitem')
+      .each(($command, index) => expect($command.text()).to.eq(subCommands2[index]));
+
+    // click on Feedback->ContactUs
+    cy.get('.slick-header-menu.slick-menu-level-1.dropleft') // left align
+      .find('.slick-header-menuitem.slick-header-menuitem')
+      .contains('Contact Us')
+      .should('exist')
+      .click();
+
+    cy.get('.slick-submenu').should('have.length', 2);
+    cy.get('.slick-header-menu.slick-menu-level-2.dropright') // right align
+      .should('exist')
+      .find('.slick-header-menuitem')
+      .each(($command, index) => expect($command.text()).to.eq(subCommands2_1[index]));
+
+    cy.get('.slick-header-menu.slick-menu-level-2')
+      .find('.slick-header-menuitem')
+      .contains('Chat with us')
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Command: contact-chat'));
+
+    cy.get('.slick-submenu').should('have.length', 0);
   });
 });

--- a/examples/example-plugin-headermenu.html
+++ b/examples/example-plugin-headermenu.html
@@ -34,7 +34,6 @@
       padding: 2px;
       border: 1px solid transparent;
       border-radius: 3px;
-      display: block;
     }
 
     .slick-header-menuitem:hover {
@@ -48,6 +47,12 @@
     }
     .slick-header-menuitem-hidden {
       display: none;
+    }
+    .slick-header-menu.slick-submenu {
+      background-color: #fbfbfb;
+      /* border-width: 2px; */
+      box-shadow: 0 2px 4px 2px rgba(146, 152, 163, 0.4);
+      min-width: 150px;
     }
   </style>
 
@@ -138,9 +143,6 @@
                 return args.column.id === "Duration";
               },
             },
-            // you can pass divider as a string or an object with a boolean
-            // "divider",
-            { divider: true },
             {
               iconCssClass: 'sgi sgi-help-circle-outline sgi-14px',
               title: "Help",
@@ -155,6 +157,34 @@
                 // you can use the "action" callback and/or subscribe to the "onCallback" event, they both have the same arguments
                 console.log('execute an action on Help', args);
               }
+            },
+            // you can pass divider as a string or an object with a boolean
+            // "divider",
+            { divider: true },
+            {
+              // we can also have multiple nested sub-menus
+              command: 'freezing', title: 'Freeze/Pinning',
+              items: [
+                { command: "freeze-columns", title: "Freeze Columns" },
+                { command: "unfreeze-columns", title: "Unfreeze all Columns" },
+              ]
+            },
+            {
+              // we can also have multiple nested sub-menus
+              command: 'feedback', title: 'Feedback',
+              items: [
+                { command: "column-love", title: "Column is great", iconCssClass: "sgi sgi-star", tooltip: "this will automatically send us an email about this new column detail" },
+                { command: "column-hate", title: "Column is not useful", iconCssClass: "sgi sgi-information-outline", tooltip: "this will automatically send us an email about this new column detail" },
+                "divider",
+                {
+                  command: 'sub-menu', title: 'Contact Us', iconCssClass: "sgi sgi-user", subMenuTitle: "contact us...", subMenuTitleCssClass: "italic",
+                  items: [
+                    { command: "contact-email", title: "Email us", iconCssClass: "sgi sgi-pencil-outline" },
+                    { command: "contact-chat", title: "Chat with us", iconCssClass: "sgi sgi-message-outline" },
+                    { command: "contact-meeting", title: "Book an appointment", iconCssClass: "sgi sgi-coffee-outline" },
+                  ]
+                }
+              ]
             }
           ]
         }
@@ -237,7 +267,7 @@
 
       grid = new Slick.Grid("#myGrid", data, columns, options);
       var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
-      headerMenuPlugin = new Slick.Plugins.HeaderMenu({ buttonCssClass: 'sgi sgi-caret' });
+      headerMenuPlugin = new Slick.Plugins.HeaderMenu({ buttonCssClass: 'sgi sgi-caret', subItemChevronClass: 'sgi sgi-chevron-right' });
 
       grid.onSort.subscribe(function (e, args) {
         executeSort(args.sortCols);
@@ -268,7 +298,6 @@
           grid.setSortColumns(sortCols);
           executeSort(sortCols);
         } else {
-          // command not recognised
           alert("Command: " + args.command);
         }
       });

--- a/src/models/headerMenuItems.interface.ts
+++ b/src/models/headerMenuItems.interface.ts
@@ -2,7 +2,7 @@ import type { Column, MenuCommandItem } from './index';
 import type { SlickGrid } from '../slick.grid';
 
 export interface HeaderMenuItems {
-  items: Array<MenuCommandItem | 'divider'>;
+  items: Array<HeaderMenuCommandItem | 'divider'>;
 }
 
 export interface HeaderMenuCommandItemCallbackArgs {
@@ -13,5 +13,10 @@ export interface HeaderMenuCommandItemCallbackArgs {
   grid: SlickGrid;
 
   /** html DOM element of the menu */
-  menu: Array<MenuCommandItem | 'divider'>;
+  menu: Array<HeaderMenuCommandItem | 'divider'>;
+}
+
+export interface HeaderMenuCommandItem extends Omit<MenuCommandItem, 'commandItems'> {
+  /** Array of Command Items (title, command, disabled, ...) */
+  items: Array<HeaderMenuCommandItem | 'divider'>;
 }

--- a/src/models/headerMenuOption.interface.ts
+++ b/src/models/headerMenuOption.interface.ts
@@ -23,6 +23,9 @@ export interface HeaderMenuOption {
   /** Minimum width that the drop menu will have */
   minWidth?: number;
 
+  /** CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon) */
+  subItemChevronClass?: string;
+
   /** Menu item text. */
   title?: string;
 

--- a/src/styles/slick.headermenu.scss
+++ b/src/styles/slick.headermenu.scss
@@ -39,11 +39,23 @@
 
 /* Menu items */
 .slick-header-menuitem {
+  display: block;
   list-style: none;
   margin: 0;
   padding: 0;
   cursor: pointer;
-  display: block;
+
+  .sub-item-chevron {
+    vertical-align: middle;
+    float: right;
+  }
+}
+
+.slick-header-menu .slick-menu-title {
+  font-size: 16px;
+  width: calc(100% - 30px);
+  border-bottom: solid 1px #d6d6d6;
+  margin-bottom: 5px;
 }
 
 .slick-header-menuicon {


### PR DESCRIPTION
- currently only works by `click` event on sub-menus, I tried to implement it with `mouseover`/`mouseout` but it's a lot more complex (we need to know if we are mousing over the correct sub-menu or over something else and this and that... wow just too much work)... so `click` should be enough for now, even though it's slightly less user friendly

#### TODOS
- [x] requires PR #867 to be merged for this PR to not fail
  - build fails because `subMenuTitle` and `subMenuTitleCssClass` were added in previous PR
- [x] add sub-menus to Grid Menu control
- [x] add Cypress E2E tests
- [x] add `subMenuTitle` & `subMenuTitleCssClass` to optionally add sub-menu title & custom styling
- [x] opening a sub-menu then open a sub-menu from another tree doesn't close previous sub-menu that becomes orphan
