### PR TITLE
fix: add more checks around cached rows

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -4642,7 +4642,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           this._canvasTopR.appendChild(xRight.firstChild as ChildNode);
         }
       } else {
-        if (this.rowsCache && this.rowsCache.hasOwnProperty(rows[i]) && xRight.firstChild) {
+        if (this.rowsCache && this.rowsCache.hasOwnProperty(rows[i]) && x.firstChild) {
           this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement];
           this._canvasTopL.appendChild(x.firstChild as ChildNode);
         }

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -4408,7 +4408,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected ensureCellNodesInRowsCache(row: number) {
     const cacheEntry = this.rowsCache[row];
     if (cacheEntry) {
-      if (cacheEntry.cellRenderQueue.length) {
+      if (cacheEntry.cellRenderQueue.length && cacheEntry.rowNode && cacheEntry.rowNode.length) {
         const rowNode = cacheEntry.rowNode as HTMLElement[];
         let children = Array.from(rowNode[0].children) as HTMLElement[];
         if (rowNode.length > 1) {
@@ -4624,20 +4624,28 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     for (let i = 0, ii = rows.length; i < ii; i++) {
       if ((this.hasFrozenRows) && (rows[i] >= this.actualFrozenRow)) {
         if (this.hasFrozenColumns()) {
-          this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement, xRight.firstChild as HTMLElement];
-          this._canvasBottomL.appendChild(x.firstChild as ChildNode);
-          this._canvasBottomR.appendChild(xRight.firstChild as ChildNode);
+          if (this.rowsCache && this.rowsCache.hasOwnProperty(rows[i]) && x.firstChild && xRight.firstChild) {
+            this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement, xRight.firstChild as HTMLElement];
+            this._canvasBottomL.appendChild(x.firstChild as ChildNode);
+            this._canvasBottomR.appendChild(xRight.firstChild as ChildNode);
+          }
         } else {
-          this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement];
+          if (this.rowsCache && this.rowsCache.hasOwnProperty(rows[i]) && x.firstChild) {
+            this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement];
           this._canvasBottomL.appendChild(x.firstChild as ChildNode);
+          }
         }
       } else if (this.hasFrozenColumns()) {
-        this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement, xRight.firstChild as HTMLElement];
-        this._canvasTopL.appendChild(x.firstChild as ChildNode);
-        this._canvasTopR.appendChild(xRight.firstChild as ChildNode);
+        if (this.rowsCache && this.rowsCache.hasOwnProperty(rows[i]) && x.firstChild && xRight.firstChild) {
+          this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement, xRight.firstChild as HTMLElement];
+          this._canvasTopL.appendChild(x.firstChild as ChildNode);
+          this._canvasTopR.appendChild(xRight.firstChild as ChildNode);
+        }
       } else {
-        this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement];
-        this._canvasTopL.appendChild(x.firstChild as ChildNode);
+        if (this.rowsCache && this.rowsCache.hasOwnProperty(rows[i]) && xRight.firstChild) {
+          this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement];
+          this._canvasTopL.appendChild(x.firstChild as ChildNode);
+        }
       }
     }
 

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -4407,19 +4407,17 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   protected ensureCellNodesInRowsCache(row: number) {
     const cacheEntry = this.rowsCache[row];
-    if (cacheEntry) {
-      if (cacheEntry.cellRenderQueue.length && cacheEntry.rowNode && cacheEntry.rowNode.length) {
-        const rowNode = cacheEntry.rowNode as HTMLElement[];
-        let children = Array.from(rowNode[0].children) as HTMLElement[];
-        if (rowNode.length > 1) {
-          children = children.concat(Array.from(rowNode[1].children) as HTMLElement[]);
-        }
+    if (cacheEntry?.cellRenderQueue.length && cacheEntry.rowNode?.length) {
+      const rowNode = cacheEntry.rowNode as HTMLElement[];
+      let children = Array.from(rowNode[0].children) as HTMLElement[];
+      if (rowNode.length > 1) {
+        children = children.concat(Array.from(rowNode[1].children) as HTMLElement[]);
+      }
 
-        let i = children.length - 1;
-        while (cacheEntry.cellRenderQueue.length) {
-          const columnIdx = cacheEntry.cellRenderQueue.pop();
-          (cacheEntry.cellNodesByColumnIdx as HTMLElement[])[columnIdx] = children[i--];
-        }
+      let i = children.length - 1;
+      while (cacheEntry.cellRenderQueue.length) {
+        const columnIdx = cacheEntry.cellRenderQueue.pop();
+        (cacheEntry.cellNodesByColumnIdx as HTMLElement[])[columnIdx] = children[i--];
       }
     }
   }
@@ -4624,25 +4622,25 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     for (let i = 0, ii = rows.length; i < ii; i++) {
       if ((this.hasFrozenRows) && (rows[i] >= this.actualFrozenRow)) {
         if (this.hasFrozenColumns()) {
-          if (this.rowsCache && this.rowsCache.hasOwnProperty(rows[i]) && x.firstChild && xRight.firstChild) {
+          if (this.rowsCache?.hasOwnProperty(rows[i]) && x.firstChild && xRight.firstChild) {
             this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement, xRight.firstChild as HTMLElement];
             this._canvasBottomL.appendChild(x.firstChild as ChildNode);
             this._canvasBottomR.appendChild(xRight.firstChild as ChildNode);
           }
         } else {
-          if (this.rowsCache && this.rowsCache.hasOwnProperty(rows[i]) && x.firstChild) {
+          if (this.rowsCache?.hasOwnProperty(rows[i]) && x.firstChild) {
             this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement];
-          this._canvasBottomL.appendChild(x.firstChild as ChildNode);
+            this._canvasBottomL.appendChild(x.firstChild as ChildNode);
           }
         }
       } else if (this.hasFrozenColumns()) {
-        if (this.rowsCache && this.rowsCache.hasOwnProperty(rows[i]) && x.firstChild && xRight.firstChild) {
+        if (this.rowsCache?.hasOwnProperty(rows[i]) && x.firstChild && xRight.firstChild) {
           this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement, xRight.firstChild as HTMLElement];
           this._canvasTopL.appendChild(x.firstChild as ChildNode);
           this._canvasTopR.appendChild(xRight.firstChild as ChildNode);
         }
       } else {
-        if (this.rowsCache && this.rowsCache.hasOwnProperty(rows[i]) && x.firstChild) {
+        if (this.rowsCache?.hasOwnProperty(rows[i]) && x.firstChild) {
           this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement];
           this._canvasTopL.appendChild(x.firstChild as ChildNode);
         }


### PR DESCRIPTION
- there were many assumptions that certain objects/fields were defined and calls on them were being made but it could happen in certain rare case that these row cache fields are actually undefined and that threw errors on our end, so this PR adds more checks before using any of these row cache objects/arrays