### PR TITLE
fix: when `onResizeStart` return false it should stop

### DIFF
--- a/examples/example4-model-esm.html
+++ b/examples/example4-model-esm.html
@@ -222,7 +222,9 @@ function changeCSS(prevFilePath, newFilePath) {
 
 function requiredFieldValidator(value) {
   if (value == null || value == undefined || !value.length) {
-    return {valid: false, msg: "This is a required field"};
+    return {valid: false, msg: 'This is a required field'};
+  } else if (!/^(task\s\d+)*$/i.test(value)) {
+    return { valid: false, msg: 'Your title is invalid, it must start with "Task" followed by a number.' };
   }
   else {
     return {valid: true, msg: null};

--- a/src/slick.interactions.ts
+++ b/src/slick.interactions.ts
@@ -231,18 +231,20 @@ export function Resizable(options: ResizableOption) {
 
   function executeResizeCallbackWhenDefined(callback?: Function, e?: MouseEvent | TouchEvent | Touch) {
     if (typeof callback === 'function') {
-      callback(e, { resizeableElement, resizeableHandleElement });
+      return callback(e, { resizeableElement, resizeableHandleElement });
     }
   }
 
   function resizeStartHandler(e: MouseEvent | TouchEvent) {
     e.preventDefault();
     const event = (e as TouchEvent).touches ? (e as TouchEvent).changedTouches[0] : e;
-    executeResizeCallbackWhenDefined(onResizeStart, event);
-    document.body.addEventListener('mousemove', resizingHandler);
-    document.body.addEventListener('mouseup', resizeEndHandler);
-    document.body.addEventListener('touchmove', resizingHandler);
-    document.body.addEventListener('touchend', resizeEndHandler);
+    const result = executeResizeCallbackWhenDefined(onResizeStart, event);
+    if (result !== false) {
+      document.body.addEventListener('mousemove', resizingHandler);
+      document.body.addEventListener('mouseup', resizeEndHandler);
+      document.body.addEventListener('touchmove', resizingHandler);
+      document.body.addEventListener('touchend', resizeEndHandler);
+    }
   }
 
   function resizingHandler(e: MouseEvent | TouchEvent) {


### PR DESCRIPTION
- when `onResizeStart` returns `false`, for example when editor `commitCurrentEdit()` fails, then the column resize shouldn't be allowed

https://github.com/6pac/SlickGrid/blob/ab634eb0b1c83542c5e6ac75f84e16fa02510609/src/slick.grid.ts#L1939-L1943

![brave_JDQMdK491W](https://github.com/6pac/SlickGrid/assets/643976/6292bf7e-3f7c-4379-8777-528a3bc7927b)
