### PR TITLE
fix: create CSS rules by style element doesn't work in salesforce

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2060,17 +2060,23 @@ if (typeof Slick === "undefined") {
       document.head.appendChild(_style);
       (options.shadowRoot || document.head).appendChild(_style);
 
+      const rowHeight = (options.rowHeight - cellHeightDiff);
+      const rules = [
+        `.${uid} .slick-group-header-column { left: 1000px; }`,
+        `.${uid} .slick-header-column { left: 1000px; }`,
+        `.${uid} .slick-top-panel { height: ${options.topPanelHeight}px; }`,
+        `.${uid} .slick-preheader-panel { height: ${options.preHeaderPanelHeight}px; }`,
+        `.${uid} .slick-headerrow-columns { height: ${options.headerRowHeight}px; }`,
+        `.${uid} .slick-footerrow-columns { height: ${options.footerRowHeight}px; }`,
+        `.${uid} .slick-cell { height: ${rowHeight}px; }`,
+        `.${uid} .slick-row { height: ${options.rowHeight}px; }`,
+      ];
+
       const sheet = _style.sheet;
       if (sheet) {
-        const rowHeight = (options.rowHeight - cellHeightDiff);
-        sheet.insertRule(`.${uid} .slick-group-header-column { left: 1000px; }`);
-        sheet.insertRule(`.${uid} .slick-header-column { left: 1000px; }`);
-        sheet.insertRule(`.${uid} .slick-top-panel { height: ${options.topPanelHeight}px; }`);
-        sheet.insertRule(`.${uid} .slick-preheader-panel { height: ${options.preHeaderPanelHeight}px; }`);
-        sheet.insertRule(`.${uid} .slick-headerrow-columns { height: ${options.headerRowHeight}px; }`);
-        sheet.insertRule(`.${uid} .slick-footerrow-columns { height: ${options.footerRowHeight}px; }`);
-        sheet.insertRule(`.${uid} .slick-cell { height: ${rowHeight}px; }`);
-        sheet.insertRule(`.${uid} .slick-row { height: ${options.rowHeight}px; }`);
+        for (let rule of rules) {
+          sheet.insertRule(rule);
+        }
 
         for (let i = 0; i < columns.length; i++) {
           if (!columns[i] || columns[i].hidden) { continue; }
@@ -2078,6 +2084,31 @@ if (typeof Slick === "undefined") {
           sheet.insertRule(`.${uid} .l${i} { }`);
           sheet.insertRule(`.${uid} .r${i} { }`);
         }
+      } else {
+        // in case the 1st approach doesn't work, let's use our previous way of create the rules which is what works in Salesforce :(
+        createCssRulesAlternative(rules);
+      }
+    }
+
+    /** Create CSS rules via template in case the first approach with createElement('style') doesn't work */
+    function createCssRulesAlternative(rules) {
+      const template = document.createElement('template');
+      template.innerHTML = '<style type="text/css" rel="stylesheet" />';
+      _style = template.content.firstChild;
+      document.head.appendChild(_style);
+      (options.shadowRoot || document.head).appendChild(_style);
+
+      for (let i = 0; i < columns.length; i++) {
+        if (!columns[i] || columns[i].hidden) continue;
+
+        rules.push(`.${uid} .l${i} { }`);
+        rules.push(`.${uid} .r${i} { }`);
+      }
+
+      if (_style.styleSheet) { // IE
+        _style.styleSheet.cssText = rules.join(" ");
+      } else {
+        _style.appendChild(document.createTextNode(rules.join(" ")));
       }
     }
 

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2057,7 +2057,6 @@ if (typeof Slick === "undefined") {
     function createCssRules() {
       _style = document.createElement('style');
       _style.nonce = 'random-string';
-      document.head.appendChild(_style);
       (options.shadowRoot || document.head).appendChild(_style);
 
       const rowHeight = (options.rowHeight - cellHeightDiff);
@@ -2085,7 +2084,7 @@ if (typeof Slick === "undefined") {
           sheet.insertRule(`.${uid} .r${i} { }`);
         }
       } else {
-        // in case the 1st approach doesn't work, let's use our previous way of create the rules which is what works in Salesforce :(
+        // fallback in case the 1st approach doesn't work, let's use our previous way of creating the css rules which is what works in Salesforce :(
         createCssRulesAlternative(rules);
       }
     }
@@ -2095,7 +2094,6 @@ if (typeof Slick === "undefined") {
       const template = document.createElement('template');
       template.innerHTML = '<style type="text/css" rel="stylesheet" />';
       _style = template.content.firstChild;
-      document.head.appendChild(_style);
       (options.shadowRoot || document.head).appendChild(_style);
 
       for (let i = 0; i < columns.length; i++) {


### PR DESCRIPTION
- for some reason the new approach to use `const style = document.createElement('style')` and then `style.sheet` doesn't work in Salesforce, so let's add back the previous code as a fallback in case option 1 doesn't work