### PR TITLE
fix: `column.editor` and `gridOptions.editorFactory` type changed

### DIFF
--- a/src/models/column.interface.ts
+++ b/src/models/column.interface.ts
@@ -85,7 +85,7 @@ export interface Column<TData = any> {
   disableTooltip?: boolean;
 
   /** Any inline editor function that implements Editor for the cell value or ColumnEditor */
-  editor?: Editor /*| { model?: Editor; }*/ | EditorConstructor | null;
+  editor?: Editor | EditorConstructor | null;
 
   /** Editor number fixed decimal places */
   editorFixedDecimalPlaces?: number;

--- a/src/models/column.interface.ts
+++ b/src/models/column.interface.ts
@@ -3,6 +3,7 @@ import type {
   CellMenuOption,
   CustomTooltipOption,
   Editor,
+  EditorConstructor,
   EditorValidator,
   Formatter,
   FormatterResultWithHtml,
@@ -84,7 +85,7 @@ export interface Column<TData = any> {
   disableTooltip?: boolean;
 
   /** Any inline editor function that implements Editor for the cell value or ColumnEditor */
-  editor?: Editor | { model?: Editor; } | null;
+  editor?: Editor /*| { model?: Editor; }*/ | EditorConstructor | null;
 
   /** Editor number fixed decimal places */
   editorFixedDecimalPlaces?: number;

--- a/src/models/editor.interface.ts
+++ b/src/models/editor.interface.ts
@@ -1,7 +1,7 @@
 import type { EditorArguments } from './editorArguments.interface';
 import type { EditorValidationResult } from './editorValidationResult.interface';
 import type { GridOption } from '../models/gridOption.interface';
-import type { Column } from '../models/column.interface';
+import type { Column, EditorArguments, EditorValidationResult, GridOption } from './index';
 /**
  * SlickGrid Editor interface, more info can be found on the SlickGrid repo
  * https://github.com/6pac/SlickGrid/wiki/Writing-custom-cell-editors

--- a/src/models/editor.interface.ts
+++ b/src/models/editor.interface.ts
@@ -1,6 +1,7 @@
 import type { EditorArguments } from './editorArguments.interface';
 import type { EditorValidationResult } from './editorValidationResult.interface';
-
+import type { GridOption } from '../models/gridOption.interface';
+import type { Column } from '../models/column.interface';
 /**
  * SlickGrid Editor interface, more info can be found on the SlickGrid repo
  * https://github.com/6pac/SlickGrid/wiki/Writing-custom-cell-editors
@@ -86,3 +87,10 @@ export interface Editor {
    */
   validate: (targetElm?: HTMLElement, options?: any) => EditorValidationResult;
 }
+
+export type EditorConstructor = {
+  new <TData = any, C extends Column<TData> = Column<TData>, O extends GridOption<C> = GridOption<C>>(args?: EditorArguments<TData, C, O>): Editor;
+
+  /** static flag used in makeActiveCellEditable*/
+  suppressClearOnEdit?: boolean;
+};

--- a/src/models/editor.interface.ts
+++ b/src/models/editor.interface.ts
@@ -1,6 +1,3 @@
-import type { EditorArguments } from './editorArguments.interface';
-import type { EditorValidationResult } from './editorValidationResult.interface';
-import type { GridOption } from '../models/gridOption.interface';
 import type { Column, EditorArguments, EditorValidationResult, GridOption } from './index';
 /**
  * SlickGrid Editor interface, more info can be found on the SlickGrid repo

--- a/src/models/editor.interface.ts
+++ b/src/models/editor.interface.ts
@@ -78,8 +78,7 @@ export interface Editor {
 
   /** Update the Editor DOM element value with a provided value, we can optionally apply the value to the item dataContext object */
   setValue?: (value: any, isApplyingValue?: boolean, triggerOnCompositeEditorChange?: boolean) => void;
-
-  suppressClearOnEdit?: boolean;
+  
   /**
    * Validate user input and return the result along with the validation message.
    * if the input is valid then the validation result output would be returning { valid:true, msg:null }
@@ -91,6 +90,6 @@ export interface Editor {
 export type EditorConstructor = {
   new <TData = any, C extends Column<TData> = Column<TData>, O extends GridOption<C> = GridOption<C>>(args?: EditorArguments<TData, C, O>): Editor;
 
-  /** static flag used in makeActiveCellEditable*/
+  /** Static flag used in makeActiveCellEditable. */
   suppressClearOnEdit?: boolean;
 };

--- a/src/models/editorArguments.interface.ts
+++ b/src/models/editorArguments.interface.ts
@@ -2,7 +2,7 @@
 import { Column, ElementPosition, PositionMethod } from './index';
 import type { SlickDataView } from '../slick.dataview';
 import type { SlickGrid } from '../slick.grid';
-import type { GridOption } from '../models/gridOption.interface';     
+import type { Column, ElementPosition, GridOption, PositionMethod } from './index';
 
 export interface EditorArguments<TData = any, C extends Column<TData> = Column<TData>, O extends GridOption<C> = GridOption<C>> {
   /** Column Definition */

--- a/src/models/editorArguments.interface.ts
+++ b/src/models/editorArguments.interface.ts
@@ -2,8 +2,9 @@
 import { Column, ElementPosition, PositionMethod } from './index';
 import type { SlickDataView } from '../slick.dataview';
 import type { SlickGrid } from '../slick.grid';
+import type { GridOption } from '../models/gridOption.interface';     
 
-export interface EditorArguments {
+export interface EditorArguments<TData = any, C extends Column<TData> = Column<TData>, O extends GridOption<C> = GridOption<C>> {
   /** Column Definition */
   column: Column;
 
@@ -17,13 +18,13 @@ export interface EditorArguments {
   container: HTMLDivElement;
 
   /** Slick DataView */
-  dataView: SlickDataView;
+  dataView?: SlickDataView;
 
   /** Event that was triggered */
   event: Event;
 
   /** Slick Grid object */
-  grid: SlickGrid;
+  grid: SlickGrid<TData, C, O>;
 
   /** Grid Position */
   gridPosition: ElementPosition;

--- a/src/models/editorArguments.interface.ts
+++ b/src/models/editorArguments.interface.ts
@@ -1,5 +1,3 @@
-
-import { Column, ElementPosition, PositionMethod } from './index';
 import type { SlickDataView } from '../slick.dataview';
 import type { SlickGrid } from '../slick.grid';
 import type { Column, ElementPosition, GridOption, PositionMethod } from './index';

--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -1,4 +1,4 @@
-import type { Column as BaseColumn, CellMenuOption, ColumnPickerOption, ColumnReorderFunction, ContextMenuOption, CustomTooltipOption, EditCommand, Editor, ExcelCopyBufferOption, Formatter, GridMenuOption, ItemMetadata, } from './index';
+import type { Column as BaseColumn, CellMenuOption, ColumnPickerOption, ColumnReorderFunction, ContextMenuOption, CustomTooltipOption, EditCommand, Editor, EditorConstructor, ExcelCopyBufferOption, Formatter, GridMenuOption, ItemMetadata, } from './index';
 import type { SlickEditorLock } from '../slick.core';
 
 export interface CellViewportRange {
@@ -121,7 +121,7 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   editCommandHandler?: (item: any, column: C, command: EditCommand) => void;
 
   /** Editor classes factory */
-  editorFactory?: null | { getEditor: (col: C) => Editor; };
+  editorFactory?: null | { getEditor: (col: C) => Editor | EditorConstructor; };
 
   /** a global singleton editor lock. */
   editorLock?: SlickEditorLock;

--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -1,4 +1,4 @@
-import type { Column as BaseColumn, CellMenuOption, ColumnPickerOption, ColumnReorderFunction, ContextMenuOption, CustomTooltipOption, EditCommand, Editor, EditorConstructor, ExcelCopyBufferOption, Formatter, GridMenuOption, ItemMetadata, } from './index';
+import type { Column as BaseColumn, CellMenuOption, ColumnPickerOption, ColumnReorderFunction, ContextMenuOption, CustomTooltipOption, EditCommand, EditorConstructor, ExcelCopyBufferOption, Formatter, GridMenuOption, ItemMetadata, } from './index';
 import type { SlickEditorLock } from '../slick.core';
 
 export interface CellViewportRange {
@@ -121,7 +121,7 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   editCommandHandler?: (item: any, column: C, command: EditCommand) => void;
 
   /** Editor classes factory */
-  editorFactory?: null | { getEditor: (col: C) => Editor | EditorConstructor; };
+  editorFactory?: null | { getEditor: (col: C) => EditorConstructor; };
 
   /** a global singleton editor lock. */
   editorLock?: SlickEditorLock;

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -2448,10 +2448,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       for (i = 0; i < cssRules.length; i++) {
         const selector = cssRules[i].selectorText;
         if (matches = /\.l\d+/.exec(selector)) {
-          columnIdx = parseInt(matches[0].slice(2), 10);
+          columnIdx = parseInt(matches[0].substr(2, matches[0].length - 2), 10);
           this.columnCssRulesL[columnIdx] = cssRules[i];
         } else if (matches = /\.r\d+/.exec(selector)) {
-          columnIdx = parseInt(matches[0].slice(2), 10);
+          columnIdx = parseInt(matches[0].substr(2, matches[0].length - 2), 10);
           this.columnCssRulesR[columnIdx] = cssRules[i];
         }
       }
@@ -5598,7 +5598,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (!cls) {
       throw new Error(`SlickGrid getCellFromNode: cannot get cell - ${cellNode.className}`);
     }
-    return parseInt(cls[0].slice(1), 10);
+    return parseInt(cls[0].substr(1, cls[0].length - 1), 10);
   }
 
   protected getRowFromNode(rowNode: HTMLElement): number | null {

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -2448,10 +2448,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       for (i = 0; i < cssRules.length; i++) {
         const selector = cssRules[i].selectorText;
         if (matches = /\.l\d+/.exec(selector)) {
-          columnIdx = parseInt(matches[0].substr(2, matches[0].length - 2), 10);
+          columnIdx = parseInt(matches[0].slice(2), 10);
           this.columnCssRulesL[columnIdx] = cssRules[i];
         } else if (matches = /\.r\d+/.exec(selector)) {
-          columnIdx = parseInt(matches[0].substr(2, matches[0].length - 2), 10);
+          columnIdx = parseInt(matches[0].slice(2), 10);
           this.columnCssRulesR[columnIdx] = cssRules[i];
         }
       }
@@ -5598,7 +5598,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (!cls) {
       throw new Error(`SlickGrid getCellFromNode: cannot get cell - ${cellNode.className}`);
     }
-    return parseInt(cls[0].substr(1, cls[0].length - 1), 10);
+    return parseInt(cls[0].slice(1), 10);
   }
 
   protected getRowFromNode(rowNode: HTMLElement): number | null {


### PR DESCRIPTION
editor and edtitor factory do not return an Editor Object but a typeof Editor to be constructed with new (...) Otherwise it is impossible to implement an Editor Factory in Typescript