### PR TITLE
Fix: CellExternalCopyManager plugin restores focus on paste

### DIFF
--- a/cypress/e2e/example-excel-compatible-spreadsheet.cy.ts
+++ b/cypress/e2e/example-excel-compatible-spreadsheet.cy.ts
@@ -1,10 +1,5 @@
 describe('Example - Excel-compatible spreadsheet and Cell Selection', { retries: 0 }, () => {
   const cellHeight = 25;
-  const titles = [
-    '', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
-    'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y',
-    'Z', 'AA', 'AB', 'AC', 'AD', 'AE', 'AF', 'AG', 'AH', 'AI', 'AJ', 'AK'
-  ];
 
   it('should load Example', () => {
     cy.visit(`${Cypress.config('baseUrl')}/examples/example-excel-compatible-spreadsheet.html`);
@@ -29,5 +24,8 @@ describe('Example - Excel-compatible spreadsheet and Cell Selection', { retries:
 
     cy.get('#myGrid .slick-cell.l3.r3.selected')
       .should('have.length', 1);
+
+    cy.getCell(3, 2, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+      .should('have.text', '3');
   });
 });

--- a/cypress/e2e/example-excel-compatible-spreadsheet.cy.ts
+++ b/cypress/e2e/example-excel-compatible-spreadsheet.cy.ts
@@ -1,0 +1,33 @@
+describe('Example - Excel-compatible spreadsheet and Cell Selection', { retries: 0 }, () => {
+  const cellHeight = 25;
+  const titles = [
+    '', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
+    'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y',
+    'Z', 'AA', 'AB', 'AC', 'AD', 'AE', 'AF', 'AG', 'AH', 'AI', 'AJ', 'AK'
+  ];
+
+  it('should load Example', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-excel-compatible-spreadsheet.html`);
+  });
+
+  it('should click on cell B2, copy value, ArrowDown, paste value, ArrowRight, and expect to be in column C', () => {
+    cy.getCell(2, 2, '', { parentSelector: "#myGrid", rowHeight: cellHeight })
+      .as('cell_B2')
+      .click();
+
+    cy.get(".slick-cell.active")
+      .realPress(["Control", "C"]);
+
+    cy.get(".slick-cell.active")
+      .type('{downarrow}');
+
+    cy.get(".slick-cell.active")
+      .realPress(["Control", "V"]);
+
+    cy.get(".slick-cell.active")
+      .type('{rightarrow}');
+
+    cy.get('#myGrid .slick-cell.l3.r3.selected')
+      .should('have.length', 1);
+  });
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -24,6 +24,7 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 import '@4tw/cypress-drag-drop';
+import "cypress-real-events";
 import { convertPosition } from './common';
 
 declare global {

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -4,7 +4,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "lib": ["es5", "dom"],
-    "types": ["@4tw/cypress-drag-drop", "cypress", "node"],
+    "types": ["@4tw/cypress-drag-drop", "cypress", "node", "cypress-real-events"],
     "jsx": "preserve"
   },
   "include": ["**/*.ts"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "cssnano": "^6.1.2",
         "cssnano-preset-lite": "^3.1.0",
         "cypress": "^13.7.2",
+        "cypress-real-events": "^1.12.0",
         "dotenv": "^16.4.5",
         "esbuild": "^0.20.2",
         "eslint": "^8.57.0",
@@ -3033,6 +3034,15 @@
       },
       "engines": {
         "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/cypress-real-events": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.12.0.tgz",
+      "integrity": "sha512-oiy+4kGKkzc2PT36k3GGQqkGxNiVypheWjMtfyi89iIk6bYmTzeqxapaLHS3pnhZOX1IEbTDUVxh8T4Nhs1tyQ==",
+      "dev": true,
+      "peerDependencies": {
+        "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x"
       }
     },
     "node_modules/cypress/node_modules/fs-extra": {
@@ -11590,6 +11600,13 @@
           }
         }
       }
+    },
+    "cypress-real-events": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.12.0.tgz",
+      "integrity": "sha512-oiy+4kGKkzc2PT36k3GGQqkGxNiVypheWjMtfyi89iIk6bYmTzeqxapaLHS3pnhZOX1IEbTDUVxh8T4Nhs1tyQ==",
+      "dev": true,
+      "requires": {}
     },
     "dargs": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "cssnano": "^6.1.2",
     "cssnano-preset-lite": "^3.1.0",
     "cypress": "^13.7.2",
+    "cypress-real-events": "^1.12.0",
     "dotenv": "^16.4.5",
     "esbuild": "^0.20.2",
     "eslint": "^8.57.0",

--- a/src/plugins/slick.cellexternalcopymanager.ts
+++ b/src/plugins/slick.cellexternalcopymanager.ts
@@ -449,8 +449,17 @@ export class SlickCellExternalCopyManager implements SlickPlugin {
         (e.which === this.keyCodes.V && (e.ctrlKey || e.metaKey) && !e.shiftKey)
         || (e.which === this.keyCodes.INSERT && e.shiftKey && !e.ctrlKey)
       )) {    // CTRL+V or Shift+INS
+        const focusEl = document.activeElement as HTMLElement;
         const ta = this._createTextBox('');
-        setTimeout(() => this._decodeTabularData(this._grid, ta), 100);
+        setTimeout(() =>
+          {
+            this._decodeTabularData(this._grid, ta);
+            // restore focus when possible
+            focusEl
+              ? focusEl.focus()
+              : console.log('No element to restore focus to after copy?');
+          }
+        , 100);
         return false;
       }
     }

--- a/src/plugins/slick.cellexternalcopymanager.ts
+++ b/src/plugins/slick.cellexternalcopymanager.ts
@@ -451,13 +451,11 @@ export class SlickCellExternalCopyManager implements SlickPlugin {
       )) {    // CTRL+V or Shift+INS
         const focusEl = document.activeElement as HTMLElement;
         const ta = this._createTextBox('');
-        setTimeout(() =>
-          {
+        setTimeout(() => {
             this._decodeTabularData(this._grid, ta);
             // restore focus when possible
             focusEl?.focus();
-          }
-        , 100);
+        }, this._options?.clipboardPasteDelay ?? CLIPBOARD_PASTE_DELAY);
         return false;
       }
     }

--- a/src/plugins/slick.cellexternalcopymanager.ts
+++ b/src/plugins/slick.cellexternalcopymanager.ts
@@ -455,9 +455,7 @@ export class SlickCellExternalCopyManager implements SlickPlugin {
           {
             this._decodeTabularData(this._grid, ta);
             // restore focus when possible
-            focusEl
-              ? focusEl.focus()
-              : console.log('No element to restore focus to after copy?');
+            focusEl?.focus();
           }
         , 100);
         return false;


### PR DESCRIPTION
When using doing copy-paste with CellExternalCopyManager, the grid loses focus after Ctrl-V.

The issue can be seen on [example-excel-compatible-spreadsheet](https://6pac.github.io/SlickGrid/examples/example-excel-compatible-spreadsheet.html) by playing with the arrow keys and doing some copy/paste.

The commit reuses the code found some 20 lines before in the same function to restore the focus.
