### PR TITLE
fix: Editor.keyCaptureList is an array of numbers

### DIFF
--- a/src/models/editor.interface.ts
+++ b/src/models/editor.interface.ts
@@ -10,7 +10,7 @@ export interface Editor {
   /** is the Editor disabled when we first open it? This could happen when we use "collectionAsync" and we wait for the "collection" to be filled before enabling the Editor. */
   disabled?: boolean;
 
-  keyCaptureList?: string;
+  keyCaptureList?: number[];
 
   /** Initialize the Editor */
   init: (args?: EditorArguments) => void;
@@ -75,7 +75,7 @@ export interface Editor {
 
   /** Update the Editor DOM element value with a provided value, we can optionally apply the value to the item dataContext object */
   setValue?: (value: any, isApplyingValue?: boolean, triggerOnCompositeEditorChange?: boolean) => void;
-  
+
   /**
    * Validate user input and return the result along with the validation message.
    * if the input is valid then the validation result output would be returning { valid:true, msg:null }

--- a/src/models/editor.interface.ts
+++ b/src/models/editor.interface.ts
@@ -10,6 +10,7 @@ export interface Editor {
   /** is the Editor disabled when we first open it? This could happen when we use "collectionAsync" and we wait for the "collection" to be filled before enabling the Editor. */
   disabled?: boolean;
 
+  /** List of key codes, which will not be captured by default slickgrid hotkeys listeners */
   keyCaptureList?: number[];
 
   /** Initialize the Editor */

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -15,7 +15,7 @@ import type {
   Editor,
   EditorArguments,
   EditorConstructor,
-  EditController, 
+  EditController,
   Formatter,
   FormatterOverrideCallback,
   FormatterResultObject,
@@ -1619,7 +1619,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     for (let i = 0; i < this.columns.length; i++) {
       const m: C = this.columns[i];
       if (m.hidden) { continue; }
-      
+
       const headerTarget = this.hasFrozenColumns() ? ((i <= this._options.frozenColumn!) ? this._headerL : this._headerR) : this._headerL;
       const headerRowTarget = this.hasFrozenColumns() ? ((i <= this._options.frozenColumn!) ? this._headerRowL : this._headerRowR) : this._headerRowL;
 
@@ -5334,7 +5334,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (!handled) {
       if (!e.shiftKey && !e.altKey) {
         if (this._options.editable && this.currentEditor?.keyCaptureList) {
-          if (this.currentEditor.keyCaptureList.indexOf(String(e.which)) > -1) {
+          if (this.currentEditor.keyCaptureList.indexOf(e.which) > -1) {
             return;
           }
         }
@@ -5349,7 +5349,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (!e.shiftKey && !e.altKey && !e.ctrlKey) {
         // editor may specify an array of keys to bubble
         if (this._options.editable && this.currentEditor?.keyCaptureList) {
-          if (this.currentEditor.keyCaptureList.indexOf(String(e.which)) > -1) {
+          if (this.currentEditor.keyCaptureList.indexOf(e.which) > -1) {
             return;
           }
         }
@@ -5949,7 +5949,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     metadata = metadata?.columns as any;
     const columnMetaData = metadata && (metadata[columnDef.id as keyof ItemMetadata] || (metadata as any)[this.activeCell]);
 
-    
+
     const editorArgs: EditorArguments<TData, C, O> = {
       grid: this,
       gridPosition: this.absBox(this._container),


### PR DESCRIPTION
The 'keyCaptureList' variable of the Editor class is an array of numbers.