### PR TITLE
fix: primary entry point to the program isn't set correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "slickgrid",
   "version": "5.8.3",
   "description": "A lightning fast JavaScript grid/spreadsheet",
-  "main": "./dist/browser/index.js",
+  "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "index.d.ts",
   "typesVersions": {


### PR DESCRIPTION
It's written in the `package.json` file that primary entry point has path `"./dist/browser/index.js"`, but there is no such file there.

![image](https://github.com/6pac/SlickGrid/assets/60598547/3c9a3f97-dfa9-49da-9f12-4a085f4721d4)

Although library works when I try to run integration tests with Jest for files which make import from node_module 'slickgrid' it complains `Cannot find module 'slickgrid'`

![image](https://github.com/6pac/SlickGrid/assets/60598547/7b2c0809-8e6c-4ca5-aa2c-b34c6353265e)
