### PR TITLE
Fix: Tweak setupColumnSort() to fix exception when col no longer exists

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -1802,7 +1802,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
               previousSortColumns,
               sortCols: this.sortColumns.map((col) => {
                 const tempCol = this.columns[this.getColumnIndex(col.columnId)];
-                return !tempCol ? null : { columnId: tempCol.id, sortCol: tempCol, sortAsc: col.sortAsc };
+                return !tempCol || tempCol.hidden ? null : { columnId: tempCol.id, sortCol: tempCol, sortAsc: col.sortAsc };
               }).filter((el) => el)
             };
           }

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -1801,8 +1801,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
               multiColumnSort: true,
               previousSortColumns,
               sortCols: this.sortColumns.map((col) => {
-                return { columnId: this.columns[this.getColumnIndex(col.columnId)].id, sortCol: this.columns[this.getColumnIndex(col.columnId)], sortAsc: col.sortAsc };
-              })
+                const tempCol = this.columns[this.getColumnIndex(col.columnId)];
+                return !tempCol ? null : { columnId: tempCol.id, sortCol: tempCol, sortAsc: col.sortAsc };
+              }).filter((el) => el)
             };
           }
 


### PR DESCRIPTION
Tweak setupColumnSort() to fix exception when a no longer existing column is in the sort list. 
Fixes #1015