### PR TITLE
fix: add `throwWhenFrozenNotAllViewable` grid option to avoid throwing

### DIFF
--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -282,6 +282,12 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   /** Defaults to false, when set to True will sync the column cell resize & apply the column width */
   syncColumnCellResize?: boolean;
 
+  /**
+   * Defaults to false, should we throw an erro when frozenColumn is wider than the grid viewport width.
+   * When that happens the unfrozen section on the right is in a phantom area that is not viewable neither clickable unless we enable double-scroll on the grid container.
+   */
+  throwWhenFrozenNotAllViewable?: boolean;
+
   /** What is the top panel height in pixels (only type the number) */
   topPanelHeight?: number;
 

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -249,6 +249,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     frozenColumn: -1,
     frozenRow: -1,
     frozenRightViewportMinWidth: 100,
+    throwWhenFrozenNotAllViewable: false,
     fullWidthRows: false,
     multiColumnSort: false,
     numberedMultiColumnSort: false,
@@ -1119,7 +1120,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       if (this.hasFrozenColumns()) {
         const cWidth = Utils.width(this._container) || 0;
-        if (cWidth > 0 && this.canvasWidthL > cWidth) {
+        if (cWidth > 0 && this.canvasWidthL > cWidth && this._options.throwWhenFrozenNotAllViewable) {
           throw new Error('[SlickGrid] Frozen columns cannot be wider than the actual grid container width. '
             + 'Make sure to have less columns freezed or make your grid container wider');
         }


### PR DESCRIPTION
- add a flag `throwWhenFrozenNotAllViewable` that will now be set to `false` by default since this was causing issues in our environment, the flag can be set to `true` if any user want to add a try/catch and do other thing instead of simply throwing and leaving the grid in a non-functional state