### PR TITLE
fix: misaligned column headers after horizontal scroll then freeze

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -3468,6 +3468,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.invalidateRow(this.getDataLength());
     }
 
+    // before applying column freeze, we need our viewports to be scrolled back to left to avoid misaligned column headers
+    if (args.frozenColumn) {
+      this.getViewports().forEach(vp => vp.scrollLeft = 0);
+      this.handleScroll(); // trigger scroll to realign column headers as well
+    }
+
     const originalOptions = Utils.extend(true, {}, this._options);
     this._options = Utils.extend(this._options, args);
     this.trigger(this.onSetOptions, { optionsBefore: originalOptions, optionsAfter: this._options });


### PR DESCRIPTION
this fixes a bug reported in this Stack Overflow: https://stackoverflow.com/q/77408111/1212166

![msedge_nuwBH9gZdn](https://github.com/6pac/SlickGrid/assets/643976/c6140bda-82ca-4097-a444-be35fef48ad6)

#### after the fix

![msedge_P9mu8Cukra](https://github.com/6pac/SlickGrid/assets/643976/638bb3f5-8ce5-42af-930b-9983d8ca4426)
