### PR TITLE
fix: CellSelectionModel for CustomDataView and SlickCustomTooltip

### DIFF
--- a/src/plugins/slick.cellselectionmodel.ts
+++ b/src/plugins/slick.cellselectionmodel.ts
@@ -1,6 +1,6 @@
 import { SlickEvent as SlickEvent_, SlickEventData as SlickEventData_, SlickRange as SlickRange_, Utils as Utils_ } from '../slick.core';
 import { SlickCellRangeSelector as SlickCellRangeSelector_ } from './slick.cellrangeselector';
-import type { OnActiveCellChangedEventArgs } from '../models/index';
+import type { CustomDataView, OnActiveCellChangedEventArgs } from '../models/index';
 import type { SlickDataView } from '../slick.dataview';
 import type { SlickGrid } from '../slick.grid';
 
@@ -25,7 +25,7 @@ export class SlickCellSelectionModel {
   // --
   // protected props
   protected _cachedPageRowCount = 0;
-  protected _dataView?: SlickDataView;
+  protected _dataView?: CustomDataView | SlickDataView;
   protected _grid!: SlickGrid;
   protected _prevSelectedRow?: number;
   protected _prevKeyDown = '';
@@ -48,7 +48,7 @@ export class SlickCellSelectionModel {
     this._options = Utils.extend(true, {}, this._defaults, this._options);
     this._grid = grid;
     if (grid.hasDataView()) {
-      this._dataView = grid.getData<SlickDataView>();
+      this._dataView = grid.getData<CustomDataView | SlickDataView>();
     }
     this._grid.onActiveCellChanged.subscribe(this.handleActiveCellChange.bind(this));
     this._grid.onKeyDown.subscribe(this.handleKeyDown.bind(this));
@@ -160,7 +160,7 @@ export class SlickCellSelectionModel {
     const colLn = this._grid.getColumns().length;
     const active = this._grid.getActiveCell();
     let dataLn = 0;
-    if (this._dataView) {
+    if (this._dataView && 'getPagingInfo' in this._dataView) {
       dataLn = this._dataView?.getPagingInfo().pageSize || this._dataView.getLength();
     } else {
       dataLn = this._grid.getDataLength();

--- a/src/plugins/slick.customtooltip.ts
+++ b/src/plugins/slick.customtooltip.ts
@@ -1,6 +1,5 @@
-import type { CancellablePromiseWrapper, Column, CustomTooltipOption, DOMEvent, Formatter, FormatterResultWithHtml, FormatterResultWithText, GridOption } from '../models/index';
+import type { CancellablePromiseWrapper, Column, CustomDataView, CustomTooltipOption, DOMEvent, Formatter, FormatterResultWithHtml, FormatterResultWithText, GridOption } from '../models/index';
 import { SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
-import type { SlickDataView } from '../slick.dataview';
 import type { SlickGrid } from '../slick.grid';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)
@@ -87,7 +86,7 @@ export class SlickCustomTooltip {
   // protected props
   protected _cancellablePromise?: CancellablePromiseWrapper;
   protected _cellNodeElm?: HTMLDivElement;
-  protected _dataView?: SlickDataView | null;
+  protected _dataView?: CustomDataView | null;
   protected _grid!: SlickGrid;
   protected _gridOptions!: GridOption;
   protected _tooltipElm?: HTMLDivElement;
@@ -113,7 +112,7 @@ export class SlickCustomTooltip {
   init(grid: SlickGrid) {
     this._grid = grid;
     const _data = grid?.getData() || [];
-    this._dataView = Array.isArray(_data) ? null : _data as SlickDataView;
+    this._dataView = Array.isArray(_data) ? null : _data as CustomDataView;
     this._gridOptions = (grid.getOptions() || {}) as GridOption;
     this._options = Utils.extend(true, {}, this._defaults, this._gridOptions.customTooltip, this.tooltipOptions);
     this._eventHandler
@@ -528,4 +527,3 @@ if (IIFE_ONLY && window.Slick) {
     }
   });
 }
-


### PR DESCRIPTION
It implied usage of SlickDataView which might provide paging; CustomDataView interface however does not require paging implementation. We assume that there is no paging on the dataview if getPagingInfo method not available on dataView.