### PR TITLE
fix: realtime trading demo grouping wasn't working

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,11 +25,11 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 3
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Set Node.js version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 
@@ -54,7 +54,7 @@ jobs:
         run: npm run serve:demo &
 
       - name: Run Cypress E2E tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           # wait-on: 'http://localhost:8080'
           browser: chrome

--- a/cypress/e2e/example-trading-esm.cy.ts
+++ b/cypress/e2e/example-trading-esm.cy.ts
@@ -1,0 +1,77 @@
+describe('Example - Real-Time Trading Platform', () => {
+  const titles = ['Currency', 'Symbol', 'Market', 'Company', 'Type', 'Change', 'Price', 'Qty', 'Amount', 'Price History', 'Execution Timestamp'];
+  const GRID_ROW_HEIGHT = 28;
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-trading-esm.html`);
+    cy.get('h2').contains('Demonstrates');
+    cy.get('h2 + ul > li').first().contains('High Frequency Update - Realtime Trading Platform');
+  });
+
+  it('should have exact column titles on 1st grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(titles[index]));
+  });
+
+  it('should check first 5 rows and expect certain data', () => {
+    for (let i = 0; i < 5; i++) {
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * i}px;"] > .slick-cell:nth(0)`).contains(/AUD|CAD|USD$/);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * i}px;"] > .slick-cell:nth(4)`).contains(/Buy|Sell$/);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * i}px;"] > .slick-cell:nth(5)`).contains(/\$\(?[0-9\.]*\)?/);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * i}px;"] > .slick-cell:nth(6)`).contains(/\$[0-9\.]*/);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * i}px;"] > .slick-cell:nth(7)`).contains(/\d$/);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * i}px;"] > .slick-cell:nth(8)`).contains(/\$[0-9\.]*/);
+    }
+  });
+
+  it('should find multiple green & pink backgrounds to show gains & losses when in real-time mode', () => {
+    cy.get('#refreshRateSlider').invoke('val', 5).trigger('change');
+
+    cy.get('.changed-gain').should('have.length.gt', 2);
+    cy.get('.changed-loss').should('have.length.gt', 2);
+  });
+
+  it('should NOT find any green neither pink backgrounds when in real-time is stopped', () => {
+    cy.get('#highlightDuration').type('{backspace}');
+    cy.get('#btnStopSimulation').click();
+
+    cy.wait(5);
+    cy.get('.changed-gain').should('have.length', 0);
+    cy.get('.changed-loss').should('have.length', 0);
+    cy.wait(1);
+    cy.get('.changed-gain').should('have.length', 0);
+    cy.get('.changed-loss').should('have.length', 0);
+  });
+
+  it('should Group by "Currency" and expect 3 groups with Totals when collapsed', () => {
+    cy.get('[data-test="group-currency-btn"]').click();
+    cy.get('[data-test="collapse-all-btn"]').click();
+
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-toggle.collapsed`).should('have.length', 1);
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-title`).should('contain', 'Currency: AUD');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(8)`).contains(/\$[0-9\,\.]*/);
+
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(0) .slick-group-toggle.collapsed`).should('have.length', 1);
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(0) .slick-group-title`).should('contain', 'Currency: CAD');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(8)`).contains(/\$[0-9\,\.]*/);
+
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(0) .slick-group-toggle.collapsed`).should('have.length', 1);
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(0) .slick-group-title`).should('contain', 'Currency: USD');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(8)`).contains(/\$[0-9\,\.]*/);
+  });
+
+  it('should clear Grouping and expect regular trading row from non specific currency', () => {
+    cy.get('[data-test="clear-grouping-btn"]').click();
+
+    for (let i = 0; i < 5; i++) {
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * i}px;"] > .slick-cell:nth(0)`).contains(/AUD|CAD|USD$/);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * i}px;"] > .slick-cell:nth(4)`).contains(/Buy|Sell$/);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * i}px;"] > .slick-cell:nth(5)`).contains(/\$\(?[0-9\.]*\)?/);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * i}px;"] > .slick-cell:nth(6)`).contains(/\$[0-9\.]*/);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * i}px;"] > .slick-cell:nth(7)`).contains(/\d$/);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * i}px;"] > .slick-cell:nth(8)`).contains(/\$[0-9\.]*/);
+    }
+  });
+});

--- a/cypress/e2e/example4-model.cy.ts
+++ b/cypress/e2e/example4-model.cy.ts
@@ -5,7 +5,7 @@ describe('Example 4 - Model', () => {
   beforeEach(() => {
     // create a console.log spy for later use
     cy.window().then((win) => {
-      cy.spy(win.console, "log");
+      cy.spy(win.console, 'log');
     });
   });
 

--- a/examples/example-trading-esm.html
+++ b/examples/example-trading-esm.html
@@ -264,7 +264,7 @@
     dataView.setGrouping({
       getter: columnName,
       formatter: function (g) {
-        return `${columnName.replace(/(^\w|\s\w)/g, m => m.toUpperCase())}:  ${g.value}  <span style='color:#029eb7'>(${g.count} items)</span>`;
+        return `${columnName.replace(/(^\w|\s\w)/g, m => m.toUpperCase())}: ${g.value}  <span style='color:#029eb7'>(${g.count} items)</span>`;
       },
       aggregators: [
         new Aggregators.Sum("amount")

--- a/examples/example-trading-esm.html
+++ b/examples/example-trading-esm.html
@@ -382,7 +382,6 @@ document.addEventListener("DOMContentLoaded", () => {
     groupItemMetadataProvider: groupItemMetadataProvider,
     inlineFilters: true
   });
-  dataView = new SlickDataView();
   grid = new SlickGrid("#myGrid", dataView, columns, options);
   grid.registerPlugin(groupItemMetadataProvider);
   grid.setSelectionModel(new SlickRowSelectionModel());


### PR DESCRIPTION
- Grouping wasn't working and was caused by a duplicate DataView instantiation and the 2nd one didn't have the groupItemMetadataProvider and it was basically overriding the 1st one which was the correct one with the groupItemMetadataProvider plugin instantiated which is needed for the Grouping to work correctly