### PR TITLE
fix: deprecate GridMenu `customItems` in favor of `commandItems`

### DIFF
--- a/cypress/e2e/example-grid-menu.cy.ts
+++ b/cypress/e2e/example-grid-menu.cy.ts
@@ -35,10 +35,10 @@ describe('Example - Grid Menu', () => {
     });
   });
 
-  it('should have the Grid Menu already opened and expect a title for "Custom Menus" and for "Columns"', () => {
+  it('should have the Grid Menu already opened and expect a title for "Custom Commands" and for "Columns"', () => {
     cy.get('.slick-gridmenu-custom')
       .find('.title')
-      .contains('Custom Menus');
+      .contains('Custom Commands');
 
     cy.get('.slick-gridmenu')
       .find('.title')
@@ -262,7 +262,7 @@ describe('Example - Grid Menu', () => {
 
   it('should expect "Clear Sorting" command to become hidden from Grid Menu when disabling feature', () => {
     cy.get('#toggle-sorting')
-    .click();
+      .click();
 
     cy.get('#myGrid')
       .find('button.slick-gridmenu-button')
@@ -276,7 +276,7 @@ describe('Example - Grid Menu', () => {
 
   it('should expect "Clear Sorting" command to become visible agaom in Grid Menu when toggling feature again', () => {
     cy.get('#toggle-sorting')
-    .click();
+      .click();
 
     cy.get('#myGrid')
       .find('button.slick-gridmenu-button')
@@ -336,7 +336,7 @@ describe('Example - Grid Menu', () => {
 
     cy.get('.slick-submenu').should('have.length', 1);
     cy.get('.slick-gridmenu.slick-menu-level-1 .slick-gridmenu-command-list')
-     .find('.slick-gridmenu-item')
+      .find('.slick-gridmenu-item')
       .contains('Excel')
       .click();
 

--- a/examples/example-grid-menu.html
+++ b/examples/example-grid-menu.html
@@ -186,7 +186,7 @@
         // we could disable the menu entirely by returning false
         return true;
       },
-      customTitle: "Custom Menus",
+      commandTitle: "Custom Commands",
       columnTitle: "Columns",
       hideForceFitButton: false,
       hideSyncResizeButton: false,
@@ -194,7 +194,7 @@
       leaveOpen: false,                 // do we want to leave the Grid Menu open after a command execution? (false by default)
       // menuWidth: 18,                 // width that will be use to resize the column header container (18 by default)
       resizeOnShowHeaderRow: true,
-      customItems: [
+      commandItems: [
         {
           iconCssClass: "sgi sgi-close red bold",
           title: "Clear Filters",
@@ -256,11 +256,11 @@
         {
           // we can also have multiple nested sub-menus
           command: 'export', title: 'Export',
-          customItems: [
+          commandItems: [
             { command: "export-txt", title: "Text" },
             {
               command: 'sub-menu', title: 'Excel', cssClass: "green", subMenuTitle: "available formats", subMenuTitleCssClass: "italic orange",
-              customItems: [
+              commandItems: [
                 { command: "export-csv", title: "Excel (csv)" },
                 { command: "export-xls", title: "Excel (xls)" },
               ]
@@ -269,12 +269,12 @@
         },
         {
           command: 'feedback', title: 'Feedback',
-          customItems: [
+          commandItems: [
             { command: "request-update", title: "Request update from shipping team", iconCssClass: "sgi sgi-tag-outline", tooltip: "this will automatically send an alert to the shipping team to contact the user for an update" },
             "divider",
             {
               command: 'sub-menu', title: 'Contact Us', iconCssClass: "sgi sgi-user", subMenuTitle: "contact us...", subMenuTitleCssClass: "italic",
-              customItems: [
+              commandItems: [
                 { command: "contact-email", title: "Email us", iconCssClass: "sgi sgi-pencil-outline" },
                 { command: "contact-chat", title: "Chat with us", iconCssClass: "sgi sgi-message-outline" },
                 { command: "contact-meeting", title: "Book an appointment", iconCssClass: "sgi sgi-coffee-outline" },
@@ -337,7 +337,7 @@
 
   function toggleSorting(e) {
     isSortingDisabled = !isSortingDisabled;
-    options.gridMenu.customItems.forEach(function(menuItem) {
+    options.gridMenu.commandItems.forEach(function(menuItem) {
         if (menuItem && typeof menuItem !== 'string') {
           const menuCommand = menuItem.command;
           if (menuCommand === 'clear-sorting') {

--- a/src/models/gridMenuCommandItemCallbackArgs.interface.ts
+++ b/src/models/gridMenuCommandItemCallbackArgs.interface.ts
@@ -1,4 +1,4 @@
-import type { Column, GridMenuItem } from './index';
+import type { Column, GridMenuItem, MenuCommandItem } from './index';
 import type { SlickGrid } from '../slick.grid';
 
 
@@ -14,7 +14,7 @@ export interface GridMenuCommandItemCallbackArgs {
   command: string;
 
   /** Menu item selected */
-  item: GridMenuItem;
+  item: GridMenuItem | MenuCommandItem;
 
   /** Slick Grid object */
   grid: SlickGrid;

--- a/src/models/gridMenuItem.interface.ts
+++ b/src/models/gridMenuItem.interface.ts
@@ -1,8 +1,8 @@
 import type { GridMenuCallbackArgs, GridMenuCommandItemCallbackArgs, MenuCommandItem } from './index';
 import type { SlickEventData } from '../slick.core';
 
-export interface GridMenuItem extends Omit<MenuCommandItem<GridMenuCommandItemCallbackArgs, GridMenuCallbackArgs>, 'commandItems'> {
-  /** Array of Command Items (title, command, disabled, ...) */
+export interface GridMenuItem extends MenuCommandItem<GridMenuCommandItemCallbackArgs, GridMenuCallbackArgs> {
+  /** @deprecated use `commandItems` instead. Array of Command Items (title, command, disabled, ...) */
   customItems?: Array<GridMenuItem | 'divider'>;
 
   // --

--- a/src/models/gridMenuOption.interface.ts
+++ b/src/models/gridMenuOption.interface.ts
@@ -1,10 +1,16 @@
-import type { Column, GridMenuItem, GridOption, MenuCallbackArgs, } from './index';
+import type { Column, GridMenuCallbackArgs, GridMenuCommandItemCallbackArgs, GridMenuItem, GridOption, MenuCallbackArgs, MenuCommandItem, } from './index';
 
 export interface GridMenuOption {
   /** Defaults to "Commands" which is the title that shows up over the custom commands list */
-  customTitle?: string;
+  commandTitle?: string;
 
   /** Array of command items (title, command, disabled, ...) */
+  commandItems?: Array<MenuCommandItem<GridMenuCommandItemCallbackArgs, GridMenuCallbackArgs> | 'divider'>;
+
+  /** @deprecated use `commandTitle` instead. Defaults to "Commands" which is the title that shows up over the custom commands list */
+  customTitle?: string;
+
+  /** @deprecated use `commandItems` instead. Array of command items (title, command, disabled, ...) */
   customItems?: Array<GridMenuItem | 'divider'>;
 
   /** Defaults to 0 (auto), minimum width of grid menu content (command, column list) */

--- a/src/models/menuCommandItem.interface.ts
+++ b/src/models/menuCommandItem.interface.ts
@@ -1,9 +1,10 @@
 import type { MenuItem } from './menuItem.interface';
+import type { GridMenuCommandItemCallbackArgs } from './gridMenuCommandItemCallbackArgs.interface';
 import type { MenuCommandItemCallbackArgs } from './menuCommandItemCallbackArgs.interface';
 import type { MenuCallbackArgs } from './menuCallbackArgs.interface';
 import type { SlickEventData } from '../slick.core';
 
-export interface MenuCommandItem<A = MenuCommandItemCallbackArgs, R = MenuCallbackArgs> extends MenuItem<R> {
+export interface MenuCommandItem<A = MenuCommandItemCallbackArgs | GridMenuCommandItemCallbackArgs, R = MenuCallbackArgs> extends MenuItem<R> {
   /** A command identifier to be passed to the onCommand event callback handler (when using "commandItems"). */
   command: string;
 


### PR DESCRIPTION
- to align with other Menu plugins (ContextMenu, CellMenu), it's better if we rename `customItems` to `commandItems`, we'll only deprecate it for now so both names would work but the `customItems` will now show a console warning