### PR TITLE
feat: introduce devMode to support nodejs based unit testing

### DIFF
--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -108,6 +108,9 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   /** Default cell Formatter that will be used by the grid */
   defaultFormatter?: Formatter;
 
+  /** Escape hatch geared towards testing Slickgrid in jsdom based environments to circumvent the lack of stylesheet.ownerNode and clientWidth calculations */
+  devMode?: false & { ownerNodeIndex?: number; containerClientWidth?: number; };
+
   /** Do we have paging enabled? */
   doPaging?: boolean;
 

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -2468,7 +2468,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (!this.stylesheet) {
       const sheets: any = (this._options.shadowRoot || document).styleSheets;
 
-      if (typeof this.options.devMode?.ownerNodeIndex == "number" &&  this.options.devMode.ownerNodeIndex >= 0) {
+      if (typeof this.options.devMode?.ownerNodeIndex === "number" &&  this.options.devMode.ownerNodeIndex >= 0) {
         sheets[this.options.devMode.ownerNodeIndex].ownerNode = this._style;
       }
 

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -2467,6 +2467,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     let i: number;
     if (!this.stylesheet) {
       const sheets: any = (this._options.shadowRoot || document).styleSheets;
+
+      if (typeof this.options.devMode?.ownerNodeIndex == "number" &&  this.options.devMode.ownerNodeIndex >= 0) {
+        sheets[this.options.devMode.ownerNodeIndex].ownerNode = this._style;
+      }
+
       for (i = 0; i < sheets.length; i++) {
         if ((sheets[i].ownerNode || sheets[i].owningElement) === this._style) {
           this.stylesheet = sheets[i];
@@ -4285,7 +4290,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   getViewportWidth() {
-    this.viewportW = parseFloat(Utils.innerSize(this._container, 'width') as unknown as string);
+    this.viewportW = parseFloat(Utils.innerSize(this._container, 'width') as unknown as string) || this.options.devMode?.containerClientWidth || 0;
     return this.viewportW;
   }
 


### PR DESCRIPTION
as the title suggests this is meant to make unit/integration tests, e.g with testing-library, possible for apps using Slickgrid. In my specific case I'm making use of angular-slickgrid and would like to be able to test my app using angular-testing-library.

The introduced devMode workarounds are in order to work around the following jsdom issues:

https://github.com/jsdom/jsdom/issues/2310 (missing clientWidth)
https://github.com/jsdom/jsdom/issues/992 (missing ownerNode, even with a nice reference to Slickgrid ;) )
For additional conversations about this topic please refer to https://github.com/ghiscoding/Angular-Slickgrid/discussions/1319