### PR TITLE
fix(core): SlickEvent handler event should be type of ArgType

### DIFF
--- a/src/models/core.interface.ts
+++ b/src/models/core.interface.ts
@@ -1,6 +1,6 @@
 import { type SlickEventData } from '../slick.core';
 
-export type Handler<ArgType = any> = (e: SlickEventData, args: ArgType) => void;
+export type Handler<ArgType = any> = (e: SlickEventData<ArgType>, args: ArgType) => void;
 
 export interface ElementEventListener {
   element: Element | Window;

--- a/src/models/rowDetailViewOption.interface.ts
+++ b/src/models/rowDetailViewOption.interface.ts
@@ -101,6 +101,9 @@ export interface OnRowDetailAsyncResponseArgs {
 
   /** An explicit view to use instead of template (Optional) */
   detailView?: any;
+
+  /** SlickGrid instance */
+  grid: SlickGrid;
 }
 
 /** Fired when the async response finished */

--- a/src/models/rowDetailViewOption.interface.ts
+++ b/src/models/rowDetailViewOption.interface.ts
@@ -103,7 +103,7 @@ export interface OnRowDetailAsyncResponseArgs {
   detailView?: any;
 
   /** SlickGrid instance */
-  grid: SlickGrid;
+  grid?: SlickGrid;
 }
 
 /** Fired when the async response finished */
@@ -115,7 +115,7 @@ export interface OnRowDetailAsyncEndUpdateArgs {
   itemDetail: any;
 
   /** Reference to the Slick grid object */
-  grid: SlickGrid;
+  grid?: SlickGrid;
 }
 
 /** Fired after the row detail gets toggled */

--- a/src/plugins/slick.rowdetailview.ts
+++ b/src/plugins/slick.rowdetailview.ts
@@ -503,7 +503,8 @@ export class SlickRowDetailView {
       this.onAsyncResponse.notify({
         item,
         itemDetail: item,
-        detailView: item[`${this._keyPrefix}detailContent`]
+        detailView: item[`${this._keyPrefix}detailContent`],
+        grid: this._grid
       }, undefined, this);
       this.applyTemplateNewLineHeight(item);
       this._dataView.updateItem(item[this._dataViewIdProperty], item);

--- a/src/slick.core.ts
+++ b/src/slick.core.ts
@@ -203,7 +203,7 @@ export class SlickEvent<ArgType = any> {
    * @param {Object} [scope] - The scope ("this") within which the handler will be executed.
    *      If not specified, the scope will be set to the <code>Event</code> instance.
    */
-  notify(args: ArgType, evt?: SlickEventData | Event | MergeTypes<SlickEventData, Event> | null, scope?: any) {
+  notify(args: ArgType, evt?: SlickEventData<ArgType> | Event | MergeTypes<SlickEventData<ArgType>, Event> | null, scope?: any) {
     const sed: SlickEventData = evt instanceof SlickEventData
       ? evt
       : new SlickEventData(evt, args);
@@ -216,7 +216,7 @@ export class SlickEvent<ArgType = any> {
 
     // user can optionally add a global PubSub Service which makes it easy to publish/subscribe to events
     if (typeof this._pubSubService?.publish === 'function' && this.eventName) {
-      const ret = this._pubSubService.publish<{ args: ArgType; eventData?: SlickEventData; nativeEvent?: Event; }>(this.eventName, { args, eventData: sed });
+      const ret = this._pubSubService.publish<{ args: ArgType; eventData?: SlickEventData<ArgType>; nativeEvent?: Event; }>(this.eventName, { args, eventData: sed });
       sed.addReturnValue(ret);
     }
     return sed;


### PR DESCRIPTION
- continuation of previous PR #969 related to issue #967 to add proper types to SlickEventHandler arguments

![image](https://github.com/6pac/SlickGrid/assets/643976/d99743b7-f228-4dc9-85b7-d6feee9136a5)
