### PR TITLE
fix: legacyAutosizeColumns should push hidden width as 0

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -3133,7 +3133,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     for (i = 0; i < this.columns.length; i++) {
       c = this.columns[i];
-      if (!c || c.hidden) { continue; }
+      if (!c || c.hidden) {
+        widths.push(0);
+        continue;
+      }
       widths.push(c.width || 0);
       total += c.width || 0;
       if (c.resizable) {


### PR DESCRIPTION
- the previous code was skipping hidden columns, however we have a `widths` array that relies on column index and it became out of sync when a hidden column is skipped because the indexes no longer matches the column widths indexes when it is used in the next for loop