### PR TITLE
fix: add `allowDragFromClosest` to make `.slick-cell` or child draggable

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -618,6 +618,7 @@ if (typeof Slick === "undefined") {
           slickDraggableInstance = Slick.Draggable({
             containerElement: _container,
             allowDragFrom: 'div.slick-cell',
+            allowDragFromClosest: 'div.slick-cell',
             onDragInit: handleDragInit,
             onDragStart: handleDragStart,
             onDrag: handleDrag,

--- a/slick.interactions.js
+++ b/slick.interactions.js
@@ -14,6 +14,7 @@
    * available optional options:
    *   - containerElement: container DOM element, defaults to "document"
    *   - allowDragFrom: when defined, only allow dragging from an element that matches a specific query selector
+   *   - allowDragFromClosest: when defined, only allow dragging from an element or its parent matching a specific .closest() query selector
    *   - onDragInit: drag initialized callback
    *   - onDragStart: drag started callback
    *   - onDrag: drag callback
@@ -61,7 +62,7 @@
       const targetEvent = event.touches ? event.touches[0] : event;
       const { target } = targetEvent;
 
-      if (!options.allowDragFrom || (options.allowDragFrom && element.matches(options.allowDragFrom))) {
+      if (!options.allowDragFrom || (options.allowDragFrom && (element.matches(options.allowDragFrom)) || (options.allowDragFromClosest && element.closest(options.allowDragFromClosest)))) {
         originaldd.dragHandle = element;
         const winScrollPos = windowScrollPosition(element);
         startX = winScrollPos.left + targetEvent.clientX;


### PR DESCRIPTION
- backported to v4.x from master branch PR #897 