### PR TITLE
feat: add the ability to receive extra filter arguments

### DIFF
--- a/src/slick.dataview.ts
+++ b/src/slick.dataview.ts
@@ -201,7 +201,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** get extra filter arguments of the filter method */
-  getFilterArgs(): any {
+  getFilterArgs() {
     return this.filterArgs;
   }
 

--- a/src/slick.dataview.ts
+++ b/src/slick.dataview.ts
@@ -200,6 +200,11 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     this.refreshHints = hints;
   }
 
+  /** get extra filter arguments of the filter method */
+  getFilterArgs(): any {
+    return this.filterArgs;
+  }
+
   /** add extra filter arguments to the filter method */
   setFilterArgs(args: any) {
     this.filterArgs = args;


### PR DESCRIPTION
It would be very handy for developers to have ability to receive extra arguments of filter function. For example when filter is applyed we can: 
- write a custom date editor which can suggest a year for user, relying on the selected year filter;
- fill cell values automatically when adding a new row, otherwise the row will not be displayed;
- and much more.

Previously there was ability to receive extra arguments of filter function by using `dataView.filters` property and much featers have already been written by using it. Now we need a way to keep these features working.