### PR TITLE
fix: add ESLint-TS rules to enforce `type` imports and exports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
   "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": ["./tsconfig.json"]
+  },
   "settings": {
     "node": {
       "tryExtensions": [".js", ".json", ".node", ".ts", ".d.ts"],
@@ -36,6 +39,8 @@
         "extendDefaults": true
       }
     ],
+    "@typescript-eslint/consistent-type-exports": "error",
+    "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-non-null-assertion": "off",

--- a/src/models/autoSize.interface.ts
+++ b/src/models/autoSize.interface.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './formatter.interface';
+import type { Formatter } from './formatter.interface';
 
 export interface AutoSize {
   allowAddlPercent?: number;

--- a/src/models/editorValidator.interface.ts
+++ b/src/models/editorValidator.interface.ts
@@ -1,4 +1,4 @@
-import { EditorArguments } from './editorArguments.interface';
-import { EditorValidationResult } from './editorValidationResult.interface';
+import type { EditorArguments } from './editorArguments.interface';
+import type { EditorValidationResult } from './editorValidationResult.interface';
 
 export type EditorValidator = (value: any, args?: EditorArguments) => EditorValidationResult;

--- a/src/models/grouping.interface.ts
+++ b/src/models/grouping.interface.ts
@@ -1,7 +1,7 @@
-import { Aggregator } from './aggregator.interface';
-import { GroupingComparerItem } from './groupingComparerItem.interface';
-import { GroupingFormatterItem } from './groupingFormatterItem.interface';
-import { SortDirectionNumber } from './sortDirectionNumber.enum';
+import type { Aggregator } from './aggregator.interface';
+import type { GroupingComparerItem } from './groupingComparerItem.interface';
+import type { GroupingFormatterItem } from './groupingFormatterItem.interface';
+import type { SortDirectionNumber } from './sortDirectionNumber.enum';
 
 export type GroupingGetterFunction<T = any> = (value: T) => any;
 

--- a/src/models/interactions.interface.ts
+++ b/src/models/interactions.interface.ts
@@ -1,7 +1,7 @@
 // --
 // slick.interactions.ts
 
-import { DragPosition } from './drag.interface';
+import type { DragPosition } from './drag.interface';
 
 export interface InteractionBase {
   destroy: () => void;

--- a/src/models/slickPlugin.interface.ts
+++ b/src/models/slickPlugin.interface.ts
@@ -1,4 +1,4 @@
-import { SlickGridModel } from './slickGridModel.interface';
+import type { SlickGridModel } from './slickGridModel.interface';
 
 export interface SlickPlugin {
   pluginName: string;

--- a/src/plugins/slick.cellcopymanager.ts
+++ b/src/plugins/slick.cellcopymanager.ts
@@ -1,5 +1,5 @@
 import type { CssStyleHash, SlickPlugin } from '../models/index';
-import { keyCode as keyCode_, SlickEvent as SlickEvent_, type SlickEventData, Utils as Utils_, SlickRange } from '../slick.core';
+import { keyCode as keyCode_, SlickEvent as SlickEvent_, type SlickEventData, Utils as Utils_, type SlickRange } from '../slick.core';
 import type { SlickGrid } from '../slick.grid';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)

--- a/src/plugins/slick.cellrangedecorator.ts
+++ b/src/plugins/slick.cellrangedecorator.ts
@@ -1,5 +1,5 @@
 import type { CSSStyleDeclarationWritable, CellRangeDecoratorOption, SlickPlugin } from '../models/index';
-import { Utils as Utils_, SlickRange } from '../slick.core';
+import { Utils as Utils_, type SlickRange } from '../slick.core';
 import type { SlickGrid } from '../slick.grid';
 
 // for (iife) load Slick methods from global Slick object, or use imports for (esm)

--- a/src/plugins/slick.crossgridrowmovemanager.ts
+++ b/src/plugins/slick.crossgridrowmovemanager.ts
@@ -1,4 +1,4 @@
-import { SlickEvent as SlickEvent_, SlickEventData as SlickEventData_, SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
+import { SlickEvent as SlickEvent_, type SlickEventData as SlickEventData_, SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
 import type { Column, DragRowMove, CrossGridRowMoveManagerOption, FormatterResultWithText, UsabilityOverrideFn } from '../models/index';
 import type { SlickGrid } from '../slick.grid';
 

--- a/src/plugins/slick.rowmovemanager.ts
+++ b/src/plugins/slick.rowmovemanager.ts
@@ -1,4 +1,4 @@
-import { SlickEvent as SlickEvent_, SlickEventData as SlickEventData_, SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
+import { SlickEvent as SlickEvent_, type SlickEventData as SlickEventData_, SlickEventHandler as SlickEventHandler_, Utils as Utils_ } from '../slick.core';
 import type { Column, DragRowMove, FormatterResultWithHtml, RowMoveManagerOption, UsabilityOverrideFn } from '../models/index';
 import type { SlickGrid } from '../slick.grid';
 

--- a/src/slick.dataview.ts
+++ b/src/slick.dataview.ts
@@ -24,7 +24,7 @@ import {
   SlickGroup as SlickGroup_,
   SlickGroupTotals as SlickGroupTotals_,
   Utils as Utils_,
-  SlickNonDataItem,
+  type SlickNonDataItem,
 } from './slick.core';
 import { SlickGroupItemMetadataProvider as SlickGroupItemMetadataProvider_ } from './slick.groupitemmetadataprovider';
 


### PR DESCRIPTION
for more info, read this ESLint article: https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/