### PR TITLE
fix(common): cell range decorator should be hidden after onDragEnd

### DIFF
--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -352,6 +352,7 @@
     }
 
     function handleDragEnd(e, dd) {
+      _decorator.hide();
       if (!_dragging) {
         return;
       }
@@ -360,7 +361,6 @@
       e.stopImmediatePropagation();
 
       stopIntervalTimer();
-      _decorator.hide();
       _self.onCellRangeSelected.notify({
         range: new Slick.Range(
           dd.range.start.row,


### PR DESCRIPTION
- issue was found when user has an Editor open and then click on a row checkbox and start dragging that row checkbox cell, then the cell range decorator appears but never goes away because checkbox plugin has prevents event bubbling when having an editor and in turns wasn't destroying the cell range decorator when it should, the cell range decorator isn't visible but it has a z-index of 9999 and even though it's invisible it was showing on top of everything else making the cell behind it unclickable for the size of the cell range decorator (usually about the size of 2-3 cells)