### PR TITLE
feat: introduce devMode to support nodejs based unit testing

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -114,7 +114,8 @@ if (typeof Slick === "undefined") {
       maxSupportedCssHeight: 1000000000,
       sanitizer: undefined,  // sanitize function, built in basic sanitizer is: Slick.RegexSanitizer(dirtyHtml)
       logSanitizedHtml: false, // log to console when sanitised - recommend true for testing of dev and production
-      shadowRoot: undefined
+      shadowRoot: undefined,
+      devMode: false
     };
 
     var columnDefaults = {
@@ -2116,6 +2117,11 @@ if (typeof Slick === "undefined") {
       var i;
       if (!stylesheet) {
         var sheets = (options.shadowRoot || document).styleSheets;
+
+        if (options.devMode?.ownerNodeIndex >= 0) {
+          sheets[options.devMode.ownerNodeIndex].ownerNode = _style;
+        }
+
         for (i = 0; i < sheets.length; i++) {
           if ((sheets[i].ownerNode || sheets[i].owningElement) == _style) {
             stylesheet = sheets[i];
@@ -3765,7 +3771,7 @@ if (typeof Slick === "undefined") {
     }
 
     function getViewportWidth() {
-      viewportW = parseFloat(utils.innerSize(_container, 'width'));
+      viewportW = parseFloat(utils.innerSize(_container, 'width')) || options.devMode?.containerClientWidth;
     }
 
     function resizeCanvas() {


### PR DESCRIPTION
as the title suggests this is meant to make unit/integration tests, e.g with testing-library, possible for apps using Slickgrid. In my specific case I'm making use of angular-slickgrid and would like to be able to test my app using angular-testing-library.

The introduced devMode workarounds are in order to work around the following jsdom issues:
* https://github.com/jsdom/jsdom/issues/2310 (missing clientWidth)
* https://github.com/jsdom/jsdom/issues/992 (missing ownerNode, even with a nice reference to Slickgrid ;) )

For additional conversations about this topic please refer to https://github.com/ghiscoding/Angular-Slickgrid/discussions/1319

P.S.: if this PR is fine I can later create an additional one targeting the master branch