### PR TITLE
GroupItemMetaDataProvider implements SlickPlugin

### DIFF
--- a/src/models/grouping.interface.ts
+++ b/src/models/grouping.interface.ts
@@ -3,7 +3,7 @@ import { GroupingComparerItem } from "./groupingComparerItem.interface";
 import { GroupingFormatterItem } from "./groupingFormatterItem.interface";
 import { SortDirectionNumber } from "./sortDirectionNumber.enum";
 
-export type GroupingGetterFunction<T = any> = (value: T) => string;
+export type GroupingGetterFunction<T = any> = (value: T) => any;
 
 export interface Grouping<T = any> {
   /** Grouping Aggregators array */

--- a/src/slick.groupitemmetadataprovider.ts
+++ b/src/slick.groupitemmetadataprovider.ts
@@ -1,5 +1,5 @@
 import { SlickGroup as SlickGroup_, keyCode as keyCode_, Utils as Utils_ } from './slick.core';
-import type { Column, DOMEvent, GroupItemMetadataProviderOption, GroupingFormatterItem, ItemMetadata } from './models/index';
+import type { Column, DOMEvent, GroupItemMetadataProviderOption, GroupingFormatterItem, ItemMetadata, SlickPlugin } from './models/index';
 import type { SlickGrid } from './slick.grid';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)
@@ -21,7 +21,9 @@ const Utils = IIFE_ONLY ? Slick.Utils : Utils_;
  * @constructor
  * @param inputOptions
  */
-export class SlickGroupItemMetadataProvider {
+export class SlickGroupItemMetadataProvider implements SlickPlugin {
+  pluginName = "GroupItemMetadataProvider" as const;
+
   protected _grid!: SlickGrid;
   protected _options: GroupItemMetadataProviderOption;
   protected _defaults: GroupItemMetadataProviderOption = {


### PR DESCRIPTION
As it needs to be registered as plugin on grid to work properly, it should implement SlickGrid plugin interface, so typechecking of `grid.registerPlugin(groupItemMetadataProvider)` succeeds.