### PR TITLE
feat: add `subMenuOpenByEvent` option to open sub-menus via mouseover

### DIFF
--- a/cypress/e2e/example-grid-menu.cy.ts
+++ b/cypress/e2e/example-grid-menu.cy.ts
@@ -262,7 +262,7 @@ describe('Example - Grid Menu', () => {
 
   it('should expect "Clear Sorting" command to become hidden from Grid Menu when disabling feature', () => {
     cy.get('#toggle-sorting')
-    .click();
+      .click();
 
     cy.get('#myGrid')
       .find('button.slick-gridmenu-button')
@@ -276,7 +276,7 @@ describe('Example - Grid Menu', () => {
 
   it('should expect "Clear Sorting" command to become visible agaom in Grid Menu when toggling feature again', () => {
     cy.get('#toggle-sorting')
-    .click();
+      .click();
 
     cy.get('#myGrid')
       .find('button.slick-gridmenu-button')
@@ -336,7 +336,7 @@ describe('Example - Grid Menu', () => {
 
     cy.get('.slick-submenu').should('have.length', 1);
     cy.get('.slick-gridmenu.slick-menu-level-1 .slick-gridmenu-command-list')
-     .find('.slick-gridmenu-item')
+      .find('.slick-gridmenu-item')
       .contains('Excel')
       .click();
 
@@ -387,7 +387,7 @@ describe('Example - Grid Menu', () => {
       .find('.slick-gridmenu-item')
       .contains('Feedback')
       .should('exist')
-      .click();
+      .trigger('mouseover'); // mouseover or click should work
 
     cy.get('.slick-submenu').should('have.length', 1);
     cy.get('.slick-gridmenu.slick-menu-level-1')

--- a/cypress/e2e/example-plugin-contextmenu.cy.ts
+++ b/cypress/e2e/example-plugin-contextmenu.cy.ts
@@ -298,7 +298,7 @@ describe('Example - Context Menu & Cell Menu', () => {
     cy.get('.slick-cell-menu.slick-menu-level-0 .slick-cell-menu-command-list')
       .find('.slick-cell-menu-item')
       .contains('Export')
-      .click();
+      .trigger('mouseover'); // mouseover or click should work
 
     cy.get('.slick-cell-menu.slick-menu-level-1 .slick-cell-menu-command-list')
       .should('exist')
@@ -458,7 +458,7 @@ describe('Example - Context Menu & Cell Menu', () => {
       .find('.slick-cell-menu-item')
       .contains('Feedback')
       .should('exist')
-      .click();
+      .trigger('mouseover'); // mouseover or click should work
 
     cy.get('.slick-submenu').should('have.length', 1);
     cy.get('.slick-cell-menu.slick-menu-level-1')
@@ -884,7 +884,7 @@ describe('Example - Context Menu & Cell Menu', () => {
       .find('.slick-context-menu-item')
       .contains('Feedback')
       .should('exist')
-      .click();
+      .trigger('mouseover'); // mouseover or click should work
 
     cy.get('.slick-submenu').should('have.length', 1);
     cy.get('.slick-context-menu.slick-menu-level-1')

--- a/cypress/e2e/example-plugin-headermenu.cy.ts
+++ b/cypress/e2e/example-plugin-headermenu.cy.ts
@@ -226,7 +226,7 @@ describe('Example - Header Menu', () => {
       .find('.slick-header-menuitem.slick-header-menuitem')
       .contains('Feedback')
       .should('exist')
-      .click();
+      .trigger('mouseover'); // mouseover or click should work
 
     cy.get('.slick-submenu').should('have.length', 1);
     cy.get('.slick-header-menu.slick-menu-level-1')

--- a/src/models/cellMenuOption.interface.ts
+++ b/src/models/cellMenuOption.interface.ts
@@ -62,6 +62,9 @@ export interface CellMenuOption {
   /** CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon) */
   subItemChevronClass?: string;
 
+  /** Defaults to "mouseover", what event type shoud we use to open sub-menu(s), 2 options are available: "mouseover" or "click" */
+  subMenuOpenByEvent?: 'mouseover' | 'click';
+
   // --
   // action/override callbacks
 

--- a/src/models/contextMenuOption.interface.ts
+++ b/src/models/contextMenuOption.interface.ts
@@ -68,6 +68,9 @@ export interface ContextMenuOption {
   /** CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon) */
   subItemChevronClass?: string;
 
+  /** Defaults to "mouseover", what event type shoud we use to open sub-menu(s), 2 options are available: "mouseover" or "click" */
+  subMenuOpenByEvent?: 'mouseover' | 'click';
+
   // --
   // action/override callbacks
 

--- a/src/models/gridMenuOption.interface.ts
+++ b/src/models/gridMenuOption.interface.ts
@@ -61,6 +61,9 @@ export interface GridMenuOption {
   /** CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon) */
   subItemChevronClass?: string;
 
+  /** Defaults to "mouseover", what event type shoud we use to open sub-menu(s), 2 options are available: "mouseover" or "click" */
+  subMenuOpenByEvent?: 'mouseover' | 'click';
+
   /** Defaults to "Synchronous resize" which is 1 of the last 2 checkbox title shown at the end of the picker list */
   syncResizeTitle?: string;
 

--- a/src/models/headerMenuOption.interface.ts
+++ b/src/models/headerMenuOption.interface.ts
@@ -26,6 +26,9 @@ export interface HeaderMenuOption {
   /** CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon) */
   subItemChevronClass?: string;
 
+  /** Defaults to "mouseover", what event type shoud we use to open sub-menu(s), 2 options are available: "mouseover" or "click" */
+  subMenuOpenByEvent?: 'mouseover' | 'click';
+
   /** Menu item text. */
   title?: string;
 

--- a/src/plugins/slick.cellmenu.ts
+++ b/src/plugins/slick.cellmenu.ts
@@ -84,6 +84,7 @@ const Utils = IIFE_ONLY ? Slick.Utils : Utils_;
  *    autoAlignSideOffset:        Optionally add an offset to the left/right side auto-align (defaults to 0)
  *    menuUsabilityOverride:      Callback method that user can override the default behavior of enabling/disabling the menu from being usable (must be combined with a custom formatter)
  *    subItemChevronClass:        CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon)
+ *    subMenuOpenByEvent:         defaults to "mouseover", what event type shoud we use to open sub-menu(s), 2 options are available: "mouseover" or "click"
  *
  *
  * Available menu Command/Option item properties:
@@ -183,6 +184,7 @@ export class SlickCellMenu implements SlickPlugin {
     hideMenuOnScroll: true,
     maxHeight: 'none',
     width: 'auto',
+    subMenuOpenByEvent: 'mouseover',
   };
 
   constructor(optionProperties: Partial<CellMenuOption>) {
@@ -702,6 +704,18 @@ export class SlickCellMenu implements SlickPlugin {
 
       if (addClickListener) {
         this._bindingEventService.bind(liElm, 'click', this.handleMenuItemClick.bind(this, item, itemType, args.level) as EventListener);
+      }
+
+      // optionally open sub-menu(s) by mouseover
+      if (this._cellMenuProperties.subMenuOpenByEvent === 'mouseover') {
+        this._bindingEventService.bind(liElm, 'mouseover', ((e: DOMMouseOrTouchEvent<HTMLDivElement>) => {
+          if ((item as MenuCommandItem).commandItems || (item as MenuOptionItem).optionItems) {
+            this.repositionSubMenu(item, itemType, args.level, e);
+            this._lastMenuTypeClicked = itemType;
+          } else if (!isSubMenu) {
+            this.destroySubMenus();
+          }
+        }) as EventListener);
       }
 
       // the option/command item could be a sub-menu if it has another list of commands/options


### PR DESCRIPTION
- when I implemented sub-menus, I thought it was complex to add open sub-menus via mouseover (not just click event) but it turns out to be quite easy with the latest code that was put in place for sub-menus. So this PR adds the mouseover option and does make it the default event (we have 2 options: `click` or `mouseover` and the latter is the default)
- this new mouseover will be the default but user could change it to work via click event only by changing the option to `subMenuOpenByEvent: 'click'` (instead of the default which is `subMenuOpenByEvent: 'mouseover'`)


![msedge_1t8KcKPjsr](https://github.com/6pac/SlickGrid/assets/643976/7f7592a9-e4fa-4a1a-93c0-432c0e77f17e)

