### PR TITLE
fix: GroupingGetterFunction should be allowed to return arbitrary value

### DIFF
--- a/src/models/grouping.interface.ts
+++ b/src/models/grouping.interface.ts
@@ -3,7 +3,7 @@ import { GroupingComparerItem } from "./groupingComparerItem.interface";
 import { GroupingFormatterItem } from "./groupingFormatterItem.interface";
 import { SortDirectionNumber } from "./sortDirectionNumber.enum";
 
-export type GroupingGetterFunction<T = any> = (value: T) => string;
+export type GroupingGetterFunction<T = any> = (value: T) => any;
 
 export interface Grouping<T = any> {
   /** Grouping Aggregators array */


### PR DESCRIPTION
Underlying slickgrid logic only takes into account equality between values returned for grouping individial rows. Getter thus does not need to return `string` but might return arbitrary value (e.g. string, number, Date).

Typing return value as `unknown` will force underlying logic using grouping getter to take into consideration that user might specify grouping function that returns arbitrary value type for individual row. With previous getter signature, user was forced to specify function that returned string, which is however not currenly needed by internal slickgrid logic.