### PR TITLE
feat: add new `preventDragFromKeys` grid option

### DIFF
--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -254,6 +254,9 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   /** Do we want to preserve copied selection on paste? */
   preserveCopiedSelectionOnPaste?: boolean;
 
+  /** Defaults to `['ctrlKey', 'metaKey']`, list of keys that when pressed will prevent Draggable events from triggering (e.g. prevent onDrag when Ctrl key is pressed while dragging) */
+  preventDragFromKeys?: Array<'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>;
+
   /** Grid row height in pixels (only type the number). Row of cell values. */
   rowHeight?: number;
 

--- a/src/models/interactions.interface.ts
+++ b/src/models/interactions.interface.ts
@@ -16,6 +16,9 @@ export interface DraggableOption {
   /** when defined, will allow dragging from a specific element or its closest parent by using the .closest() query selector. */
   allowDragFromClosest?: string;
 
+  /** Defaults to `['ctrlKey', 'metaKey']`, list of keys that when pressed will prevent Draggable events from triggering (e.g. prevent onDrag when Ctrl key is pressed while dragging) */
+  preventDragFromKeys?: Array<'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>;
+
   /** drag initialized callback */
   onDragInit?: (e: DragEvent, dd: DragPosition) => boolean | void;
 

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -268,6 +268,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     forceSyncScrolling: false,
     addNewRowCssClass: 'new-row',
     preserveCopiedSelectionOnPaste: false,
+    preventDragFromKeys: ['ctrlKey', 'metaKey'],
     showCellSelection: true,
     viewportClass: undefined,
     minRowBuffer: 3,
@@ -935,6 +936,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           allowDragFrom: 'div.slick-cell',
           // the slick cell parent must always contain `.dnd` and/or `.cell-reorder` class to be identified as draggable
           allowDragFromClosest: 'div.slick-cell.dnd, div.slick-cell.cell-reorder',
+          preventDragFromKeys: this._options.preventDragFromKeys,
           onDragInit: this.handleDragInit.bind(this),
           onDragStart: this.handleDragStart.bind(this),
           onDrag: this.handleDrag.bind(this),


### PR DESCRIPTION
- the issue was brought by a user and the root cause was the mouse drag sometime kicks in when the user selects a few row by using the Ctrl+click combo, however in rare occasion the user might move by even a single pixel and that sends an onDrag event which the SlickCellRangeSelector picks up when then sends a new event `onCellRangeSelecting` and then the SlickRowSelectionModel assumes it's a new range from a mouse drag and override the previous range. However we should really prevent this mouse drag from happening when the user is pressing the Ctrl/Shift keys to avoid having the issue that was brought

![control-select](https://github.com/ghiscoding/slickgrid-universal/assets/34568483/0508c709-4294-4d39-9736-f4c57f191afb)
