### PR TITLE
fix: interface for controls/plugins w/Formatter might return HTMLElement

### DIFF
--- a/src/controls/slick.columnmenu.ts
+++ b/src/controls/slick.columnmenu.ts
@@ -157,7 +157,7 @@ export class SlickColumnMenu {
 
       const labelElm = document.createElement('label');
       labelElm.htmlFor = `${this._gridUid}colpicker-${columnId}`;
-      labelElm.innerHTML = this.grid.sanitizeHtmlString(columnLabel);
+      labelElm.innerHTML = this.grid.sanitizeHtmlString(columnLabel instanceof HTMLElement ? columnLabel.innerHTML : columnLabel);
       liElm.appendChild(labelElm);
       this._listElm.appendChild(liElm);
     }

--- a/src/controls/slick.columnpicker.ts
+++ b/src/controls/slick.columnpicker.ts
@@ -158,7 +158,7 @@ export class SlickColumnPicker {
 
       const labelElm = document.createElement('label');
       labelElm.htmlFor = `${this._gridUid}colpicker-${columnId}`;
-      labelElm.innerHTML = this.grid.sanitizeHtmlString(columnLabel);
+      labelElm.innerHTML = this.grid.sanitizeHtmlString(columnLabel instanceof HTMLElement ? columnLabel.innerHTML : columnLabel);
       liElm.appendChild(labelElm);
       this._listElm.appendChild(liElm);
     }

--- a/src/controls/slick.gridmenu.ts
+++ b/src/controls/slick.gridmenu.ts
@@ -592,7 +592,7 @@ export class SlickGridMenu {
 
       const labelElm = document.createElement('label');
       labelElm.htmlFor = `${this._gridUid}-gridmenu-colpicker-${columnId}`;
-      labelElm.innerHTML = this.grid.sanitizeHtmlString(columnLabel || '');
+      labelElm.innerHTML = this.grid.sanitizeHtmlString((columnLabel instanceof HTMLElement ? columnLabel.innerHTML : columnLabel) || '');
       liElm.appendChild(labelElm);
       this._listElm.appendChild(liElm);
     }

--- a/src/models/columnPicker.interface.ts
+++ b/src/models/columnPicker.interface.ts
@@ -33,7 +33,7 @@ export interface ColumnPickerOption {
   syncResizeTitle?: string;
 
   /** Callback method to override the column name output used by the ColumnPicker/GridMenu. */
-  headerColumnValueExtractor?: (column: Column, gridOptions?: GridOption) => string;
+  headerColumnValueExtractor?: (column: Column, gridOptions?: GridOption) => string | HTMLElement;
 }
 
 export interface OnColumnsChangedArgs {

--- a/src/models/gridMenuOption.interface.ts
+++ b/src/models/gridMenuOption.interface.ts
@@ -86,7 +86,7 @@ export interface GridMenuOption {
   // action/override callbacks
 
   /** Callback method to override the column name output used by the ColumnPicker/GridMenu. */
-  headerColumnValueExtractor?: (column: Column, gridOptions?: GridOption) => string;
+  headerColumnValueExtractor?: (column: Column, gridOptions?: GridOption) => string | HTMLElement;
 
   /** Callback method that user can override the default behavior of enabling/disabling an item from the list. */
   menuUsabilityOverride?: (args: MenuCallbackArgs<any>) => boolean;

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -2615,8 +2615,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (typeof columnOrIndexOrId === 'number') {
       colDef = this.columns[columnOrIndexOrId];
       colIndex = columnOrIndexOrId;
-    }
-    else if (typeof columnOrIndexOrId === 'string') {
+    } else if (typeof columnOrIndexOrId === 'string') {
       for (let i = 0; i < this.columns.length; i++) {
         if (this.columns[i].id === columnOrIndexOrId) { colDef = this.columns[i]; colIndex = i; }
       }
@@ -3836,8 +3835,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     rowDiv.style.top = `${(this.getRowTop(row) - frozenRowOffset)}px`;
     divArrayL.push(rowDiv);
     if (this.hasFrozenColumns()) {
-      //it has to be a deep copy otherwise we will have issues with pass by reference in js since
-      //attempting to add the same element to 2 different arrays will just move 1 item to the other array
+      // it has to be a deep copy otherwise we will have issues with pass by reference in js since
+      // attempting to add the same element to 2 different arrays will just move 1 item to the other array
       rowDivR = rowDiv.cloneNode(true) as HTMLElement;
       divArrayR.push(rowDivR);
     }
@@ -4693,12 +4692,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     const x = document.createElement('div');
     const xRight = document.createElement('div');
-    divArrayL.forEach(elm => {
-      x.appendChild(elm as HTMLElement);
-    });
-    divArrayR.forEach(elm => {
-      xRight.appendChild(elm as HTMLElement);
-    });
+    divArrayL.forEach(elm => x.appendChild(elm as HTMLElement));
+    divArrayR.forEach(elm => xRight.appendChild(elm as HTMLElement));
+
     for (let i = 0, ii = rows.length; i < ii; i++) {
       if ((this.hasFrozenRows) && (rows[i] >= this.actualFrozenRow)) {
         if (this.hasFrozenColumns()) {


### PR DESCRIPTION
- some interfaces were not fully updated in PR #894 which brought the possibility of passing HTMLElement to Formatter, then after updating these interfaces it was found that some controls/plugins did not handled the HTMLElement possibility