### PR TITLE
Update slick.checkboxselectcolumn.ts

### DIFF
--- a/src/plugins/slick.checkboxselectcolumn.ts
+++ b/src/plugins/slick.checkboxselectcolumn.ts
@@ -338,7 +338,7 @@ export class SlickCheckboxSelectColumn<T = any> implements SlickPlugin {
   getColumnDefinition() {
     return {
       id: this._options.columnId,
-      name: (this._options.hideSelectAllCheckbox || this._options.hideInColumnTitleRow) ? '' : `<input id="header-selector${this._selectAll_UID}" type="checkbox"><label for="header-selector${this._selectAll_UID}"></label>`,
+      name: (this._options.hideSelectAllCheckbox || this._options.hideInColumnTitleRow) ? this._options.name : `<input id="header-selector${this._selectAll_UID}" type="checkbox"><label for="header-selector${this._selectAll_UID}"></label>`,
       toolTip: (this._options.hideSelectAllCheckbox || this._options.hideInColumnTitleRow) ? '' : this._options.toolTip,
       field: "sel",
       width: this._options.width,


### PR DESCRIPTION
When fetching the column description, just because we don't want a select all / select none in the heading, it doesn't mean we don't want the actual column heading - it makes more sense to return the columns defined heading (aka name) and if the user doesn't want anything in there, put an empty string.