### PR TITLE
feat(core): add `rowHighlightCssClass` & `highlightRow()` to SlickGrid

### DIFF
--- a/examples/example-frozen-columns.html
+++ b/examples/example-frozen-columns.html
@@ -68,6 +68,7 @@
     <button id="setFrozenColumn">Set</button>
     <br/><br/>
     <button id="btnSelectRows">Select first 10 rows</button>
+    <button onclick="highlightSecondRow()">Highlight 2nd Row (750ms)</button>
 
     <br/>
 
@@ -188,6 +189,9 @@ function addItem(newItem, columnDef) {
   dataView.addItem(item);
 }
 
+function highlightSecondRow() {
+  grid.highlightRow(1, 750);
+}
 
 function toggleFilterRow() {
   grid.setTopPanelVisibility(!grid.getOptions().showTopPanel);

--- a/examples/example14-highlighting.html
+++ b/examples/example14-highlighting.html
@@ -7,6 +7,11 @@
   <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css"/>
   <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css"/>
   <style>
+    @keyframes fade {
+      0%, 100% { background: none }
+      50% { background: #e8f8d0 }
+    }
+
     .load-medium {
       color: orange;
       font-weight: bold;
@@ -25,6 +30,11 @@
     .current-server {
       background: moccasin;
       box-shadow: inset 0 0 0 1px darksalmon;
+    }
+
+    .slick-row.highlighting-animation {
+      background: #e8f8d0 !important;
+      animation: fade 1.5s linear;
     }
   </style>
 </head>
@@ -52,6 +62,9 @@
     <button onclick="simulateRealTimeUpdates()">Start simulation</button>
     <button onclick="stopSimulation()">Stop simulation</button>
     <button onclick="findCurrentServer()">Find current server</button>
+    <section style="margin-top: 5px">
+      <button onclick="highlightSecondRow()">Highlight 2nd Row (500ms)</button>
+    </section>
       <h2>View Source:</h2>
       <ul>
           <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example14-highlighting.html" target="_sourcewindow"> View the source for this example on Github</a></li>
@@ -160,6 +173,12 @@
     let currentServer = Math.round(Math.random() * (data.length - 1));
     grid.scrollRowIntoView(currentServer);
     grid.flashCell(currentServer, grid.getColumnIndex("server"), 100);
+  }
+
+  function highlightSecondRow() {
+    // default is: { rowHighlightCssClass: 'highlight-animate' }
+    grid.setOptions({ rowHighlightCssClass: 'highlighting-animation' });
+    grid.highlightRow(1, 500);
   }
 </script>
 </body>

--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -254,6 +254,13 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   /** Grid row height in pixels (only type the number). Row of cell values. */
   rowHeight?: number;
 
+  /**
+   * Defaults to "highlight-animate", a CSS class name used to simulate row highlight with an optional duration (e.g. after insert).
+   * Note: make sure that the duration is always lower than the duration defined in the CSS/SASS variable `$alpine-row-highlight-fade-animation`.
+   * Also note that the highlight is temporary and will also disappear as soon as the user starts scrolling or a `render()` is being called
+   */
+  rowHighlightCssClass?: string;
+
   /** Optional sanitizer function to use for sanitizing data to avoid XSS attacks */
   sanitizer?: (dirtyHtml: string) => string;
 

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -17,6 +17,8 @@ $alpine-icon-size:                                18px !default;
 
 $alpine-odd-row-color:                            #fbfbfb !default;
 $alpine-row-mouse-hover-color:                    #e8f4fe !default;
+$alpine-row-highlight-fade-animation:             1s linear !default;
+$alpine-row-highlight-background-color:           darken($alpine-row-mouse-hover-color, 3%) !default;
 
 $alpine-cell-border-color:                        #dae1e7 !default;
 $alpine-cell-border-radius:                       0 !default;

--- a/src/styles/slick-alpine-theme.scss
+++ b/src/styles/slick-alpine-theme.scss
@@ -12,6 +12,11 @@
 @import './mixins';
 @import './variables';
 
+@keyframes fade {
+  0%, 100% { background: none }
+  50% { background: var(--alpine-row-highlight-fade-animation, $alpine-row-highlight-fade-animation) }
+}
+
 // Grid Styles
 #myGrid, .slick-container {
   box-sizing: border-box;
@@ -74,6 +79,10 @@
   }
   &:hover {
     background-color: var(--alpine-row-mouse-hover-color, $alpine-row-mouse-hover-color);
+  }
+  &.highlight-animate {
+    background: var(--alpine-row-highlight-background-color, $alpine-row-highlight-background-color) !important;
+    animation: fade var(--alpine-row-highlight-fade-animation, $alpine-row-highlight-fade-animation);
   }
 }
 


### PR DESCRIPTION
- this new approach is much simpler than using ItemMetadata and calling multiple `updateItem()` and `render()` and is a lot more performant
- also fix potential mem leaks found on some `setTimeout` not having any `clearTimeout` assigned which could cause potential mem leaks

![brave_9niv1NRv93](https://github.com/6pac/SlickGrid/assets/643976/11e9c6fb-69fd-4314-bd35-fe728be9d98f)
![brave_RUWpJ4EsE4](https://github.com/6pac/SlickGrid/assets/643976/6acb3547-72b9-48b1-a7b9-bf6b21ecde25)
