### PR TITLE
fix: element `replaceChildren()` not supported by salesforce

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2203,7 +2203,7 @@ if (typeof Slick === "undefined") {
         _bindingEventService.unbindByEventName(column, 'mouseleave', handleHeaderMouseHoverOff);
       });
 
-      _container.replaceChildren();
+      utils.emptyElement(_container);
       _container.classList.remove(uid);
 
       if (shouldDestroyAllElements) {


### PR DESCRIPTION
- we can remove `.replaceChildren()` that is not supported in Salesforce (it basically doesn't like any functions targeting HTML Node instead of HTML Element), however we can simply replace the usage with our own `Utils.emptyElement(container);`

![image](https://github.com/6pac/SlickGrid/assets/643976/a1592ed2-64d6-4f09-b4ad-6ab5885612bf)
