### PR TITLE
fix: changing `enableCellNavigation` grid option not working

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -627,9 +627,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   protected initialize(options: Partial<O>) {
     // calculate these only once and share between grid instances
-    if (options.mixinDefaults) {
-      if (!options) { options = {}; }
-      Utils.applyDefaults(options, this._defaults);
+    if (options?.mixinDefaults) {
+      if (!options) { this._options = {} as O; }
+      Utils.applyDefaults(this._options, this._defaults);
     } else {
       this._options = Utils.extend<O>(true, {}, this._defaults, options);
     }


### PR DESCRIPTION
- the previous code had 2 different `options` and `_options` that were not always in sync which caused issue when trying to update for example the `enableCellNavigation` option on the fly. With this new code change, there will no possibility to mix them up anywmore