### PR TITLE
fix: regression `onSelectedRowsChanged` not receiving correct `caller`

### DIFF
--- a/src/plugins/slick.cellselectionmodel.ts
+++ b/src/plugins/slick.cellselectionmodel.ts
@@ -111,9 +111,9 @@ export class SlickCellSelectionModel {
 
     this._ranges = this.removeInvalidRanges(ranges);
     if (rangeHasChanged) {
-      // provide extra "caller" argument through SlickEventData to avoid breaking pubsub event that only accepts an array of selected range
-      const eventData = new SlickEventData(null, this._ranges);
-      Object.defineProperty(eventData, 'detail', { writable: true, configurable: true, value: { caller: caller || 'SlickCellSelectionModel.setSelectedRanges' } });
+      // provide extra "caller" argument through SlickEventData event to avoid breaking the previous pubsub event structure
+      // that only accepts an array of selected range `SlickRange[]`, the SlickEventData args will be merged and used later by `onSelectedRowsChanged`
+      const eventData = new SlickEventData(new CustomEvent('click', { detail: { caller } }), this._ranges);
       this.onSelectedRangesChanged.notify(this._ranges, eventData);
     }
   }

--- a/src/plugins/slick.rowselectionmodel.ts
+++ b/src/plugins/slick.rowselectionmodel.ts
@@ -141,9 +141,9 @@ export class SlickRowSelectionModel {
     }
     this._ranges = ranges;
 
-    // provide extra "caller" argument through SlickEventData to avoid breaking pubsub event that only accepts an array of selected range
-    const eventData = new SlickEventData(null, this._ranges);
-    Object.defineProperty(eventData, 'detail', { writable: true, configurable: true, value: { caller: caller || 'SlickRowSelectionModel.setSelectedRanges' } });
+    // provide extra "caller" argument through SlickEventData event to avoid breaking the previous pubsub event structure
+    // that only accepts an array of selected range `SlickRange[]`, the SlickEventData args will be merged and used later by `onSelectedRowsChanged`
+    const eventData = new SlickEventData(new CustomEvent('click', { detail: { caller } }), this._ranges);
     this.onSelectedRangesChanged.notify(this._ranges, eventData);
   }
 


### PR DESCRIPTION
- a regression was introduced when dropping jQuery, the SlickEvent structure changed in the `notify` function. Previously a SlickEvent would accept a CustomEvent directly and the previous code was expecting that event to exists and override its CustomEvent `detail`, however the newer approach is to always use a SlickEventData and no longer use the CustomEvent directly and this caused the regression since the SlickEventData doesn't have a `detail` property but rather something like this `SlickEventData { event: { detail } }`
- the fix is to simply create a CustomEvent with `{ detail: caller }` which we then pass to the `SlickEventData` constructor so that our `caller` isn't lost and rather reused later when triggered by `onSelectedRowsChanged`