### PR TITLE
fix: only allow row drag on cell w/`dnd` or `cell-reorder`, fix #937

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -858,8 +858,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (Draggable) {
         this.slickDraggableInstance = Draggable({
           containerElement: this._container,
-          // the slick cell must contain `.dnd` and/or `.cell-reorder` class to be identified as draggable
-          allowDragFrom: 'div.slick-cell.dnd, div.slick-cell.cell-reorder',
+          allowDragFrom: 'div.slick-cell',
+          // the slick cell parent must always contain `.dnd` and/or `.cell-reorder` class to be identified as draggable
           allowDragFromClosest: 'div.slick-cell.dnd, div.slick-cell.cell-reorder',
           onDragInit: this.handleDragInit.bind(this),
           onDragStart: this.handleDragStart.bind(this),


### PR DESCRIPTION
- a previous PR #897 caused a regression on a cell with a select dropdown (like `Slick.Editors.YesNoSelect`), the regression was caused by the implementation of Draggable `allowDragFromClosest` which will check if current DOM element is `.slick-cell` or if not it will also try its parent and that caused the regression because the cell with the editor also had a `.slick-cell` and so the code taught that the user started a drag and it cancelled event bubbling which in turn also prevented the select dropdown to be clickable.
- to fix this issue we need to make sure that the cell is queried not just with `div.slick-cell` but also with certain CSS classes, we need to check if it has either `.dnd` or `.cell-reorder` to permit the dragging