### PR TITLE
fix(common): cell range decorator should be hidden after onDragEnd

### DIFF
--- a/src/plugins/slick.cellrangeselector.ts
+++ b/src/plugins/slick.cellrangeselector.ts
@@ -365,6 +365,7 @@ export class SlickCellRangeSelector implements SlickPlugin {
   }
 
   protected handleDragEnd(e: Event, dd: DragPosition) {
+    this._decorator.hide();
     if (!this._dragging) {
       return;
     }
@@ -373,7 +374,6 @@ export class SlickCellRangeSelector implements SlickPlugin {
     e.stopImmediatePropagation();
 
     this.stopIntervalTimer();
-    this._decorator.hide();
     this.onCellRangeSelected.notify({
       range: new SlickRange(
         dd.range.start.row ?? 0,


### PR DESCRIPTION
- issue was found when user has an Editor open and then click on a row checkbox and start dragging that row checkbox cell, then the cell range decorator appears but never goes away because checkbox plugin has prevents event bubbling when having an editor and in turns wasn't destroying the cell range decorator when it should, the cell range decorator isn't visible but it has a z-index of 9999 and even though it's invisible it was showing on top of everything else making the cell behind it unclickable for the size of the cell range selection decorator (usually about the size of 2-3 cells)