### PR TITLE
fix: Draggable shouldn't trigger dragEnd without first dragging

### DIFF
--- a/slick.interactions.js
+++ b/slick.interactions.js
@@ -97,15 +97,19 @@
     }
 
     function userReleased(event) {
-      const { target } = event;
-      originaldd = Object.assign(originaldd, { target });
-      executeDragCallbackWhenDefined(onDragEnd, event, originaldd);
       document.removeEventListener('mousemove', userMoved);
       document.removeEventListener('touchmove', userMoved);
       document.removeEventListener('mouseup', userReleased);
       document.removeEventListener('touchend', userReleased);
       document.removeEventListener('touchcancel', userReleased);
-      dragStarted = false;
+
+      // trigger a dragEnd event only after dragging started and stopped
+      if (dragStarted) {
+        const { target } = event;
+        originaldd = Object.assign(originaldd, { target });
+        executeDragCallbackWhenDefined(onDragEnd, event, originaldd);
+        dragStarted = false;
+      }
     }
 
     function windowScrollPosition() {


### PR DESCRIPTION
- the `onDragEnd` was called every time a cell was clicked even when user was not even dragging, we should make sure to only trigger `onDragEnd` if a drag actually started to avoid triggering too many events for no reasons