### PR TITLE
fix: add `throwWhenFrozenNotAllViewable` grid option to avoid throwing

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -85,6 +85,7 @@ if (typeof Slick === "undefined") {
       frozenColumn: -1,
       frozenRow: -1,
       frozenRightViewportMinWidth: 100,
+      throwWhenFrozenNotAllViewable: false,
       fullWidthRows: false,
       multiColumnSort: false,
       numberedMultiColumnSort: false,
@@ -898,7 +899,7 @@ if (typeof Slick === "undefined") {
 
         if (hasFrozenColumns()) {
           const cWidth = utils.width(_container) || 0;
-          if (cWidth > 0 && canvasWidthL > cWidth) {
+          if (cWidth > 0 && canvasWidthL > cWidth && options.throwWhenFrozenNotAllViewable) {
             throw new Error('[SlickGrid] Frozen columns cannot be wider than the actual grid container width. '
               + 'Make sure to have less columns freezed or make your grid container wider');
           }


### PR DESCRIPTION
- add a flag `throwWhenFrozenNotAllViewable` that will now be set to `false` by default since this was causing issues in our environment, the flag can be set to `true` if any user want to add a try/catch and do other thing instead of simply throwing and leaving the grid in a non-functional state