### PR TITLE
fix: DataView `inlineFilters` should allow ES6 arrow functions

### DIFF
--- a/examples/example4-model-esm.html
+++ b/examples/example4-model-esm.html
@@ -229,18 +229,6 @@ function requiredFieldValidator(value) {
   }
 }
 
-function myFilter(item, args) {
-  if (item["percentComplete"] < args.percentCompleteThreshold) {
-    return false;
-  }
-
-  if (args.searchString != "" && item["title"].indexOf(args.searchString) == -1) {
-    return false;
-  }
-
-  return true;
-}
-
 function percentCompleteSort(a, b) {
   return a["percentComplete"] - b["percentComplete"];
 }
@@ -400,7 +388,18 @@ document.addEventListener("DOMContentLoaded", () => {
     percentCompleteThreshold,
     searchString
   });
-  dataView.setFilter(myFilter);
+  dataView.setFilter((item, args) => {
+    if (item['percentComplete'] < args.percentCompleteThreshold) {
+      return false;
+    }
+
+    const searchString = args.searchString.toLowerCase();
+    if (args.searchString != '' && !item['title'].toLowerCase().includes(searchString)) {
+      return false;
+    }
+
+    return true;
+  });
   dataView.endUpdate();
 
   // if you don't want the items that are not visible (due to being filtered out

--- a/src/models/function.type.ts
+++ b/src/models/function.type.ts
@@ -1,0 +1,1 @@
+export type AnyFunction = (...args: any[]) => any;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -30,6 +30,7 @@ export * from './externalCopyClipCommand.interface';
 export * from './fieldType.enum';
 export * from './formatter.interface';
 export * from './formatterResultObject.interface';
+export * from './function.type';
 export * from './gridEvents.interface';
 export * from './gridMenu.interface';
 export * from './gridMenuCommandItemCallbackArgs.interface';

--- a/src/slick.dataview.ts
+++ b/src/slick.dataview.ts
@@ -1,5 +1,6 @@
 import type {
   Aggregator,
+  AnyFunction,
   CssStyleHash,
   CustomDataView,
   DataViewHints,
@@ -54,7 +55,6 @@ export type FilterWithCspCachingFn<T> = (item: T[], args: any, filterCache: any[
 export type DataIdType = number | string;
 export type SlickDataItem = SlickNonDataItem | SlickGroup_ | SlickGroupTotals_ | any;
 export type GroupGetterFn = (val: any) => string | number;
-export type AnyFunction = (...args: any[]) => any;
 
 /**
   * A simple Model implementation.
@@ -1033,17 +1033,6 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return groupedRows;
   }
 
-  protected getFunctionInfo(fn: AnyFunction) {
-    const fnStr = fn.toString();
-    const usingEs5 = fnStr.indexOf('function') >= 0; // with ES6, the word function is not present
-    const fnRegex = usingEs5 ? /^function[^(]*\(([^)]*)\)\s*{([\s\S]*)}$/ : /^[^(]*\(([^)]*)\)\s*{([\s\S]*)}$/;
-    const matches = fn.toString().match(fnRegex) || [];
-    return {
-      params: matches[1].split(','),
-      body: matches[2]
-    };
-  }
-
   protected compileAccumulatorLoopCSPSafe(aggregator: Aggregator) {
     if (aggregator.accumulate) {
       return function (items: any[]) {
@@ -1079,7 +1068,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     if (stopRunningIfCSPSafeIsActive) {
       return null as any;
     }
-    const filterInfo = this.getFunctionInfo(this.filter as FilterFn<TData>);
+    const filterInfo = Utils.getFunctionDetails(this.filter as FilterFn<TData>);
 
     const filterPath1 = '{ continue _coreloop; }$1';
     const filterPath2 = '{ _retval[_idx++] = $item$; continue _coreloop; }$1';
@@ -1121,7 +1110,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
       return null as any;
     }
 
-    const filterInfo = this.getFunctionInfo(this.filter as FilterFn<TData>);
+    const filterInfo = Utils.getFunctionDetails(this.filter as FilterFn<TData>);
 
     const filterPath1 = '{ continue _coreloop; }$1';
     const filterPath2 = '{ _cache[_i] = true;_retval[_idx++] = $item$; continue _coreloop; }$1';


### PR DESCRIPTION
- the sample code below, with inline ES6 arrow function, was not working prior to this PR
```ts
dataView = new Slick.Data.DataView({ inlineFilters: true });
dataView.setFilter((item, args) => item["percentComplete"] > args.percentCompleteThreshold);
```