### PR TITLE
fix: sub-menu event listeners leaking when closing sub-menus

### DIFF
--- a/src/controls/slick.gridmenu.ts
+++ b/src/controls/slick.gridmenu.ts
@@ -380,6 +380,7 @@ export class SlickGridMenu {
 
   /** Close and destroy all previously opened sub-menus */
   destroySubMenus() {
+    this._bindingEventService.unbindAll('sub-menu');
     document.querySelectorAll(`.slick-gridmenu.slick-submenu${this.getGridUidSelector()}`)
       .forEach(subElm => subElm.remove());
   }
@@ -387,7 +388,8 @@ export class SlickGridMenu {
   /** Construct the custom command menu items. */
   protected populateCommandsMenu(commandItems: Array<GridMenuItem | MenuCommandItem | 'divider'>, commandListElm: HTMLElement, args: { grid: SlickGrid, level: number }) {
     // user could pass a title on top of the custom section
-    const isSubMenu = args.level > 0;
+    const level = args?.level || 0;
+    const isSubMenu = level > 0;
     if (!isSubMenu && (this._gridMenuOptions?.commandTitle || this._gridMenuOptions?.customTitle)) {
       this._commandTitleElm = document.createElement('div');
       this._commandTitleElm.className = 'title';
@@ -470,14 +472,15 @@ export class SlickGridMenu {
       commandListElm.appendChild(liElm);
 
       if (addClickListener) {
-        this._bindingEventService.bind(liElm, 'click', this.handleMenuItemClick.bind(this, item, args.level) as EventListener);
+        const eventGroup = isSubMenu ? 'sub-menu' : 'parent-menu';
+        this._bindingEventService.bind(liElm, 'click', this.handleMenuItemClick.bind(this, item, level) as EventListener, undefined, eventGroup);
       }
 
       // optionally open sub-menu(s) by mouseover
       if (this._gridMenuOptions?.subMenuOpenByEvent === 'mouseover') {
         this._bindingEventService.bind(liElm, 'mouseover', ((e: DOMMouseOrTouchEvent<HTMLDivElement>) => {
           if ((item as GridMenuItem).commandItems || (item as GridMenuItem).customItems) {
-            this.repositionSubMenu(item, args.level, e);
+            this.repositionSubMenu(item, level, e);
           } else if (!isSubMenu) {
             this.destroySubMenus();
           }

--- a/src/models/core.interface.ts
+++ b/src/models/core.interface.ts
@@ -4,6 +4,7 @@ export interface ElementEventListener {
   element: Element | Window;
   eventName: string;
   listener: EventListenerOrEventListenerObject;
+  groupName?: string;
 }
 
 export interface EditController {

--- a/src/plugins/slick.contextmenu.ts
+++ b/src/plugins/slick.contextmenu.ts
@@ -450,12 +450,16 @@ export class SlickContextMenu implements SlickPlugin {
   /** Destroy all parent menus and any sub-menus */
   destroyAllMenus() {
     this.destroySubMenus();
+
+    // remove all parent menu listeners before removing them from the DOM
+    this._bindingEventService.unbindAll('parent-menu');
     document.querySelectorAll(`.slick-context-menu${this.getGridUidSelector()}`)
       .forEach(subElm => subElm.remove());
   }
 
   /** Close and destroy all previously opened sub-menus */
   destroySubMenus() {
+    this._bindingEventService.unbindAll('sub-menu');
     document.querySelectorAll(`.slick-context-menu.slick-submenu${this.getGridUidSelector()}`)
       .forEach(subElm => subElm.remove());
   }
@@ -551,7 +555,8 @@ export class SlickContextMenu implements SlickPlugin {
     }
 
     // user could pass a title on top of the Commands/Options section
-    const isSubMenu = args.level > 0;
+    const level = args?.level || 0;
+    const isSubMenu = level > 0;
     if (contextMenu?.[`${itemType}Title`] && !isSubMenu) {
       this[`_${itemType}TitleElm`] = document.createElement('div');
       this[`_${itemType}TitleElm`]!.className = 'slick-menu-title';
@@ -631,14 +636,15 @@ export class SlickContextMenu implements SlickPlugin {
       commandOrOptionMenuElm.appendChild(liElm);
 
       if (addClickListener) {
-        this._bindingEventService.bind(liElm, 'click', this.handleMenuItemClick.bind(this, item, itemType, args.level) as EventListener);
+        const eventGroup = isSubMenu ? 'sub-menu' : 'parent-menu';
+        this._bindingEventService.bind(liElm, 'click', this.handleMenuItemClick.bind(this, item, itemType, level) as EventListener, undefined, eventGroup);
       }
 
       // optionally open sub-menu(s) by mouseover
       if (this._contextMenuProperties.subMenuOpenByEvent === 'mouseover') {
         this._bindingEventService.bind(liElm, 'mouseover', ((e: DOMMouseOrTouchEvent<HTMLDivElement>) => {
           if ((item as MenuCommandItem).commandItems || (item as MenuOptionItem).optionItems) {
-            this.repositionSubMenu(item, itemType, args.level, e);
+            this.repositionSubMenu(item, itemType, level, e);
             this._lastMenuTypeClicked = itemType;
           } else if (!isSubMenu) {
             this.destroySubMenus();

--- a/src/plugins/slick.headermenu.ts
+++ b/src/plugins/slick.headermenu.ts
@@ -171,12 +171,16 @@ export class SlickHeaderMenu implements SlickPlugin {
 
   destroyAllMenus() {
     this.destroySubMenus();
+
+    // remove all parent menu listeners before removing them from the DOM
+    this._bindingEventService.unbindAll('parent-menu');
     document.querySelectorAll(`.slick-header-menu${this.getGridUidSelector()}`)
       .forEach(subElm => subElm.remove());
   }
 
   /** Close and destroy all previously opened sub-menus */
   destroySubMenus() {
+    this._bindingEventService.unbindAll('sub-menu');
     document.querySelectorAll(`.slick-header-menu.slick-submenu${this.getGridUidSelector()}`)
       .forEach(subElm => subElm.remove());
   }
@@ -425,7 +429,8 @@ export class SlickHeaderMenu implements SlickPlugin {
       menuElm.appendChild(menuItemElm);
 
       if (addClickListener) {
-        this._bindingEventService.bind(menuItemElm, 'click', this.handleMenuItemClick.bind(this, item, columnDef, level) as EventListener);
+        const eventGroup = isSubMenu ? 'sub-menu' : 'parent-menu';
+        this._bindingEventService.bind(menuItemElm, 'click', this.handleMenuItemClick.bind(this, item, columnDef, level) as EventListener, undefined, eventGroup);
       }
 
       // optionally open sub-menu(s) by mouseover


### PR DESCRIPTION
- when a sub-menu is closed, we remove it from the DOM but we also need to remove any click event listeners attached to all list items