### PR TITLE
fix: only allow row drag on cell w/`dnd` or `cell-reorder`

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -618,8 +618,8 @@ if (typeof Slick === "undefined") {
         if (Slick.Draggable) {
           slickDraggableInstance = Slick.Draggable({
             containerElement: _container,
-            // the slick cell must contain `.dnd` and/or `.cell-reorder` class to be identified as draggable
-            allowDragFrom: 'div.slick-cell.dnd, div.slick-cell.cell-reorder',
+            allowDragFrom: 'div.slick-cell',
+            // the slick cell parent must always contain `.dnd` and/or `.cell-reorder` class to be identified as draggable
             allowDragFromClosest: 'div.slick-cell.dnd, div.slick-cell.cell-reorder',
             onDragInit: handleDragInit,
             onDragStart: handleDragStart,

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -618,8 +618,9 @@ if (typeof Slick === "undefined") {
         if (Slick.Draggable) {
           slickDraggableInstance = Slick.Draggable({
             containerElement: _container,
-            allowDragFrom: 'div.slick-cell',
-            allowDragFromClosest: 'div.slick-cell',
+            // the slick cell must contain `.dnd` and/or `.cell-reorder` class to be identified as draggable
+            allowDragFrom: 'div.slick-cell.dnd, div.slick-cell.cell-reorder',
+            allowDragFromClosest: 'div.slick-cell.dnd, div.slick-cell.cell-reorder',
             onDragInit: handleDragInit,
             onDragStart: handleDragStart,
             onDrag: handleDrag,


### PR DESCRIPTION
- a previous PR #898 caused a regression on a cell with a select dropdown (like `Slick.Editors.YesNoSelect`), the regression was caused by the implementation of Draggable `allowDragFromClosest` which will check if current DOM element is `.slick-cell` or if not it will also try its parent and that caused the regression because the cell with the editor also had a `.slick-cell` and so the code taught that the user started a drag and it cancelled event bubbling which in turn also prevented the select dropdown to be clickable.
- to fix this issue we need to make sure that the cell is queried not just with `div.slick-cell` but also with certain CSS classes, we need to check if parent has either `.dnd` or `.cell-reorder` to permit the dragging when checking parent cell with `allowDragFromClosest` 