### PR TITLE
fix: improve build & types exports for all targets, Node, CJS/ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
       "require": "./dist/cjs/index.js",
       "default": "./dist/esm/index.js"
     },
+    "./dist/styles/*": "./dist/styles/*",
     "./package.json": "./package.json"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -2,24 +2,25 @@
   "name": "slickgrid",
   "version": "5.4.2",
   "description": "A lightning fast JavaScript grid/spreadsheet",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/browser/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/browser/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/cjs/index.js",
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "directories": {
     "example": "examples",
     "test": "tests"


### PR DESCRIPTION
- previous implementation didn't pass all type exports as can be shown in [Are the types wrong?](https://arethetypeswrong.github.io/?p=slickgrid) website, already applied the changes in `multiple-select-vanilla` library with a much greater success
- better approach came from RxJS [package.json](https://github.com/ReactiveX/rxjs/blob/master/packages/rxjs/package.json) which is a great implementation of it

![image](https://github.com/6pac/SlickGrid/assets/643976/9ed4dee7-136d-4faf-9729-e004672a723b)
