### PR TITLE
fix: EventHandler subscribed event should be SlickEventData type

### DIFF
--- a/src/controls/slick.columnmenu.ts
+++ b/src/controls/slick.columnmenu.ts
@@ -1,4 +1,4 @@
-import { BindingEventService as BindingEventService_, Event as SlickEvent_, Utils as Utils_ } from '../slick.core';
+import { BindingEventService as BindingEventService_, Event as SlickEvent_, type SlickEventData, Utils as Utils_ } from '../slick.core';
 import type { Column, ColumnPickerOption, DOMMouseOrTouchEvent, GridOption, OnColumnsChangedArgs } from '../models/index';
 import type { SlickGrid } from '../slick.grid';
 
@@ -122,7 +122,7 @@ export class SlickColumnMenu {
     }
   }
 
-  handleHeaderContextMenu(e: DOMMouseOrTouchEvent<HTMLDivElement>) {
+  handleHeaderContextMenu(e: SlickEventData) {
     e.preventDefault();
     Utils.emptyElement(this._listElm);
     this.updateColumnOrder();
@@ -216,8 +216,8 @@ export class SlickColumnMenu {
     this.repositionMenu(e);
   }
 
-  repositionMenu(event: DOMMouseOrTouchEvent<HTMLDivElement>) {
-    const targetEvent = event?.touches?.[0] || event;
+  repositionMenu(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData) {
+    const targetEvent = (event as TouchEvent)?.touches?.[0] || event;
     this._menuElm.style.top = `${targetEvent.pageY - 10}px`;
     this._menuElm.style.left = `${targetEvent.pageX - 10}px`;
     this._menuElm.style.maxHeight = `${window.innerHeight - targetEvent.clientY}px`;

--- a/src/controls/slick.columnpicker.ts
+++ b/src/controls/slick.columnpicker.ts
@@ -1,4 +1,4 @@
-import { BindingEventService as BindingEventService_, Event as SlickEvent_, Utils as Utils_ } from '../slick.core';
+import { BindingEventService as BindingEventService_, Event as SlickEvent_, type SlickEventData, Utils as Utils_ } from '../slick.core';
 import type { Column, ColumnPickerOption, DOMMouseOrTouchEvent, GridOption, OnColumnsChangedArgs } from '../models/index';
 import type { SlickGrid } from '../slick.grid';
 
@@ -123,7 +123,7 @@ export class SlickColumnPicker {
     }
   }
 
-  protected handleHeaderContextMenu(e: DOMMouseOrTouchEvent<HTMLDivElement>) {
+  protected handleHeaderContextMenu(e: SlickEventData) {
     e.preventDefault();
     Utils.emptyElement(this._listElm);
     this.updateColumnOrder();
@@ -217,7 +217,7 @@ export class SlickColumnPicker {
     this.repositionMenu(e);
   }
 
-  protected repositionMenu(event: DOMMouseOrTouchEvent<HTMLDivElement>) {
+  protected repositionMenu(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData) {
     const targetEvent: MouseEvent | Touch = (event as TouchEvent)?.touches?.[0] ?? event;
     this._menuElm.style.top = `${targetEvent.pageY - 10}px`;
     this._menuElm.style.left = `${targetEvent.pageX - 10}px`;

--- a/src/models/core.interface.ts
+++ b/src/models/core.interface.ts
@@ -1,4 +1,6 @@
-export type Handler<ArgType = any> = (e: any, args: ArgType) => void;
+import { type SlickEventData } from '../slick.core';
+
+export type Handler<ArgType = any> = (e: SlickEventData, args: ArgType) => void;
 
 export interface ElementEventListener {
   element: Element | Window;

--- a/src/models/gridEvents.interface.ts
+++ b/src/models/gridEvents.interface.ts
@@ -1,44 +1,44 @@
 import type { Column, CompositeEditorOption, CssStyleHash, Editor, EditorValidationResult, GridOption } from './index';
 import type { SlickGrid } from '../slick.grid';
 
-export interface SlickGridEventData { grid: SlickGrid; }
-export interface OnActiveCellChangedEventArgs extends SlickGridEventData { cell: number; row: number; }
-export interface OnAddNewRowEventArgs extends SlickGridEventData { item: any; column: Column; }
-export interface OnAutosizeColumnsEventArgs extends SlickGridEventData { columns: Column[]; }
-export interface OnBeforeUpdateColumnsEventArgs extends SlickGridEventData { columns: Column[]; }
-export interface OnBeforeAppendCellEventArgs extends SlickGridEventData { row: number; cell: number; value: any; dataContext: any; }
-export interface OnBeforeCellEditorDestroyEventArgs extends SlickGridEventData { editor: Editor; }
-export interface OnBeforeColumnsResizeEventArgs extends SlickGridEventData { triggeredByColumn: string; }
-export interface OnBeforeEditCellEventArgs extends SlickGridEventData { row?: number; cell?: number; item: any; column: Column; target?: 'grid' | 'composite'; compositeEditorOptions?: CompositeEditorOption; }
-export interface OnBeforeHeaderCellDestroyEventArgs extends SlickGridEventData { node: HTMLElement; column: Column; }
-export interface OnBeforeHeaderRowCellDestroyEventArgs extends SlickGridEventData { node: HTMLElement; column: Column; }
-export interface OnBeforeFooterRowCellDestroyEventArgs extends SlickGridEventData { node: HTMLElement; column: Column; }
-export interface OnBeforeSetColumnsEventArgs extends SlickGridEventData { previousColumns: Column[]; newColumns: Column[]; }
-export interface OnCellChangeEventArgs extends SlickGridEventData { row: number; cell: number; item: any; column: Column; }
-export interface OnCellCssStylesChangedEventArgs extends SlickGridEventData { key: string; hash: CssStyleHash; }
-export interface OnColumnsDragEventArgs extends SlickGridEventData { triggeredByColumn: string; resizeHandle: HTMLDivElement; }
-export interface OnColumnsReorderedEventArgs extends SlickGridEventData { impactedColumns: Column[]; }
-export interface OnColumnsResizedEventArgs extends SlickGridEventData { triggeredByColumn: string; }
-export interface OnColumnsResizeDblClickEventArgs extends SlickGridEventData { triggeredByColumn: string; }
-export interface OnCompositeEditorChangeEventArgs extends SlickGridEventData { row?: number; cell?: number; item: any; column: Column; formValues: any; editors: { [columnId: string]: Editor; }; triggeredBy?: 'user' | 'system'; }
-export interface OnClickEventArgs extends SlickGridEventData { row: number; cell: number; }
-export interface OnDblClickEventArgs extends SlickGridEventData { row: number; cell: number; }
-export interface OnFooterContextMenuEventArgs extends SlickGridEventData { column: Column; }
-export interface OnFooterRowCellRenderedEventArgs extends SlickGridEventData { node: HTMLDivElement; column: Column; }
-export interface OnHeaderCellRenderedEventArgs extends SlickGridEventData { node: HTMLDivElement; column: Column; }
-export interface OnFooterClickEventArgs extends SlickGridEventData { column: Column; }
-export interface OnHeaderClickEventArgs extends SlickGridEventData { column: Column; }
-export interface OnHeaderContextMenuEventArgs extends SlickGridEventData { column: Column; }
-export interface OnHeaderMouseEventArgs extends SlickGridEventData { column: Column; }
-export interface OnHeaderRowCellRenderedEventArgs extends SlickGridEventData { node: HTMLDivElement; column: Column; }
-export interface OnKeyDownEventArgs extends SlickGridEventData { row: number; cell: number; }
-export interface OnValidationErrorEventArgs extends SlickGridEventData { row: number; cell: number; validationResults: EditorValidationResult; column: Column; editor: Editor; cellNode: HTMLDivElement; }
-export interface OnRenderedEventArgs extends SlickGridEventData { startRow: number; endRow: number; }
-export interface OnSelectedRowsChangedEventArgs extends SlickGridEventData { rows: number[]; previousSelectedRows: number[]; changedSelectedRows: number[]; changedUnselectedRows: number[]; caller: string; }
-export interface OnSetOptionsEventArgs extends SlickGridEventData { optionsBefore: GridOption; optionsAfter: GridOption; }
-export interface OnActivateChangedOptionsEventArgs extends SlickGridEventData { options: GridOption; }
-export interface OnScrollEventArgs extends SlickGridEventData { scrollLeft: number; scrollTop: number; cell: number; row: number; }
-export interface OnDragEventArgs extends SlickGridEventData {
+export interface SlickGridArg { grid: SlickGrid; }
+export interface OnActiveCellChangedEventArgs extends SlickGridArg { cell: number; row: number; }
+export interface OnAddNewRowEventArgs extends SlickGridArg { item: any; column: Column; }
+export interface OnAutosizeColumnsEventArgs extends SlickGridArg { columns: Column[]; }
+export interface OnBeforeUpdateColumnsEventArgs extends SlickGridArg { columns: Column[]; }
+export interface OnBeforeAppendCellEventArgs extends SlickGridArg { row: number; cell: number; value: any; dataContext: any; }
+export interface OnBeforeCellEditorDestroyEventArgs extends SlickGridArg { editor: Editor; }
+export interface OnBeforeColumnsResizeEventArgs extends SlickGridArg { triggeredByColumn: string; }
+export interface OnBeforeEditCellEventArgs extends SlickGridArg { row?: number; cell?: number; item: any; column: Column; target?: 'grid' | 'composite'; compositeEditorOptions?: CompositeEditorOption; }
+export interface OnBeforeHeaderCellDestroyEventArgs extends SlickGridArg { node: HTMLElement; column: Column; }
+export interface OnBeforeHeaderRowCellDestroyEventArgs extends SlickGridArg { node: HTMLElement; column: Column; }
+export interface OnBeforeFooterRowCellDestroyEventArgs extends SlickGridArg { node: HTMLElement; column: Column; }
+export interface OnBeforeSetColumnsEventArgs extends SlickGridArg { previousColumns: Column[]; newColumns: Column[]; }
+export interface OnCellChangeEventArgs extends SlickGridArg { row: number; cell: number; item: any; column: Column; }
+export interface OnCellCssStylesChangedEventArgs extends SlickGridArg { key: string; hash: CssStyleHash; }
+export interface OnColumnsDragEventArgs extends SlickGridArg { triggeredByColumn: string; resizeHandle: HTMLDivElement; }
+export interface OnColumnsReorderedEventArgs extends SlickGridArg { impactedColumns: Column[]; }
+export interface OnColumnsResizedEventArgs extends SlickGridArg { triggeredByColumn: string; }
+export interface OnColumnsResizeDblClickEventArgs extends SlickGridArg { triggeredByColumn: string; }
+export interface OnCompositeEditorChangeEventArgs extends SlickGridArg { row?: number; cell?: number; item: any; column: Column; formValues: any; editors: { [columnId: string]: Editor; }; triggeredBy?: 'user' | 'system'; }
+export interface OnClickEventArgs extends SlickGridArg { row: number; cell: number; }
+export interface OnDblClickEventArgs extends SlickGridArg { row: number; cell: number; }
+export interface OnFooterContextMenuEventArgs extends SlickGridArg { column: Column; }
+export interface OnFooterRowCellRenderedEventArgs extends SlickGridArg { node: HTMLDivElement; column: Column; }
+export interface OnHeaderCellRenderedEventArgs extends SlickGridArg { node: HTMLDivElement; column: Column; }
+export interface OnFooterClickEventArgs extends SlickGridArg { column: Column; }
+export interface OnHeaderClickEventArgs extends SlickGridArg { column: Column; }
+export interface OnHeaderContextMenuEventArgs extends SlickGridArg { column: Column; }
+export interface OnHeaderMouseEventArgs extends SlickGridArg { column: Column; }
+export interface OnHeaderRowCellRenderedEventArgs extends SlickGridArg { node: HTMLDivElement; column: Column; }
+export interface OnKeyDownEventArgs extends SlickGridArg { row: number; cell: number; }
+export interface OnValidationErrorEventArgs extends SlickGridArg { row: number; cell: number; validationResults: EditorValidationResult; column: Column; editor: Editor; cellNode: HTMLDivElement; }
+export interface OnRenderedEventArgs extends SlickGridArg { startRow: number; endRow: number; }
+export interface OnSelectedRowsChangedEventArgs extends SlickGridArg { rows: number[]; previousSelectedRows: number[]; changedSelectedRows: number[]; changedUnselectedRows: number[]; caller: string; }
+export interface OnSetOptionsEventArgs extends SlickGridArg { optionsBefore: GridOption; optionsAfter: GridOption; }
+export interface OnActivateChangedOptionsEventArgs extends SlickGridArg { options: GridOption; }
+export interface OnScrollEventArgs extends SlickGridArg { scrollLeft: number; scrollTop: number; cell: number; row: number; }
+export interface OnDragEventArgs extends SlickGridArg {
   count: number; deltaX: number; deltaY: number; offsetX: number; offsetY: number; originalX: number; originalY: number;
   available: HTMLDivElement | HTMLDivElement[]; drag: HTMLDivElement; drop: HTMLDivElement | HTMLDivElement[]; helper: HTMLDivElement;
   proxy: HTMLDivElement; target: HTMLDivElement; mode: string;

--- a/src/plugins/slick.autotooltips.ts
+++ b/src/plugins/slick.autotooltips.ts
@@ -1,5 +1,5 @@
 import type { AutoTooltipOption, Column, SlickPlugin } from '../models/index';
-import { Utils as Utils_ } from '../slick.core';
+import { type SlickEventData, Utils as Utils_ } from '../slick.core';
 import type { SlickGrid } from '../slick.grid';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)
@@ -62,9 +62,9 @@ export class SlickAutoTooltips implements SlickPlugin {
 
   /**
    * Handle mouse entering grid cell to add/remove tooltip.
-   * @param {MouseEvent} event - The event
+   * @param {SlickEventData} event - The event
    */
-  protected handleMouseEnter(event: MouseEvent) {
+  protected handleMouseEnter(event: SlickEventData) {
     const cell = this._grid.getCellFromEvent(event);
     if (cell) {
       let node: HTMLElement | null = this._grid.getCellNode(cell.row, cell.cell);
@@ -86,10 +86,10 @@ export class SlickAutoTooltips implements SlickPlugin {
 
   /**
    * Handle mouse entering header cell to add/remove tooltip.
-   * @param {MouseEvent} event   - The event
+   * @param {SlickEventData} event   - The event
    * @param {object} args.column - The column definition
    */
-  protected handleHeaderMouseEnter(event: MouseEvent, args: { column: Column; }) {
+  protected handleHeaderMouseEnter(event: SlickEventData, args: { column: Column; }) {
     const column = args.column;
     let node: HTMLDivElement | null;
     const targetElm = (event.target as HTMLDivElement);

--- a/src/plugins/slick.cellcopymanager.ts
+++ b/src/plugins/slick.cellcopymanager.ts
@@ -1,5 +1,5 @@
 import type { CssStyleHash, SlickPlugin } from '../models/index';
-import { SlickEvent as SlickEvent_, keyCode as keyCode_, Utils as Utils_, SlickRange } from '../slick.core';
+import { keyCode as keyCode_, SlickEvent as SlickEvent_, type SlickEventData, Utils as Utils_, SlickRange } from '../slick.core';
 import type { SlickGrid } from '../slick.grid';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)
@@ -33,7 +33,7 @@ export class SlickCellCopyManager implements SlickPlugin {
     this._grid.onKeyDown.unsubscribe(this.handleKeyDown.bind(this));
   }
 
-  protected handleKeyDown(e: KeyboardEvent) {
+  protected handleKeyDown(e: SlickEventData) {
     let ranges: SlickRange[] | undefined;
     if (!this._grid.getEditorLock().isActive()) {
       if (e.which === keyCode.ESCAPE) {

--- a/src/plugins/slick.cellexternalcopymanager.ts
+++ b/src/plugins/slick.cellexternalcopymanager.ts
@@ -1,6 +1,6 @@
 import type { Column, CssStyleHash, ExcelCopyBufferOption, ExternalCopyClipCommand, SlickPlugin } from '../models/index';
 import type { SlickGrid } from '../slick.grid';
-import { SlickEvent as SlickEvent_, SlickRange as SlickRange_, Utils as Utils_ } from '../slick.core';
+import { SlickEvent as SlickEvent_, type SlickEventData, SlickRange as SlickRange_, Utils as Utils_ } from '../slick.core';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)
 const SlickEvent = IIFE_ONLY ? Slick.Event : SlickEvent_;
@@ -102,7 +102,7 @@ export class SlickCellExternalCopyManager implements SlickPlugin {
     return columnDef.name;
   }
 
-  protected getDataItemValueForColumn(item: any, columnDef: Column, event: Event): string {
+  protected getDataItemValueForColumn(item: any, columnDef: Column, event: SlickEventData): string {
     if (typeof this._options.dataItemColumnValueExtractor === 'function') {
       const val = this._options.dataItemColumnValueExtractor(item, columnDef) as string | null;
       if (val) {
@@ -354,7 +354,7 @@ export class SlickCellExternalCopyManager implements SlickPlugin {
     }
   }
 
-  protected handleKeyDown(e: KeyboardEvent): boolean | void {
+  protected handleKeyDown(e: SlickEventData): boolean | void {
     let ranges: SlickRange_[];
     if (!this._grid.getEditorLock().isActive() || this._grid.getOptions().autoEdit) {
       if (e.which === this.keyCodes.ESC) {

--- a/src/plugins/slick.cellmenu.ts
+++ b/src/plugins/slick.cellmenu.ts
@@ -417,7 +417,7 @@ export class SlickCellMenu implements SlickPlugin {
   }
 
   /** Close and destroy Cell Menu */
-  closeMenu(e?: DOMMouseOrTouchEvent<HTMLButtonElement | HTMLDivElement>, args?: MenuFromCellCallbackArgs) {
+  closeMenu(e?: DOMMouseOrTouchEvent<HTMLButtonElement | HTMLDivElement> | SlickEventData_, args?: MenuFromCellCallbackArgs) {
     if (this._menuElm) {
       if (this.onBeforeMenuClose.notify({
         cell: args?.cell ?? 0,

--- a/src/plugins/slick.cellrangeselector.ts
+++ b/src/plugins/slick.cellrangeselector.ts
@@ -1,7 +1,7 @@
-import { SlickEvent as SlickEvent_, SlickEventData, SlickEventHandler as SlickEventHandler_, SlickRange as SlickRange_, Utils as Utils_ } from '../slick.core';
+import { SlickEvent as SlickEvent_, type SlickEventData, SlickEventHandler as SlickEventHandler_, SlickRange as SlickRange_, Utils as Utils_ } from '../slick.core';
 import { Draggable as Draggable_ } from '../slick.interactions';
 import { SlickCellRangeDecorator as SlickCellRangeDecorator_ } from './slick.cellrangedecorator';
-import type { CellRangeSelectorOption, DOMMouseOrTouchEvent, DragPosition, DragRange, DragRowMove, GridOption, MouseOffsetViewport, OnScrollEventArgs, SlickPlugin } from '../models/index';
+import type { CellRangeSelectorOption, DragPosition, DragRange, DragRowMove, GridOption, MouseOffsetViewport, OnScrollEventArgs, SlickPlugin } from '../models/index';
 import type { SlickGrid } from '../slick.grid';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)
@@ -96,12 +96,12 @@ export class SlickCellRangeSelector implements SlickPlugin {
     return this._decorator;
   }
 
-  protected handleScroll(_e: DOMMouseOrTouchEvent<HTMLDivElement>, args: OnScrollEventArgs) {
+  protected handleScroll(_e: SlickEventData, args: OnScrollEventArgs) {
     this._scrollTop = args.scrollTop;
     this._scrollLeft = args.scrollLeft;
   }
 
-  protected handleDragInit(e: Event) {
+  protected handleDragInit(e: SlickEventData) {
     // Set the active canvas node because the decorator needs to append its
     // box to the correct canvas
     this._activeCanvas = this._grid.getActiveCanvasNode(e);
@@ -143,7 +143,7 @@ export class SlickCellRangeSelector implements SlickPlugin {
     e.preventDefault();
   }
 
-  protected handleDragStart(e: DOMMouseOrTouchEvent<HTMLDivElement>, dd: DragRowMove) {
+  protected handleDragStart(e: SlickEventData, dd: DragRowMove) {
     const cell = this._grid.getCellFromEvent(e);
     if (cell && this.onBeforeCellRangeSelected.notify(cell).getReturnValue() !== false && this._grid.canCellBeSelected(cell.row, cell.cell)) {
       this._dragging = true;
@@ -365,7 +365,7 @@ export class SlickCellRangeSelector implements SlickPlugin {
     return !!(this._grid.getPluginByName('RowMoveManager') || this._grid.getPluginByName('CrossGridRowMoveManager'));
   }
 
-  protected handleDragEnd(e: Event, dd: DragPosition) {
+  protected handleDragEnd(e: SlickEventData, dd: DragPosition) {
     this._decorator.hide();
     if (!this._dragging) {
       return;

--- a/src/plugins/slick.cellselectionmodel.ts
+++ b/src/plugins/slick.cellselectionmodel.ts
@@ -126,19 +126,19 @@ export class SlickCellSelectionModel {
     this.setSelectedRanges(this.getSelectedRanges());
   }
 
-  protected handleBeforeCellRangeSelected(e: Event): boolean | void {
+  protected handleBeforeCellRangeSelected(e: SlickEventData_): boolean | void {
     if (this._grid.getEditorLock().isActive()) {
       e.stopPropagation();
       return false;
     }
   }
 
-  protected handleCellRangeSelected(_e: any, args: { range: SlickRange_; }) {
+  protected handleCellRangeSelected(_e: SlickEventData_, args: { range: SlickRange_; }) {
     this._grid.setActiveCell(args.range.fromRow, args.range.fromCell, false, false, true);
     this.setSelectedRanges([args.range]);
   }
 
-  protected handleActiveCellChange(_e: Event, args: OnActiveCellChangedEventArgs) {
+  protected handleActiveCellChange(_e: SlickEventData_, args: OnActiveCellChangedEventArgs) {
     this._prevSelectedRow = undefined;
     const isCellDefined = Utils.isDefined(args.cell);
     const isRowDefined = Utils.isDefined(args.row);
@@ -155,7 +155,7 @@ export class SlickCellSelectionModel {
     return ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageDown', 'PageUp', 'Home', 'End'].some(k => k === key);
   }
 
-  protected handleKeyDown(e: KeyboardEvent) {
+  protected handleKeyDown(e: SlickEventData_) {
     let ranges: SlickRange_[], last: SlickRange_;
     const colLn = this._grid.getColumns().length;
     const active = this._grid.getActiveCell();
@@ -166,7 +166,7 @@ export class SlickCellSelectionModel {
       dataLn = this._grid.getDataLength();
     }
 
-    if (active && (e.shiftKey || e.ctrlKey) && !e.altKey && this.isKeyAllowed(e.key)) {
+    if (active && (e.shiftKey || e.ctrlKey) && !e.altKey && this.isKeyAllowed(e.key as string)) {
       ranges = this.getSelectedRanges().slice();
       if (!ranges.length) {
         ranges.push(new SlickRange(active.row, active.cell));
@@ -185,7 +185,7 @@ export class SlickCellSelectionModel {
       // walking direction
       const dirRow = active.row === last.fromRow ? 1 : -1;
       const dirCell = active.cell === last.fromCell ? 1 : -1;
-      const isSingleKeyMove = e.key.startsWith('Arrow');
+      const isSingleKeyMove = e.key!.startsWith('Arrow');
       let toCell: undefined | number = undefined;
       let toRow = 0;
 
@@ -263,7 +263,7 @@ export class SlickCellSelectionModel {
 
       e.preventDefault();
       e.stopPropagation();
-      this._prevKeyDown = e.key;
+      this._prevKeyDown = e.key as string;
     }
   }
 }

--- a/src/plugins/slick.checkboxselectcolumn.ts
+++ b/src/plugins/slick.checkboxselectcolumn.ts
@@ -1,5 +1,5 @@
 import type { CheckboxSelectorOption, Column, DOMEvent, SlickPlugin, SelectableOverrideCallback, OnHeaderClickEventArgs } from '../models/index';
-import { BindingEventService as BindingEventService_, SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
+import { BindingEventService as BindingEventService_, type SlickEventData, SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
 import type { SlickDataView } from '../slick.dataview';
 import type { SlickGrid } from '../slick.grid';
 
@@ -220,7 +220,7 @@ export class SlickCheckboxSelectColumn<T = any> implements SlickPlugin {
     }
   }
 
-  protected handleKeyDown(e: KeyboardEvent, args: any) {
+  protected handleKeyDown(e: SlickEventData, args: any) {
     if (e.which === 32) {
       if (this._grid.getColumns()[args.cell].id === this._options.columnId) {
         // if editing, try to commit
@@ -233,9 +233,9 @@ export class SlickCheckboxSelectColumn<T = any> implements SlickPlugin {
     }
   }
 
-  protected handleClick(e: DOMEvent<HTMLInputElement>, args: { row: number; cell: number; }) {
+  protected handleClick(e: SlickEventData, args: { row: number; cell: number; }) {
     // clicking on a row select checkbox
-    if (this._grid.getColumns()[args.cell].id === this._options.columnId && e.target.type === 'checkbox') {
+    if (this._grid.getColumns()[args.cell].id === this._options.columnId && (e.target as HTMLInputElement).type === 'checkbox') {
       // if editing, try to commit
       if (this._grid.getEditorLock().isActive() && !this._grid.getEditorLock().commitCurrentEdit()) {
         e.preventDefault();
@@ -285,8 +285,8 @@ export class SlickCheckboxSelectColumn<T = any> implements SlickPlugin {
     this._grid.setSelectedRows(this._grid.getSelectedRows().filter((n) => removeRows.indexOf(n) < 0), 'SlickCheckboxSelectColumn.deSelectRows');
   }
 
-  protected handleHeaderClick(e: DOMEvent<HTMLInputElement>, args: OnHeaderClickEventArgs) {
-    if (args.column.id === this._options.columnId && e.target.type === 'checkbox') {
+  protected handleHeaderClick(e: DOMEvent<HTMLInputElement> | SlickEventData, args: OnHeaderClickEventArgs) {
+    if (args.column.id === this._options.columnId && (e.target as HTMLInputElement).type === 'checkbox') {
       // if editing, try to commit
       if (this._grid.getEditorLock().isActive() && !this._grid.getEditorLock().commitCurrentEdit()) {
         e.preventDefault();
@@ -294,7 +294,7 @@ export class SlickCheckboxSelectColumn<T = any> implements SlickPlugin {
         return;
       }
 
-      let isAllSelected = e.target.checked;
+      let isAllSelected = (e.target as HTMLInputElement).checked;
       const caller = isAllSelected ? 'click.selectAll' : 'click.unselectAll';
       const rows: number[] = [];
 

--- a/src/plugins/slick.contextmenu.ts
+++ b/src/plugins/slick.contextmenu.ts
@@ -431,7 +431,7 @@ export class SlickContextMenu implements SlickPlugin {
     }
   }
 
-  destroyMenu(e?: Event, args?: { cell: number; row: number; }) {
+  destroyMenu(e?: Event | SlickEventData_, args?: { cell: number; row: number; }) {
     this._menuElm = this._menuElm || document.querySelector(`.slick-context-menu${this.getGridUidSelector()}`);
 
     if (this._menuElm?.remove) {

--- a/src/plugins/slick.crossgridrowmovemanager.ts
+++ b/src/plugins/slick.crossgridrowmovemanager.ts
@@ -1,5 +1,5 @@
 import { SlickEvent as SlickEvent_, SlickEventData as SlickEventData_, SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
-import type { Column, DOMEvent, DragRowMove, CrossGridRowMoveManagerOption, FormatterResultWithText, UsabilityOverrideFn } from '../models/index';
+import type { Column, DragRowMove, CrossGridRowMoveManagerOption, FormatterResultWithText, UsabilityOverrideFn } from '../models/index';
 import type { SlickGrid } from '../slick.grid';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)
@@ -92,7 +92,7 @@ export class SlickCrossGridRowMoveManager {
     e.stopImmediatePropagation();
   }
 
-  protected handleDragStart(e: DOMEvent<HTMLDivElement>, dd: DragRowMove & { fromGrid: SlickGrid; toGrid: SlickGrid; }): boolean | void {
+  protected handleDragStart(e: SlickEventData_, dd: DragRowMove & { fromGrid: SlickGrid; toGrid: SlickGrid; }): boolean | void {
     const cell = this._grid.getCellFromEvent(e) || { cell: -1, row: -1 };
     const currentRow = cell?.row ?? 0;
     const dataContext = this._grid.getDataItem(currentRow);

--- a/src/plugins/slick.customtooltip.ts
+++ b/src/plugins/slick.customtooltip.ts
@@ -1,5 +1,5 @@
-import type { CancellablePromiseWrapper, Column, CustomDataView, CustomTooltipOption, DOMEvent, Formatter, FormatterResultWithHtml, FormatterResultWithText, GridOption } from '../models/index';
-import { SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
+import type { CancellablePromiseWrapper, Column, CustomDataView, CustomTooltipOption, Formatter, FormatterResultWithHtml, FormatterResultWithText, GridOption } from '../models/index';
+import { type SlickEventData, SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
 import type { SlickGrid } from '../slick.grid';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)
@@ -133,7 +133,7 @@ export class SlickCustomTooltip {
   }
 
   /** depending on the selector type, execute the necessary handler code */
-  protected handleOnHeaderMouseEnterByType(e: DOMEvent<HTMLDivElement>, args: any, selector: CellType) {
+  protected handleOnHeaderMouseEnterByType(e: SlickEventData, args: any, selector: CellType) {
     // before doing anything, let's remove any previous tooltip before
     // and cancel any opened Promise/Observable when using async
     this.hideTooltip();
@@ -177,7 +177,7 @@ export class SlickCustomTooltip {
    * Handle mouse entering grid cell to show tooltip.
    * @param {jQuery.Event} e - The event
    */
-  protected handleOnMouseEnter(e: DOMEvent<HTMLDivElement>, args: any) {
+  protected handleOnMouseEnter(e: SlickEventData, args: any) {
     // before doing anything, let's remove any previous tooltip before
     // and cancel any opened Promise/Observable when using async
     this.hideTooltip();

--- a/src/plugins/slick.headerbuttons.ts
+++ b/src/plugins/slick.headerbuttons.ts
@@ -7,7 +7,7 @@ import type {
   OnHeaderCellRenderedEventArgs,
   SlickPlugin
 } from '../models/index';
-import { BindingEventService as BindingEventService_, Event as SlickEvent_, EventHandler as EventHandler_, Utils as Utils_ } from '../slick.core';
+import { BindingEventService as BindingEventService_,  EventHandler as EventHandler_, SlickEvent as SlickEvent_, type SlickEventData, Utils as Utils_ } from '../slick.core';
 import type { SlickGrid } from '../slick.grid';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)
@@ -117,7 +117,7 @@ export class SlickHeaderButtons implements SlickPlugin {
     this._bindingEventService.unbindAll();
   }
 
-  protected handleHeaderCellRendered(_e: Event, args: OnHeaderCellRenderedEventArgs) {
+  protected handleHeaderCellRendered(_e: SlickEventData, args: OnHeaderCellRenderedEventArgs) {
     const column = args.column;
 
     if (column.header?.buttons) {
@@ -177,7 +177,7 @@ export class SlickHeaderButtons implements SlickPlugin {
   }
 
 
-  protected handleBeforeHeaderCellDestroy(_e: Event, args: { column: Column; node: HTMLElement; }) {
+  protected handleBeforeHeaderCellDestroy(_e: SlickEventData, args: { column: Column; node: HTMLElement; }) {
     const column = args.column;
 
     if (column.header?.buttons) {

--- a/src/plugins/slick.headermenu.ts
+++ b/src/plugins/slick.headermenu.ts
@@ -1,4 +1,4 @@
-import { BindingEventService as BindingEventService_, Event as SlickEvent_, SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
+import { BindingEventService as BindingEventService_, Event as SlickEvent_, type SlickEventData, SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
 import type {
   Column,
   DOMEvent,
@@ -216,7 +216,7 @@ export class SlickHeaderMenu implements SlickPlugin {
     this.destroySubMenus();
   }
 
-  protected handleHeaderCellRendered(_e: MouseEvent, args: OnHeaderCellRenderedEventArgs) {
+  protected handleHeaderCellRendered(_e: SlickEventData, args: OnHeaderCellRenderedEventArgs) {
     const column = args.column;
     const menu = column?.header?.menu as HeaderMenuItems;
 
@@ -262,7 +262,7 @@ export class SlickHeaderMenu implements SlickPlugin {
     }
   }
 
-  protected handleBeforeHeaderCellDestroy(_e: Event, args: { column: Column; node: HTMLElement; }) {
+  protected handleBeforeHeaderCellDestroy(_e: SlickEventData, args: { column: Column; node: HTMLElement; }) {
     const column = args.column;
 
     if (column.header?.menu) {

--- a/src/plugins/slick.rowdetailview.ts
+++ b/src/plugins/slick.rowdetailview.ts
@@ -1,5 +1,5 @@
-import { SlickEvent as SlickEvent_, SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
-import type { Column, DOMEvent, FormatterResultWithHtml, GridOption, OnAfterRowDetailToggleArgs, OnBeforeRowDetailToggleArgs, OnRowBackToViewportRangeArgs, OnRowDetailAsyncEndUpdateArgs, OnRowDetailAsyncResponseArgs, OnRowOutOfViewportRangeArgs, RowDetailViewOption, UsabilityOverrideFn } from '../models/index';
+import { SlickEvent as SlickEvent_, type SlickEventData, SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
+import type { Column, FormatterResultWithHtml, GridOption, OnAfterRowDetailToggleArgs, OnBeforeRowDetailToggleArgs, OnRowBackToViewportRangeArgs, OnRowDetailAsyncEndUpdateArgs, OnRowDetailAsyncResponseArgs, OnRowOutOfViewportRangeArgs, RowDetailViewOption, UsabilityOverrideFn } from '../models/index';
 import type { SlickDataView } from '../slick.dataview';
 import type { SlickGrid } from '../slick.grid';
 
@@ -242,14 +242,14 @@ export class SlickRowDetailView {
   }
 
   /** Handle mouse click event */
-  protected handleClick(e: DOMEvent<HTMLDivElement>, args: { row: number; cell: number; }) {
+  protected handleClick(e: SlickEventData, args: { row: number; cell: number; }) {
     const dataContext = this._grid.getDataItem(args.row);
     if (!this.checkExpandableOverride(args.row, dataContext, this._grid)) {
       return;
     }
 
     // clicking on a row select checkbox
-    if (this._options.useRowClick || this._grid.getColumns()[args.cell]['id'] === this._options.columnId && e.target.classList.contains(this._options.cssClass || '')) {
+    if (this._options.useRowClick || this._grid.getColumns()[args.cell]['id'] === this._options.columnId && (e.target as HTMLDivElement).classList.contains(this._options.cssClass || '')) {
       // if editing, try to commit
       if (this._grid.getEditorLock().isActive() && !this._grid.getEditorLock().commitCurrentEdit()) {
         e.preventDefault();

--- a/src/plugins/slick.rowmovemanager.ts
+++ b/src/plugins/slick.rowmovemanager.ts
@@ -1,5 +1,5 @@
 import { SlickEvent as SlickEvent_, SlickEventData as SlickEventData_, SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
-import type { Column, DOMEvent, DragRowMove, FormatterResultWithHtml, RowMoveManagerOption, UsabilityOverrideFn } from '../models/index';
+import type { Column, DragRowMove, FormatterResultWithHtml, RowMoveManagerOption, UsabilityOverrideFn } from '../models/index';
 import type { SlickGrid } from '../slick.grid';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)
@@ -85,12 +85,12 @@ export class SlickRowMoveManager {
     this._options = Utils.extend({}, this._options, newOptions);
   }
 
-  protected handleDragInit(e: MouseEvent) {
+  protected handleDragInit(e: SlickEventData_) {
     // prevent the grid from cancelling drag'n'drop by default
     e.stopImmediatePropagation();
   }
 
-  protected handleDragStart(e: DOMEvent<HTMLDivElement>, dd: DragRowMove): boolean | void {
+  protected handleDragStart(e: SlickEventData_, dd: DragRowMove): boolean | void {
     const cell = this._grid.getCellFromEvent(e) || { cell: -1, row: -1 };
     const currentRow = cell?.row;
     const dataContext = this._grid.getDataItem(currentRow);
@@ -208,7 +208,7 @@ export class SlickRowMoveManager {
     }
   }
 
-  protected handleDragEnd(e: MouseEvent, dd: DragRowMove) {
+  protected handleDragEnd(e: SlickEventData_, dd: DragRowMove) {
     if (!this._dragging) {
       return;
     }

--- a/src/slick.dataview.ts
+++ b/src/slick.dataview.ts
@@ -1427,7 +1427,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
       }
     };
 
-    grid.onSelectedRowsChanged.subscribe((_e: Event, args: { rows: number[]; }) => {
+    grid.onSelectedRowsChanged.subscribe((_e: SlickEventData_, args: { rows: number[]; }) => {
       if (!inHandler) {
         const newSelectedRowIds = this.mapRowsToIds(args.rows);
         const selectedRowsChangedArgs = {
@@ -1601,7 +1601,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
       }
     };
 
-    grid.onCellCssStylesChanged.subscribe((_e: Event, args: any) => {
+    grid.onCellCssStylesChanged.subscribe((_e: SlickEventData_, args: any) => {
       if (inHandler) { return; }
       if (key !== args.key) { return; }
       if (args.hash) {

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -62,7 +62,6 @@ import type {
   RowInfo,
   SelectionModel,
   SingleColumnSort,
-  SlickGridEventData,
   SlickGridModel,
   SlickPlugin,
   MenuCommandItemCallbackArgs,
@@ -143,13 +142,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   // Events
   onActiveCellChanged: SlickEvent_<OnActiveCellChangedEventArgs>;
-  onActiveCellPositionChanged: SlickEvent_<SlickGridEventData>;
+  onActiveCellPositionChanged: SlickEvent_<{ grid: SlickGrid; }>;
   onAddNewRow: SlickEvent_<OnAddNewRowEventArgs>;
   onAutosizeColumns: SlickEvent_<OnAutosizeColumnsEventArgs>;
   onBeforeAppendCell: SlickEvent_<OnBeforeAppendCellEventArgs>;
   onBeforeCellEditorDestroy: SlickEvent_<OnBeforeCellEditorDestroyEventArgs>;
   onBeforeColumnsResize: SlickEvent_<OnBeforeColumnsResizeEventArgs>;
-  onBeforeDestroy: SlickEvent_<SlickGridEventData>;
+  onBeforeDestroy: SlickEvent_<{ grid: SlickGrid; }>;
   onBeforeEditCell: SlickEvent_<OnBeforeEditCellEventArgs>;
   onBeforeFooterRowCellDestroy: SlickEvent_<OnBeforeFooterRowCellDestroyEventArgs>;
   onBeforeHeaderCellDestroy: SlickEvent_<OnBeforeHeaderCellDestroyEventArgs>;
@@ -192,7 +191,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   onActivateChangedOptions: SlickEvent_<OnActivateChangedOptionsEventArgs>;
   onSort: SlickEvent_<SingleColumnSort | MultiColumnSort>;
   onValidationError: SlickEvent_<OnValidationErrorEventArgs>;
-  onViewportChanged: SlickEvent_<SlickGridEventData>;
+  onViewportChanged: SlickEvent_<{ grid: SlickGrid; }>;
 
   // ---
   // protected variables
@@ -525,13 +524,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     this._pubSubService = externalPubSub;
     this.onActiveCellChanged = new SlickEvent<OnActiveCellChangedEventArgs>('onActiveCellChanged', externalPubSub);
-    this.onActiveCellPositionChanged = new SlickEvent<SlickGridEventData>('onActiveCellPositionChanged', externalPubSub);
+    this.onActiveCellPositionChanged = new SlickEvent<{ grid: SlickGrid; }>('onActiveCellPositionChanged', externalPubSub);
     this.onAddNewRow = new SlickEvent<OnAddNewRowEventArgs>('onAddNewRow', externalPubSub);
     this.onAutosizeColumns = new SlickEvent<OnAutosizeColumnsEventArgs>('onAutosizeColumns', externalPubSub);
     this.onBeforeAppendCell = new SlickEvent<OnBeforeAppendCellEventArgs>('onBeforeAppendCell', externalPubSub);
     this.onBeforeCellEditorDestroy = new SlickEvent<OnBeforeCellEditorDestroyEventArgs>('onBeforeCellEditorDestroy', externalPubSub);
     this.onBeforeColumnsResize = new SlickEvent<OnBeforeColumnsResizeEventArgs>('onBeforeColumnsResize', externalPubSub);
-    this.onBeforeDestroy = new SlickEvent<SlickGridEventData>('onBeforeDestroy', externalPubSub);
+    this.onBeforeDestroy = new SlickEvent<{ grid: SlickGrid; }>('onBeforeDestroy', externalPubSub);
     this.onBeforeEditCell = new SlickEvent<OnBeforeEditCellEventArgs>('onBeforeEditCell', externalPubSub);
     this.onBeforeFooterRowCellDestroy = new SlickEvent<OnBeforeFooterRowCellDestroyEventArgs>('onBeforeFooterRowCellDestroy', externalPubSub);
     this.onBeforeHeaderCellDestroy = new SlickEvent<OnBeforeHeaderCellDestroyEventArgs>('onBeforeHeaderCellDestroy', externalPubSub);
@@ -574,7 +573,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.onActivateChangedOptions = new SlickEvent<OnActivateChangedOptionsEventArgs>('onActivateChangedOptions', externalPubSub);
     this.onSort = new SlickEvent<SingleColumnSort | MultiColumnSort>('onSort', externalPubSub);
     this.onValidationError = new SlickEvent<OnValidationErrorEventArgs>('onValidationError', externalPubSub);
-    this.onViewportChanged = new SlickEvent<SlickGridEventData>('onViewportChanged', externalPubSub);
+    this.onViewportChanged = new SlickEvent<{ grid: SlickGrid; }>('onViewportChanged', externalPubSub);
 
     this.initialize(options);
   }

--- a/src/slick.groupitemmetadataprovider.ts
+++ b/src/slick.groupitemmetadataprovider.ts
@@ -1,5 +1,5 @@
-import { SlickGroup as SlickGroup_, keyCode as keyCode_, Utils as Utils_ } from './slick.core';
-import type { Column, DOMEvent, GroupItemMetadataProviderOption, GroupingFormatterItem, ItemMetadata, SlickPlugin } from './models/index';
+import { type SlickEventData, SlickGroup as SlickGroup_, keyCode as keyCode_, Utils as Utils_ } from './slick.core';
+import type { Column, GroupItemMetadataProviderOption, GroupingFormatterItem, ItemMetadata, SlickPlugin } from './models/index';
 import type { SlickGrid } from './slick.grid';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)
@@ -113,8 +113,8 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     }
   }
 
-  protected handleGridClick(e: DOMEvent<HTMLDivElement>, args: { row: number; cell: number; grid: SlickGrid; }) {
-    const target = e.target;
+  protected handleGridClick(e: SlickEventData, args: { row: number; cell: number; grid: SlickGrid; }) {
+    const target = e.target as HTMLElement;
     const item = this._grid.getDataItem(args.row);
     if (item && item instanceof SlickGroup && target.classList.contains(this._options.toggleCssClass || '')) {
       this.handleDataViewExpandOrCollapse(item);
@@ -132,7 +132,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
   }
 
   // TODO:  add -/+ handling
-  protected handleGridKeyDown(e: KeyboardEvent) {
+  protected handleGridKeyDown(e: SlickEventData) {
     if (this._options.enableExpandCollapse && (e.which === keyCode.SPACE)) {
       const activeCell = this._grid.getActiveCell();
       if (activeCell) {


### PR DESCRIPTION
- fixes #967
- previously the 1st argument event was typed as `any` but in practical it will always be of type `SlickEventData` because a SlickEvent `.notify()` method always passes a SlickEventData

![image](https://github.com/6pac/SlickGrid/assets/643976/e0b3104a-c8dc-4ae1-b2de-fc315063fb05)
![image](https://github.com/6pac/SlickGrid/assets/643976/a1f273b7-72a4-4661-95d8-6a8433983547)
