### PR TITLE
fix: `applyHtmlCode` util should always clear targeted native element

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -518,17 +518,21 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /**
    * Apply HTML code by 3 different ways depending on what is provided as input and what options are enabled.
-   * 1. value is an HTMLElement, then simply append the HTML to the target element.
+   * 1. value is an HTMLElement or DocumentFragment, then first empty the target and simply append the HTML to the target element.
    * 2. value is string and `enableHtmlRendering` is enabled, then use `target.innerHTML = value;`
    * 3. value is string and `enableHtmlRendering` is disabled, then use `target.textContent = value;`
    * @param target - target element to apply to
    * @param val - input value can be either a string or an HTMLElement
    */
-  applyHtmlCode(target: HTMLElement, val: string | HTMLElement | DocumentFragment) {
+  applyHtmlCode(target: HTMLElement, val: string | HTMLElement | DocumentFragment, emptyTarget = true) {
     if (target) {
       if (val instanceof HTMLElement || val instanceof DocumentFragment) {
+        // first empty target and then append new HTML element
+        if (emptyTarget) {
+          Utils.emptyElement(target);
+        }
         target.appendChild(val);
-      } else if (typeof val === 'string') {
+      } else {
         if (this._options.enableHtmlRendering) {
           target.innerHTML = this.sanitizeHtmlString(val as string);
         } else {


### PR DESCRIPTION
- when calling `applyHtmlCode` when a native element, we use `appendChild` but of course that will append to what already exist, however in the case of the util we should always clear the target element first since that is what we do when passing html string (assigning with `innerHTML` will overwrite any previous content)
- this was caught in one of the example when collapsing groups, we ended up seeing duplicate groups and this came up after converting SlickGroupItemMetadataProvider Formatter to return native element

![image](https://github.com/6pac/SlickGrid/assets/643976/93a27318-a63d-4abd-969f-3eecb0ecac72)
