### PR TITLE
perf: skip reapplying empty html when target is already empty

### DIFF
--- a/src/slick.core.ts
+++ b/src/slick.core.ts
@@ -787,7 +787,7 @@ export class Utils {
   }
 
   public static isDefined<T>(value: T | undefined | null): value is T {
-    return <T>value !== undefined && <T>value !== null;
+    return <T>value !== undefined && <T>value !== null && <T>value !== '';
   }
 
   public static getElementProp(elm: HTMLElement & { getComputedStyle?: () => CSSStyleDeclaration }, property: string) {

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -523,17 +523,28 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * 3. value is string and `enableHtmlRendering` is disabled, then use `target.textContent = value;`
    * @param target - target element to apply to
    * @param val - input value can be either a string or an HTMLElement
+   * @param options -
+   *   `emptyTarget`, defaults to true, will empty the target.
+   *   `skipEmptyReassignment`, defaults to true, when enabled it will not try to reapply an empty value when the target is already empty
    */
-  applyHtmlCode(target: HTMLElement, val: string | HTMLElement | DocumentFragment, emptyTarget = true) {
+  applyHtmlCode(target: HTMLElement, val: string | HTMLElement | DocumentFragment, options?: { emptyTarget?: boolean; skipEmptyReassignment?: boolean; }) {
     if (target) {
       if (val instanceof HTMLElement || val instanceof DocumentFragment) {
         // first empty target and then append new HTML element
+        const emptyTarget = options?.emptyTarget !== false;
         if (emptyTarget) {
           Utils.emptyElement(target);
         }
         target.appendChild(val);
       } else {
-        if (this._options.enableHtmlRendering) {
+        // when it's already empty and we try to reassign empty, it's probably ok to skip the assignment
+        const skipEmptyReassignment = options?.skipEmptyReassignment !== false;
+        if (skipEmptyReassignment && !Utils.isDefined(val) && !target.innerHTML) {
+          return;
+        }
+
+        // apply HTML when enableHtmlRendering is enabled but make sure we do have a value (without a value, it will simply use `textContent` to clear text content)
+        if (this._options.enableHtmlRendering && val) {
           target.innerHTML = this.sanitizeHtmlString(val as string);
         } else {
           target.textContent = this.sanitizeHtmlString(val as string);


### PR DESCRIPTION
- when calling `applyHtmlCode()` method and our target element is empty and we try to reapply empty, it should always be ok to simply skip this reassignment because the end result is exactly the same
- this should also help with performance since trying to reapply empty using `innerHTML` will probably cause a canvas repaint but if we manage to skip this assignment then a repaint will also be skipped
- it should help as well for CSP because we could write a Formatter with native element while still returning empty string when there's no value to return, that will then call `applyHtmlCode` and skip the assignment if the cell is already empty

for example the code below would be 100% CSP Safe and iinterpreted by SlickGrid as native without using `innerHTML` at all
```ts
function myNativePercentFormatter(cell, row, val) {
  if (!val) {
    return ''; // we still want to accept empty string (or `null`) without calling innerHTML in SlickGrid
  }
  // when value is defined, return a native HTML element
  const div = document.createElement('div');
  div.textContent = `${val / 100}%`;
  return div;
}
```