### PR TITLE
fix: add `nonce` grid option set the nonce value for CSP header (#902)

### DIFF
--- a/examples/example-csp-header.html
+++ b/examples/example-csp-header.html
@@ -4,8 +4,8 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css"/>
   <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css"/>
-  <!-- <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://cdn.jsdelivr.net 'nonce-random-string' 'nonce-browser-sync'; require-trusted-types-for 'script'; trusted-types dompurify"> -->
-  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'; trusted-types dompurify">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net 'nonce-browser-sync'; style-src 'self' 'nonce-random-string'; require-trusted-types-for 'script'; trusted-types dompurify">
+  <!-- <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'; trusted-types dompurify"> -->
 </head>
 <body>
 <table width="100%">

--- a/examples/example-csp-header.html
+++ b/examples/example-csp-header.html
@@ -4,8 +4,8 @@
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css"/>
   <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css"/>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net 'nonce-browser-sync'; style-src 'self' 'nonce-random-string'; require-trusted-types-for 'script'; trusted-types dompurify">
-  <!-- <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'; trusted-types dompurify"> -->
+  <!-- <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net 'nonce-browser-sync'; style-src 'self' 'nonce-random-string'; require-trusted-types-for 'script'; trusted-types dompurify"> -->
+  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'; trusted-types dompurify">
 </head>
 <body>
 <table width="100%">

--- a/examples/example-csp-header.js
+++ b/examples/example-csp-header.js
@@ -11,6 +11,7 @@ var columns = [
 var options = {
   enableCellNavigation: true,
   enableColumnReorder: false,
+  nonce: 'random-string',
   sanitizer: (html) => DOMPurify.sanitize(html, { RETURN_TRUSTED_TYPE: true })
 };
 

--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -44,6 +44,11 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   auto?: boolean;
 
   /**
+   * Added for CSP header because of dynamic css generation.
+   */
+  nonce?: string;
+
+  /**
    * Defaults to false, when enabled will try to commit the current edit without focusing on the next row.
    * If a custom editor is implemented and the grid cannot auto commit, you must use this option to implement it yourself
    */

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -226,6 +226,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     enableAsyncPostRenderCleanup: false,
     asyncPostRenderCleanupDelay: 40,
     auto: false,
+    nonce: '',
     editorLock: GlobalEditorLock,
     showColumnHeader: true,
     showHeaderRow: false,
@@ -2304,7 +2305,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   protected createCssRules() {
     this._style = document.createElement('style');
-    this._style.nonce = 'random-string';
+    this._style.nonce = this._options.nonce || '';
     (this._options.shadowRoot || document.head).appendChild(this._style);
 
     const rowHeight = (this._options.rowHeight! - this.cellHeightDiff);


### PR DESCRIPTION
* Made the user set the nonce value
- cherry-picked commit commit cb39c7a from PR #902 to merge into `master` branch
   - however I had to put back previous CSP header since the master branch doesn't remove all `innerHTML` (which is in a separate draft PR)