### PR TITLE
fix: regression, Row Detail no longer displayed after CSP safe code

### DIFF
--- a/cypress/e2e/example-row-detail-selection-and-move.cy.ts
+++ b/cypress/e2e/example-row-detail-selection-and-move.cy.ts
@@ -1,13 +1,6 @@
 describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
     const fullTitles = ['', '', '', '#', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
 
-    beforeEach(() => {
-        // create a console.log spy for later use
-        cy.window().then((win) => {
-            cy.spy(win.console, "log");
-        });
-    });
-
     it('should display Example Row Detail/Row Move/Checkbox Selector Plugins', () => {
         cy.visit(`${Cypress.config('baseUrl')}/examples/example-row-detail-selection-and-move.html`);
         cy.get('h2').should('contain', 'Demonstrates:');
@@ -26,7 +19,7 @@ describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
             .click()
             .wait(250);
 
-        cy.get('.innerDetailView_3')
+      cy.get('.slick-cell + .dynamic-cell-detail .innerDetailView_3')
             .find('h2')
             .should('contain', 'Task 3');
 
@@ -158,7 +151,7 @@ describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
             .click()
             .wait(250);
 
-        cy.get('.innerDetailView_3')
+      cy.get('.slick-cell + .dynamic-cell-detail .innerDetailView_3')
             .find('h2')
             .should('contain', 'Task 3');
 

--- a/cypress/e2e/example16-row-detail.cy.ts
+++ b/cypress/e2e/example16-row-detail.cy.ts
@@ -1,0 +1,79 @@
+describe('Example - Row Detail/Row Move/Checkbox Selector Plugins', () => {
+  const GRID_ROW_HEIGHT = 25;
+  const fullTitles = ['', '#', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
+
+  it('should display Example Row Detail/Row Move/Checkbox Selector Plugins', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example16-row-detail.html`);
+    cy.get('h2').should('contain', 'Demonstrates:');
+    cy.get('li').should('contain', 'RowDetailView Plugin');
+  });
+
+  it('should have exact Column Titles in the grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+  });
+
+  it('should open the 1st Row Detail of the 2nd row and expect to find some details', () => {
+    cy.get('.slick-cell.detailView-toggle:nth(1)')
+      .click()
+      .wait(50);
+
+    cy.get('.slick-cell + .dynamic-cell-detail .detailViewContainer_1')
+      .find('h4')
+      .should('contain', 'Task 1');
+
+    cy.get('input[id="assignee_1"]')
+      .should('exist');
+
+    cy.get('input[type="checkbox"]:checked')
+      .should('have.length', 0);
+  });
+
+  it('should open the 2nd Row Detail of the 4th row and expect to find some details', () => {
+    cy.get(`.slick-row[style="top: ${GRID_ROW_HEIGHT * 10}px;"] .slick-cell:nth(1)`)
+      .click()
+      .wait(50);
+
+    cy.get('.slick-cell + .dynamic-cell-detail .detailViewContainer_3')
+      .find('h4')
+      .should('contain', 'Task 3');
+
+    cy.get('input[id="assignee_3"]')
+      .should('exist');
+
+    cy.get('input[type="checkbox"]:checked')
+      .should('have.length', 0);
+  });
+
+  it('should be able to collapse all row details', () => {
+    cy.get('.dynamic-cell-detail').should('have.length', 2);
+    cy.get('[data-test="collapse-all-btn"]').click();
+    cy.get('.dynamic-cell-detail').should('have.length', 0);
+  });
+
+  it('should open the Task 3 Row Detail and still expect same detail', () => {
+    cy.get(`.slick-row[style="top: ${GRID_ROW_HEIGHT * 3}px;"] .slick-cell:nth(1)`)
+      .click()
+      .wait(50);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+
+    cy.get('.slick-cell + .dynamic-cell-detail .innerDetailView_3')
+      .find('h4')
+      .should('contain', 'Task 3');
+
+    cy.get('input[id="assignee_3"]')
+      .should('exist');
+  });
+
+  it('should click on "click me" and expect an Alert to show the Help text', () => {
+    cy.on('window:alert', (str) => {
+      expect(str).to.contain('Assignee is');
+    });
+
+    cy.contains('Click Me')
+      .click();
+  });
+});

--- a/examples/example16-row-detail.html
+++ b/examples/example16-row-detail.html
@@ -120,6 +120,8 @@
         <button onclick="detailView.setOptions({ loadOnce: true, useRowClick: detailView.useRowClick })">Load Once ON</button>
         &nbsp;
         <button onclick="detailView.setOptions({ loadOnce: false, useRowClick: detailView.useRowClick})">Load Once OFF</button>
+        &nbsp;
+        <button onclick="detailView.collapseAll()" data-test="collapse-all-btn">Collapse All</button>
       </p>
 	    <p>
 	      <input type="number" id="panelRowInput"/> <button onclick="setPanelRows()">Set Panel Rows Option</button>

--- a/src/models/formatterResultObject.interface.ts
+++ b/src/models/formatterResultObject.interface.ts
@@ -7,6 +7,13 @@ export interface FormatterResultObject {
 
   /** Optional tooltip text when hovering the cell div container. */
   toolTip?: string;
+
+  /**
+   * optionally insert an HTML element after the element target
+   * for example we use this technique to take a div containing the row detail and insert it after the `.slick-cell`
+   * e.g.: <div class="slick-cell"></div><div class="row-detail">...</div>
+   */
+  insertElementAfterTarget?: HTMLElement;
 }
 
 export interface FormatterResultWithText extends FormatterResultObject {

--- a/src/slick.core.ts
+++ b/src/slick.core.ts
@@ -820,6 +820,10 @@ export class Utils {
     return null;
   }
 
+  public static insertAfterElement(referenceNode: HTMLElement, newNode: HTMLElement) {
+    referenceNode.parentNode?.insertBefore(newNode, referenceNode.nextSibling);
+  }
+
   public static isEmptyObject(obj: any) {
     if (obj === null || obj === undefined) {
       return true;

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -4024,6 +4024,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
     divRow.appendChild(cellDiv);
 
+    // Formatter can optional add an "insertElementAfterTarget" option but it must be inserted only after the `.slick-row` div exists
+    if ((formatterResult as FormatterResultObject).insertElementAfterTarget) {
+      Utils.insertAfterElement(cellDiv, (formatterResult as FormatterResultObject).insertElementAfterTarget as HTMLElement);
+    }
+
     this.rowsCache[row].cellRenderQueue.push(cell);
     this.rowsCache[row].cellColSpans[cell] = colspan;
   }


### PR DESCRIPTION
with the CSP safe code implementation, the SlickRowDetail stopped working because it was using a hack. The hack was to using html string and add closing div tag to fall outside the `.slick-cell` but now that we use native HTML element then this hack no longer works. What we can do now is to add an optional `insertElementAfterTarget` that will provide a way to insert our Row Detail container element after our target which is this case is the `.slick-cell`

#### before 
![image](https://github.com/6pac/SlickGrid/assets/643976/b866c7fa-c4cc-48ef-9039-53338e142972)

#### after
![image](https://github.com/6pac/SlickGrid/assets/643976/193bd93f-5024-484b-b28c-632be8afe0d4)

the issue was because we append everything into the `.slick-cell` HTML element inside it but SlickRowDetail was hacking the html string to insert the HTML element after the `.slick-cell`. So our new code will simply do it in the correct way via `insertElementAfterTarget`

we can see below, the `.dynamic-cell-detail` div is supposed to go **after** the `.slick-cell.l0.r0` but was instead within it which was wrong and causing the regression
![image](https://github.com/6pac/SlickGrid/assets/643976/f60ccb06-5c4b-4290-a2be-b5fd0d5fd6e4)
