### PR TITLE
fix: Draggable Grouping, destroy all Sortable instances fixes mem leak

### DIFF
--- a/src/plugins/slick.draggablegrouping.ts
+++ b/src/plugins/slick.draggablegrouping.ts
@@ -252,6 +252,9 @@ export class SlickDraggableGrouping {
    */
   destroy() {
     this.destroySortableInstances();
+    if (this._droppableInstance?.el) {
+      this._droppableInstance?.destroy();
+    }
     this.onGroupChanged.unsubscribe();
     this._handler.unsubscribeAll();
     this._bindingEventService.unbindAll();


### PR DESCRIPTION
- the drop box had a Sortable instance that was not destroyed causing it to not be garbage collected (mem leak)