### PR TITLE
feat: add optional Top-Header for Drag Grouping + Header Grouping

### DIFF
--- a/cypress/e2e/example-draggable-header-grouping.cy.ts
+++ b/cypress/e2e/example-draggable-header-grouping.cy.ts
@@ -1,25 +1,28 @@
 describe('Example - Draggable Grouping', { retries: 1 }, () => {
   // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
   const GRID_ROW_HEIGHT = 25;
+  const preHeaders = ['', 'Common Factor', 'Period', 'Analysis', ''];
   const fullTitles = ['#', 'Title', 'Duration', 'Start', 'Finish', 'Cost', 'Effort-Driven'];
   for (let i = 0; i < 30; i++) {
     fullTitles.push(`Mock${i}`);
   }
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseUrl')}/examples/example-draggable-grouping.html`);
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-draggable-header-grouping.html`);
     cy.get('h2').contains('Demonstrates');
     cy.get('h2 + ul > li').first().contains('Draggable Grouping feature');
   });
 
+  it('should have exact column (pre-header) grouping titles in grid', () => {
+    cy.get('#myGrid')
+      .find('.slick-preheader-panel .slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(preHeaders[index]));
+  });
+
   it('should have exact column titles in grid', () => {
     cy.get('#myGrid')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
-
-    cy.get('#myGrid')
-      .find('.slick-header-columns')
+      .find('.slick-header:not(.slick-preheader-panel) .slick-header-columns')
       .children()
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
@@ -101,8 +104,8 @@ describe('Example - Draggable Grouping', { retries: 1 }, () => {
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(2)`).should('contain', '0');
     });
 
-    it('should use the preheader Toggle All button and expect all groups to now be collapsed', () => {
-      cy.get('.slick-preheader-panel .slick-group-toggle-all').click();
+    it('should use the topheader Toggle All button and expect all groups to now be collapsed', () => {
+      cy.get('.slick-topheader-panel .slick-group-toggle-all').click();
 
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-toggle.collapsed`).should('have.length', 1);
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-title`).should('contain', 'Effort-Driven:  False');
@@ -149,8 +152,8 @@ describe('Example - Draggable Grouping', { retries: 1 }, () => {
         .should('exist');
     });
 
-    it('should use the preheader Toggle All button and expect all groups to now be expanded', () => {
-      cy.get('.slick-preheader-panel .slick-group-toggle-all').click();
+    it('should use the topheader Toggle All button and expect all groups to now be expanded', () => {
+      cy.get('.slick-topheader-panel .slick-group-toggle-all').click();
 
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-toggle.expanded`).should('have.length', 1);
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-title`).should('contain', 'Effort-Driven:  False');
@@ -161,8 +164,8 @@ describe('Example - Draggable Grouping', { retries: 1 }, () => {
         .should('have.css', 'marginLeft').and('eq', `15px`);
     });
 
-    it('should use the preheader Toggle All button again and expect all groups to now be collapsed', () => {
-      cy.get('.slick-preheader-panel .slick-group-toggle-all').click();
+    it('should use the topheader Toggle All button again and expect all groups to now be collapsed', () => {
+      cy.get('.slick-topheader-panel .slick-group-toggle-all').click();
 
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-toggle.collapsed`).should('have.length', 1);
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-title`).should('contain', 'Effort-Driven:  False');
@@ -187,25 +190,29 @@ describe('Example - Draggable Grouping', { retries: 1 }, () => {
         .should('have.text', 'Drop a column header here to group by the column :)');
     });
 
-    it('should add 500 items and expect 500 of 500 items displayed', () => {
+    it('should add 500 items and expect last row to be Task 500', () => {
       cy.get('[data-test="add-500-rows-btn"]')
         .click();
 
-      cy.get('.slick-pager-status')
-        .contains('Showing all 500 rows');
+      cy.get('#myGrid')
+        .find('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('bottom')
+        .wait(10);
+
+      cy.get(`#myGrid [style="top: ${GRID_ROW_HEIGHT * 499}px;"] > .slick-cell:nth(1)`).should('have.text', 'Task 499');
     });
-  });
 
-  describe('Pagination', () => {
-    it('should be able to destroy pager (pagination)', () => {
-      cy.get('.slick-pager')
-        .should('exist');
-
-      cy.get('[data-test="destroy-pager"]')
+    it('should add 50K items and expect last row to be Task 50,000', () => {
+      cy.get('[data-test="add-50k-rows-btn"]')
         .click();
 
-      cy.get('.slick-pager')
-        .should('not.exist');
+      cy.get('#myGrid')
+        .find('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('bottom')
+        .wait(10);
+
+      // cy.get(`#myGrid [style="top: ${GRID_ROW_HEIGHT * 49999}px;"] > .slick-cell:nth(1)`).should('have.text', 'Task 49999');
+      cy.get(`#myGrid [style="top: 1.24998e+06px;"] > .slick-cell:nth(1)`).should('have.text', 'Task 49999');
     });
   });
 });

--- a/examples/example-draggable-header-grouping.html
+++ b/examples/example-draggable-header-grouping.html
@@ -1,0 +1,544 @@
+<!--
+ *
+ * Draggable Grouping + Header Grouping
+ -->
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
+  <title>SlickGrid example: Droppable Grouping</title>
+  <link rel="stylesheet" href="../dist/styles/css/slick-icons.css" type="text/css"/>
+  <link rel="stylesheet" href="../dist/styles/css/slick.columnpicker.css" type="text/css"/>
+  <link rel="stylesheet" href="../dist/styles/css/slick.draggablegrouping.css" type="text/css"/>
+  <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css"/>
+  <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css"/>
+  <style>
+    .cell-effort-driven {
+      justify-content: center;
+    }
+
+    .slick-group-title[level='0'] {
+      font-weight: bold;
+    }
+
+    .slick-group-title[level='1'] {
+      text-decoration: underline;
+    }
+
+    .slick-group-title[level='2'] {
+      font-style: italic;
+    }
+    .slick-preheader-panel,
+    .slick-topheader-panel {
+      border-bottom: 1px solid #dae1e7;
+    }
+    .cell-selection {
+      display: flex;
+    }
+    .alpine-theme .slick-column-groupable {
+      height: 1em;
+      width: 1em;
+      mask-size: 1em;
+      -webkit-mask-size: 1em;
+    }
+    .alpine-theme .slick-pane-top {
+      top: 89px;
+    }
+    .btn-alpine-theme {
+      background-color: gray;
+      color: white;
+      border-width: 1px;
+      border-radius: 2px;
+      height: 22px;
+    }
+    .btn-classic-theme {
+      background-color: #bbd1ee;
+      border-width: 1px;
+      border-radius: 2px;
+      height: 22px;
+    }
+    .slick-header-column {
+      justify-content: space-between;
+    }
+  </style>
+</head>
+<body>
+<div style="position:relative">
+  <div style="width:675px;">
+    <div class="grid-header" style="width:100%">
+      <label>SlickGrid</label>
+    </div>
+    <div id="myGrid" class="slick-container alpine-theme" style="width:100%;height:500px;"></div>
+  </div>
+
+  <div class="options-panel" style="width:450px; margin-left: 50px;">
+    <h2>
+      <a href="/examples/index.html" style="text-decoration: none; font-size: 22px">&#x2302;</a>
+      Demonstrates:
+    </h2>
+    <ul>
+      <li>Draggable Grouping feature</li>
+      <li>Similar to regular grouping but the "grouping" must be defined in the column we want to group by</li>
+    </ul>
+    <b>Options:</b>
+    <hr/>
+    <div style="padding:6px;">
+      <label style="width:200px;float:left">Show tasks with % at least: </label>
+
+      <div style="padding:2px;">
+        <input style="width:100px;display:inline-block;" id="pcSlider" type="range" min="1" max="100" value="1">
+      </div>
+      <br/><br/>
+      <button data-test="add-500-rows-btn" onclick="loadData(500)">500 rows</button>
+      <button data-test="add-50k-rows-btn" onclick="loadData(50000)">50k rows</button>
+      <button data-test="add-500k-rows-btn" onclick="loadData(500000)">500k rows</button>
+      <hr/>
+      <button onclick="toggleDraggableGrouping()">Toggle Draggable Grouping</button>
+      <button onclick="groupByTitle()">Group by Title</button>
+      <br/>
+      <button data-test="group-duration-sort-value-btn" onclick="groupByDurationOrderByCount(false)">
+        Group by duration &amp; sort groups by value
+      </button>
+      <button data-test="group-duration-sort-count-btn" onclick="groupByDurationOrderByCount(true)">
+        Group by duration &amp; sort groups by count
+      </button>
+      <button data-test="group-duration-effort-btn" onclick="groupByDurationEffortDriven()">
+        Group by Duration then Effort-Driven
+      </button>
+      <br/>
+      <button data-test="clear-grouping-btn" onclick="clearGroupings()">Clear grouping</button>
+      <button data-test="collapse-all-btn" onclick="toggleGrouping(false)">Collapse all groups</button>
+      <button data-test="expand-all-btn" onclick="toggleGrouping(true)">Expand all groups</button>
+      <hr>
+      <strong>Load CSS Theme:</strong>
+      <button class="btn-alpine-theme" data-test="theme-alpine-btn" onclick="toggleTheme('alpine')">Alpine Theme</button>
+      <button class="btn-classic-theme" data-test="theme-classic-btn" onclick="toggleTheme('classic')">Classic Theme</button>
+      <br/>
+    </div>
+    <hr/>
+    <h2>Demonstrates:</h2>
+    <ul>
+      <li>
+        Fully dynamic and interactive multi-level grouping with filtering and aggregates over <b>50'000</b> items<br>
+        Each grouping level can have its own aggregates (over child rows, child groups, or all descendant rows).<br>
+        Personally, this is just the coolest slickest thing I've ever seen done with DHTML grids!
+      </li>
+    </ul>
+    <h2>View Source:</h2>
+    <ul>
+        <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-draggable-header-grouping.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+    </ul>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
+<script src="sortable-cdn-fallback.js"></script>
+
+<script src="../dist/browser/slick.core.js"></script>
+<script src="../dist/browser/slick.interactions.js"></script>
+<script src="../dist/browser/slick.grid.js"></script>
+<script src="../dist/browser/slick.formatters.js"></script>
+<script src="../dist/browser/slick.editors.js"></script>
+<script src="../dist/browser/plugins/slick.cellrangedecorator.js"></script>
+<script src="../dist/browser/plugins/slick.cellrangeselector.js"></script>
+<script src="../dist/browser/plugins/slick.cellselectionmodel.js"></script>
+<script src="../dist/browser/plugins/slick.draggablegrouping.js"></script>
+<script src="../dist/browser/slick.groupitemmetadataprovider.js"></script>
+<script src="../dist/browser/slick.dataview.js"></script>
+<script src="../dist/browser/controls/slick.columnpicker.js"></script>
+
+<script>
+  function CreateAddlHeaderRow() {
+    var preHeaderPanelElm = grid.getPreHeaderPanel();
+    preHeaderPanelElm.innerHTML = '';
+    preHeaderPanelElm.className = "slick-header-columns";
+    preHeaderPanelElm.style.left = '-1000px';
+    preHeaderPanelElm.style.width = `${grid.getHeadersWidth()}px`;
+    preHeaderPanelElm.parentElement.classList.add("slick-header");
+
+    var headerColumnWidthDiff = grid.getHeaderColumnWidthDiff();
+    var m, headerElm, lastColumnGroup = '', widthTotal = 0;
+
+    for (var i = 0; i < columns.length; i++) {
+      m = columns[i];
+      if (lastColumnGroup === m.columnGroup && i>0) {
+        widthTotal += m.width;
+        headerElm.style.width = `${widthTotal - headerColumnWidthDiff}px`;
+      } else {
+          widthTotal = m.width;
+          headerElm = document.createElement('div');
+          headerElm.className = 'ui-state-default slick-header-column';
+          headerElm.style.width = `${(m.width || 0) - headerColumnWidthDiff}px`;
+
+          const spanElm = document.createElement('span');
+          spanElm.className='slick-column-name';
+          spanElm.textContent = m.columnGroup || '';
+          headerElm.appendChild(spanElm);
+          preHeaderPanelElm.appendChild(headerElm);
+      }
+      lastColumnGroup = m.columnGroup;
+    }
+  }
+
+var dataView;
+var draggableGrouping;
+var grid;
+var data = [];
+var columns = [
+  {
+    id: "sel", name: "#", field: "sel", cssClass: "cell-selection", width: 40, resizable: false, selectable: false, focusable: false,
+    grouping: {}
+  },
+  {
+    id: "title", name: "Title", field: "title", width: 90, minWidth: 50, cssClass: "cell-title", sortable: true, editor: Slick.Editors.Text,
+    columnGroup:"Common Factor", grouping: {
+      getter: "title",
+      formatter: function (g) {
+        return "Title:  " + g.value + "  <span style='color:green'>(" + g.count + " items)</span>";
+      },
+      aggregators: [
+        new Slick.Data.Aggregators.Sum("cost")
+      ],
+      aggregateCollapsed: false,
+      collapsed: false
+    }
+  },
+  {
+    id: "duration", name: "Duration", field: "duration", width: 110, sortable: true, groupTotalsFormatter: sumTotalsFormatter,
+    columnGroup:"Common Factor", grouping: {
+      getter: "duration",
+      formatter: function (g) {
+        return "Duration:  " + g.value + "  <span style='color:green'>(" + g.count + " items)</span>";
+      },
+      editor: Slick.Editors.PercentComplete,
+      aggregators: [
+        new Slick.Data.Aggregators.Sum("cost")
+      ],
+      aggregateCollapsed: false,
+      collapsed: false
+    }
+  },
+  {
+    id: "start", name: "Start", field: "start", minWidth: 60, sortable: true,
+    columnGroup:"Period", grouping: {
+      getter: "start",
+      formatter: function (g) {
+        return "Start:  " + g.value + "  <span style='color:green'>(" + g.count + " items)</span>";
+      },
+      aggregators: [
+        new Slick.Data.Aggregators.Sum("cost")
+      ],
+      aggregateCollapsed: false,
+      collapsed: false
+    }
+  },
+  {
+    id: "finish", name: "Finish", field: "finish", minWidth: 60, sortable: true,
+    columnGroup:"Period", grouping: {
+      getter: "finish",
+      formatter: function (g) {
+        return "Finish:  " + g.value + "  <span style='color:green'>(" + g.count + " items)</span>";
+      },
+      aggregators: [
+        new Slick.Data.Aggregators.Sum("cost")
+      ],
+      aggregateCollapsed: false,
+      collapsed: false
+    }
+  },
+  {
+    id: "cost", name: "Cost", field: "cost", width: 90, sortable: true, groupTotalsFormatter: sumTotalsFormatter,
+    columnGroup:"Analysis", grouping: {
+      getter: "cost",
+      formatter: function (g) {
+        return "Cost:  " + g.value + "  <span style='color:green'>(" + g.count + " items)</span>";
+      },
+      aggregators: [
+        new Slick.Data.Aggregators.Sum("cost")
+      ],
+      aggregateCollapsed: false,
+      collapsed: false
+    }
+  },
+  {
+    id: "effortDriven", name: "Effort-Driven",  width: 125, minWidth: 20, maxWidth: 125, cssClass: "cell-effort-driven", field: "effortDriven", formatter: Slick.Formatters.Checkmark, sortable: true,
+    columnGroup:"Analysis", grouping: {
+      getter: "effortDriven",
+      formatter :function (g) {
+        return "Effort-Driven:  " + (g.value ? "True" : "False") + "  <span style='color:green'>(" + g.count + " items)</span>";
+      },
+      aggregators: [
+        new Slick.Data.Aggregators.Sum("cost")
+      ],
+      collapsed: false
+    }
+  }
+];
+
+var columnpicker;
+var sortcol = "title";
+var sortdir = 1;
+var percentCompleteThreshold = 0;
+var prevPercentCompleteThreshold = 0;
+
+function toggleTheme(theme) {
+  const gridElm = document.querySelector('#myGrid');
+
+  if (theme === 'alpine') {
+    changeCSS('../dist/styles/css/slick.grid.css', '../dist/styles/css/slick-alpine-theme.css');
+    changeCSS('examples.css', '../dist/styles/css/example-demo.css');
+    changeCSS('examples-unicode-icons.css', '../dist/styles/css/slick-icons.css');
+    gridElm.classList.add('alpine-theme');
+    gridElm.classList.remove('classic-theme');
+  } else {
+    changeCSS('../dist/styles/css/slick-alpine-theme.css', '../dist/styles/css/slick.grid.css');
+    changeCSS('../dist/styles/css/example-demo.css', 'examples.css');
+    changeCSS('../dist/styles/css/slick-icons.css', 'examples-unicode-icons.css');
+    gridElm.classList.add('classic-theme');
+    gridElm.classList.remove('alpine-theme');
+  }
+}
+
+function changeCSS(prevFilePath, newFilePath) {
+  let headerIndex = 0;
+  let previousCssElm = document.getElementsByTagName("head")[0].querySelector(`link[href="${prevFilePath}"]`);
+  if (previousCssElm) {
+    previousCssElm.setAttribute('href', newFilePath);
+  }
+}
+
+function avgTotalsFormatter(totals, columnDef) {
+  var val = totals.avg && totals.avg[columnDef.field];
+  if (val != null) {
+    return "avg: " + Math.round(val) + "%";
+  }
+  return "";
+}
+
+function sumTotalsFormatter(totals, columnDef) {
+  var val = totals.sum && totals.sum[columnDef.field];
+  if (val != null) {
+    return "total: " + ((Math.round(parseFloat(val)*100)/100));
+  }
+  return "";
+}
+
+function myFilter(item, args) {
+  return item["percentComplete"] >= args.percentComplete;
+}
+
+function percentCompleteSort(a, b) {
+  return a["percentComplete"] - b["percentComplete"];
+}
+
+function comparer(a, b) {
+  var x = a[sortcol], y = b[sortcol];
+  return (x == y ? 0 : (x > y ? 1 : -1));
+}
+
+var draggableEnabled = true;
+
+function groupByTitle() {
+  grid.setSortColumns([]);
+  clearGroupings();
+  draggableGrouping.setDroppedGroups('title');
+  grid.invalidate();
+}
+
+function groupByDuration() {
+  grid.setSortColumns([]);
+  clearGroupings();
+  if (draggableGrouping.setDroppedGroups) {
+    showTopHeader();
+    draggableGrouping.setDroppedGroups('duration');
+    grid.invalidate(); // invalidate all rows and re-render
+  }
+  grid.invalidate();
+}
+
+function groupByDurationOrderByCount(sortedByCount = false) {
+  grid.setSortColumns([]);
+  durationOrderByCount = sortedByCount;
+  clearGroupings();
+  groupByDuration();
+
+  // you need to manually add the sort icon(s) in UI
+  const sortColumns = sortedByCount ? [] : [{ columnId: 'duration', sortAsc: true }];
+  grid.setSortColumns(sortColumns);
+  grid.invalidate(); // invalidate all rows and re-render
+}
+
+function groupByDurationEffortDriven() {
+  grid.setSortColumns([]);
+  clearGroupings();
+  if (draggableGrouping.setDroppedGroups) {
+    showTopHeader();
+    draggableGrouping.setDroppedGroups(['duration', 'effortDriven']);
+    grid.invalidate(); // invalidate all rows and re-render
+  }
+  grid.invalidate();
+}
+
+function clearGroupings() {
+   draggableGrouping.clearDroppedGroups();
+}
+
+function showTopHeader() {
+  grid.setTopHeaderPanelVisibility(true);
+}
+
+function toggleDraggableGrouping() {
+   clearGroupings();
+  if ( draggableEnabled == true ) {
+    grid.setTopHeaderPanelVisibility(false);
+    draggableEnabled = false;
+  } else {
+    grid.setTopHeaderPanelVisibility(true);
+    draggableEnabled = true;
+  }
+}
+
+function toggleGrouping(expand) {
+  const groupToggleAllElm = document.querySelector(".slick-group-toggle-all");
+
+  if(expand) {
+    dataView.expandAllGroups();
+    groupToggleAllElm.classList.remove('collapsed');
+    groupToggleAllElm.classList.add('expanded');
+  } else {
+    dataView.collapseAllGroups();
+    groupToggleAllElm.classList.remove('expanded');
+    groupToggleAllElm.classList.add('collapsed');
+  }
+}
+
+function loadData(count) {
+  var someDates = ["01/01/2009", "02/02/2009", "03/03/2009"];
+  data = [];
+  // prepare the data
+  for (var i = 0; i < count; i++) {
+    var d = (data[i] = {});
+
+    d["id"] = "id_" + i;
+    d["num"] = i;
+    d["title"] = "Task " + i;
+    d["duration"] = Math.round(Math.random() * 14);
+    d["percentComplete"] = Math.round(Math.random() * 100);
+    d["start"] = someDates[ Math.floor((Math.random()*2)) ];
+    d["finish"] = someDates[ Math.floor((Math.random()*2)) ];
+    d["cost"] = Math.round(Math.random() * 10000) / 100;
+    d["effortDriven"] = (i % 5 == 0);
+  }
+  dataView.setItems(data);
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+  draggableGrouping = new Slick.DraggableGrouping({iconImage :'../images/delete.png', /*deleteIconCssClass :'sgi sgi-close',*/ groupIconCssClass: 'sgi sgi-drag-vertical', dropPlaceHolderText: 'Drop a column header here to group by the column :)'});
+
+  var options = {
+    enableCellNavigation: true,
+    editable: true,
+    enableColumnReorder: draggableGrouping.getSetupColumnReorder.bind(draggableGrouping),
+
+    // pre-header will include our Header Grouping (i.e. "Common Factor")
+    // Draggable Grouping could be located in either the Pre-Header OR the new Top-Header
+    createPreHeaderPanel: true,
+    showPreHeaderPanel: true,
+    preHeaderPanelHeight: 28,
+
+    // when Top-Header is created, it will be used by the Draggable Grouping (otherwise the Pre-Header will be used)
+    createTopHeaderPanel: true,
+    showTopHeaderPanel: true,
+    topHeaderPanelHeight: 28,
+  };
+
+  var groupItemMetadataProvider = new Slick.Data.GroupItemMetadataProvider();
+  dataView = new Slick.Data.DataView({
+    groupItemMetadataProvider: groupItemMetadataProvider,
+    inlineFilters: true,
+    useCSPSafeFilter: true,
+  });
+
+  grid = new Slick.Grid("#myGrid", dataView, columns, options);
+
+  // register the group item metadata provider to add expand/collapse group handlers
+  grid.registerPlugin(groupItemMetadataProvider);
+  grid.registerPlugin(draggableGrouping);
+  grid.setSelectionModel(new Slick.CellSelectionModel());
+  columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
+
+  grid.onSort.subscribe(function (e, args) {
+    sortdir = args.sortAsc ? 1 : -1;
+    sortcol = args.sortCol.field;
+
+    dataView.sort(comparer, args.sortAsc);
+
+  });
+
+  // wire up model events to drive the grid
+  dataView.onRowCountChanged.subscribe(function (e, args) {
+    grid.updateRowCount();
+    grid.render();
+  });
+
+  dataView.onRowsChanged.subscribe(function (e, args) {
+    grid.invalidateRows(args.rows);
+    grid.render();
+  });
+
+
+  var h_runfilters = null;
+
+  // wire up the slider to apply the filter to the model
+  var slider = document.getElementById("pcSlider");
+  var sliderCallback = function() {
+    Slick.GlobalEditorLock.cancelCurrentEdit();
+
+    if (percentCompleteThreshold != this.value) {
+      window.clearTimeout(h_runfilters);
+      h_runfilters = window.setTimeout(filterAndUpdate, 10);
+      percentCompleteThreshold = this.value;
+    }
+  }
+
+  slider.oninput = sliderCallback;
+
+
+  function filterAndUpdate() {
+    var isNarrowing = percentCompleteThreshold > prevPercentCompleteThreshold;
+    var isExpanding = percentCompleteThreshold < prevPercentCompleteThreshold;
+    var renderedRange = grid.getRenderedRange();
+
+    dataView.setFilterArgs({
+      percentComplete: percentCompleteThreshold
+    });
+    dataView.setRefreshHints({
+      ignoreDiffsBefore: renderedRange.top,
+      ignoreDiffsAfter: renderedRange.bottom + 1,
+      isFilterNarrowing: isNarrowing,
+      isFilterExpanding: isExpanding
+    });
+    dataView.refresh();
+
+    prevPercentCompleteThreshold = percentCompleteThreshold;
+  }
+
+  // initialize the model after all the events have been hooked up
+  dataView.beginUpdate();
+  dataView.setFilter(myFilter);
+  dataView.setFilterArgs({
+    percentComplete: percentCompleteThreshold
+  });
+  loadData(50);
+  dataView.endUpdate();
+
+  grid.onColumnsResized.subscribe(function (e, args) {
+    CreateAddlHeaderRow();
+  });
+
+  CreateAddlHeaderRow();
+});
+</script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -112,6 +112,7 @@
       <li><a href="./example5-collapsing.html">Adding tree functionality (expand/collapse) to the grid</a></li>
       <li><a href="./example5-collapsing-treeGrid-sort.html">Adding tree functionality with tree sorting</a></li>
       <li><a href="./example-draggable-grouping.html">Adding grouping using column dragging and dropping</a></li>
+      <li><a href="./example-draggable-header-grouping.html">Adding Header Grouping and Draggable Column Grouping & Dropping</a></li>
       <li><a href="./example-grouping-checkbox-row-select.html">Checkbox row selection with grouping and checkbox to select rows in group</a></li>
       <li><a href="./example-grouping-groupcolumn.html">Row Group with dedicated Grouping Column</a></li>
     </ul>

--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -87,11 +87,14 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   /** Context menu options (mouse right+click) */
   contextMenu?: ContextMenuOption;
 
-  /** Defaults to false, which leads to create the footer row of the grid */
+  /** Defaults to false, which leads to creating the footer row of the grid */
   createFooterRow?: boolean;
 
-  /** Default to false, which leads to create an extra pre-header panel (on top of column header) for column grouping purposes */
+  /** Default to false, which leads to creating an extra pre-header panel (on top of column header) for column grouping purposes */
   createPreHeaderPanel?: boolean;
+
+  /** Default to false, which leads to creating an extra top-header panel (on top of column header & pre-header) for column grouping purposes */
+  createTopHeaderPanel?: boolean;
 
   /**
    * Custom Tooltip Options, the tooltip could be defined in any of the Column Definition or in the Grid Options,
@@ -254,6 +257,12 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   /** Defaults to "auto", extra pre-header panel (on top of column header) width, it could be a number (pixels) or a string ("100%" or "auto") */
   preHeaderPanelWidth?: number | string;
 
+  /** Extra top-header panel height (on top of column header & pre-header) */
+  topHeaderPanelHeight?: number;
+
+  /** Defaults to "auto", extra top-header panel (on top of column header & pre-header) width, it could be a number (pixels) or a string ("100%" or "auto") */
+  topHeaderPanelWidth?: number | string;
+
   /** Do we want to preserve copied selection on paste? */
   preserveCopiedSelectionOnPaste?: boolean;
 
@@ -296,6 +305,9 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
 
   /** Do we want to show the extra pre-header panel (on top of column header) for column grouping purposes */
   showPreHeaderPanel?: boolean;
+
+  /** Do we want to show the extra top-header panel (on top of column header & pre-header) for column grouping purposes */
+  showTopHeaderPanel?: boolean;
 
   /** Do we want to show top panel row? */
   showTopPanel?: boolean;

--- a/src/plugins/slick.draggablegrouping.ts
+++ b/src/plugins/slick.draggablegrouping.ts
@@ -19,7 +19,7 @@ const Utils = IIFE_ONLY ? Slick.Utils : Utils_;
  *  github.com/muthukumarse/Slickgrid
  *
  * NOTES:
- *     This plugin provides the Draggable Grouping feature
+ *     This plugin provides the Draggable Grouping feature which could be located in either the Top-Header or the Pre-Header
  * A plugin to add Draggable Grouping feature.
  *
  * USAGE:
@@ -90,7 +90,7 @@ export class SlickDraggableGrouping {
     this._gridUid = this._grid.getUID();
     this._gridColumns = this._grid.getColumns();
     this._dataView = this._grid.getData();
-    this._dropzoneElm = this._grid.getPreHeaderPanel();
+    this._dropzoneElm = this._grid.getTopHeaderPanel() || this._grid.getPreHeaderPanel();
     this._dropzoneElm.classList.add('slick-dropzone');
 
     const dropPlaceHolderText = this._options.dropPlaceHolderText || 'Drop a column header here to group by the column';
@@ -151,7 +151,7 @@ export class SlickDraggableGrouping {
    */
   getSetupColumnReorder(grid: SlickGrid, headers: any, _headerColumnWidthDiff: any, setColumns: (columns: Column[]) => void, setupColumnResize: () => void, _columns: Column[], getColumnIndex: (columnId: string) => number, _uid: string, trigger: (slickEvent: SlickEvent_, data?: any) => void) {
     this.destroySortableInstances();
-    const dropzoneElm = grid.getPreHeaderPanel();
+    const dropzoneElm = grid.getTopHeaderPanel() || grid.getPreHeaderPanel();
     const groupTogglerElm = dropzoneElm.querySelector<HTMLDivElement>('.slick-group-toggle-all');
 
     const sortableOptions = {
@@ -260,7 +260,7 @@ export class SlickDraggableGrouping {
     this.onGroupChanged.unsubscribe();
     this._handler.unsubscribeAll();
     this._bindingEventService.unbindAll();
-    Utils.emptyElement(document.querySelector(`.${this._gridUid} .slick-preheader-panel`));
+    Utils.emptyElement(document.querySelector(`.${this._gridUid} .slick-preheader-panel,.${this._gridUid} .slick-topheader-panel`));
   }
 
   protected destroySortableInstances() {

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -241,11 +241,15 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     showFooterRow: false,
     footerRowHeight: 25,
     createPreHeaderPanel: false,
+    createTopHeaderPanel: false,
     showPreHeaderPanel: false,
+    showTopHeaderPanel: false,
     preHeaderPanelHeight: 25,
     showTopPanel: false,
     topPanelHeight: 25,
     preHeaderPanelWidth: 'auto', // mostly useful for Draggable Grouping dropzone to take full width
+    topHeaderPanelHeight: 25,
+    topHeaderPanelWidth: 'auto', // mostly useful for Draggable Grouping dropzone to take full width
     formatterFactory: null,
     editorFactory: null,
     cellFlashingCssClass: 'flashing',
@@ -364,6 +368,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected _preHeaderPanelR!: HTMLDivElement;
   protected _preHeaderPanelScrollerR!: HTMLDivElement;
   protected _preHeaderPanelSpacerR!: HTMLDivElement;
+  protected _topHeaderPanel!: HTMLDivElement;
+  protected _topHeaderPanelScroller!: HTMLDivElement;
+  protected _topHeaderPanelSpacer!: HTMLDivElement;
   protected _topPanelScrollers!: HTMLDivElement[];
   protected _topPanels!: HTMLDivElement[];
   protected _viewport!: HTMLDivElement[];
@@ -681,6 +688,17 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     this._focusSink = Utils.createDomElement('div', { tabIndex: 0, style: { position: 'fixed', width: '0px', height: '0px', top: '0px', left: '0px', outline: '0px' } }, this._container);
 
+    if (this._options.createTopHeaderPanel) {
+      this._topHeaderPanelScroller = Utils.createDomElement('div', { className: 'slick-topheader-panel slick-state-default', style: { overflow: 'hidden', position: 'relative' } }, this._container);
+      this._topHeaderPanelScroller.appendChild(document.createElement('div'));
+      this._topHeaderPanel = Utils.createDomElement('div', null, this._topHeaderPanelScroller);
+      this._topHeaderPanelSpacer = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this._topHeaderPanelScroller);
+
+      if (!this._options.showTopHeaderPanel) {
+        Utils.hide(this._topHeaderPanelScroller);
+      }
+    }
+
     // Containers used for scrolling frozen columns and rows
     this._paneHeaderL = Utils.createDomElement('div', { className: 'slick-pane slick-pane-header slick-pane-left', tabIndex: 0 }, this._container);
     this._paneHeaderR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-header slick-pane-right', tabIndex: 0 }, this._container);
@@ -793,6 +811,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     // Default the active canvas to the top left
     this._activeCanvasNode = this._canvasTopL;
+
+    // top-header
+    if (this._topHeaderPanelSpacer) {
+      Utils.width(this._topHeaderPanelSpacer, this.getCanvasWidth() + this.scrollbarDimensions.width);
+    }
 
     // pre-header
     if (this._preHeaderPanelSpacer) {
@@ -913,6 +936,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         this._footerRowScroller.forEach((scroller) => {
           this._bindingEventService.bind(scroller, 'scroll', this.handleFooterRowScroll.bind(this) as EventListener);
         });
+      }
+
+      if (this._options.createTopHeaderPanel) {
+        this._bindingEventService.bind(this._topHeaderPanelScroller, 'scroll', this.handleTopHeaderPanelScroll.bind(this) as EventListener);
       }
 
       if (this._options.createPreHeaderPanel) {
@@ -1191,6 +1218,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const oldCanvasWidthR = this.canvasWidthR;
     this.canvasWidth = this.getCanvasWidth();
 
+    if (this._options.createTopHeaderPanel) {
+      Utils.width(this._topHeaderPanel, this._options.topHeaderPanelWidth ?? this.canvasWidth);
+    }
+
     const widthChanged = this.canvasWidth !== oldCanvasWidth || this.canvasWidthL !== oldCanvasWidthL || this.canvasWidthR !== oldCanvasWidthR;
 
     if (widthChanged || this.hasFrozenColumns() || this.hasFrozenRows) {
@@ -1456,6 +1487,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   /** Get the Pre-Header Panel Right DOM node element */
   getPreHeaderPanelRight() {
     return this._preHeaderPanelR;
+  }
+
+  /** Get the Top-Header Panel DOM node element */
+  getTopHeaderPanel() {
+    return this._topHeaderPanel;
   }
 
   /**
@@ -2378,6 +2414,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       `.${this.uid} .slick-header-column { left: 1000px; }`,
       `.${this.uid} .slick-top-panel { height: ${this._options.topPanelHeight}px; }`,
       `.${this.uid} .slick-preheader-panel { height: ${this._options.preHeaderPanelHeight}px; }`,
+      `.${this.uid} .slick-topheader-panel { height: ${this._options.topHeaderPanelHeight}px; }`,
       `.${this.uid} .slick-headerrow-columns { height: ${this._options.headerRowHeight}px; }`,
       `.${this.uid} .slick-footerrow-columns { height: ${this._options.footerRowHeight}px; }`,
       `.${this.uid} .slick-cell { height: ${rowHeight}px; }`,
@@ -2544,6 +2581,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     if (this._preHeaderPanelScroller) {
       this._bindingEventService.unbindByEventName(this._preHeaderPanelScroller, 'scroll');
+    }
+
+    if (this._topHeaderPanelScroller) {
+      this._bindingEventService.unbindByEventName(this._topHeaderPanelScroller, 'scroll');
     }
 
     this._bindingEventService.unbindByEventName(this._focusSink, 'keydown');
@@ -3701,7 +3742,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return !Array.isArray(this.data);
   }
 
-  protected togglePanelVisibility(option: 'showTopPanel' | 'showHeaderRow' | 'showColumnHeader' | 'showFooterRow' | 'showPreHeaderPanel', container: HTMLElement | HTMLElement[], visible?: boolean, animate?: boolean) {
+  protected togglePanelVisibility(option: 'showTopPanel' | 'showHeaderRow' | 'showColumnHeader' | 'showFooterRow' | 'showPreHeaderPanel' | 'showTopHeaderPanel', container: HTMLElement | HTMLElement[], visible?: boolean, animate?: boolean) {
     const animated = (animate === false) ? false : true;
 
     if (this._options[option] !== visible) {
@@ -3767,6 +3808,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    */
   setPreHeaderPanelVisibility(visible?: boolean, animate?: boolean) {
     this.togglePanelVisibility('showPreHeaderPanel', [this._preHeaderPanelScroller, this._preHeaderPanelScrollerR], visible, animate);
+  }
+
+  /**
+   * Set the Top-Header Visibility
+   * @param {Boolean} [visible] - optionally set if top-header panel is visible or not
+   */
+  setTopHeaderPanelVisibility(visible?: boolean) {
+    this.togglePanelVisibility('showTopHeaderPanel', this._topHeaderPanelScroller, visible);
   }
 
   /** Get Grid Canvas Node DOM Element */
@@ -4266,6 +4315,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     } else {
       const columnNamesH = (this._options.showColumnHeader) ? Utils.toFloat(Utils.height(this._headerScroller[0]) as number) + this.getVBoxDelta(this._headerScroller[0]) : 0;
       const preHeaderH = (this._options.createPreHeaderPanel && this._options.showPreHeaderPanel) ? this._options.preHeaderPanelHeight! + this.getVBoxDelta(this._preHeaderPanelScroller) : 0;
+      const topHeaderH = (this._options.createTopHeaderPanel && this._options.showTopHeaderPanel) ? this._options.topHeaderPanelHeight! + this.getVBoxDelta(this._topHeaderPanelScroller) : 0;
 
       const style = getComputedStyle(this._container);
       this.viewportH = Utils.toFloat(style.height)
@@ -4275,7 +4325,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         - this.topPanelH
         - this.headerRowH
         - this.footerRowH
-        - preHeaderH;
+        - preHeaderH
+        - topHeaderH;
     }
 
     this.numVisibleRows = Math.ceil(this.viewportH / this._options.rowHeight!);
@@ -4330,7 +4381,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this._paneTopL.style.position = 'relative';
     }
 
-    Utils.setStyleSize(this._paneTopL, 'top', Utils.height(this._paneHeaderL) || (this._options.showHeaderRow ? this._options.headerRowHeight! : 0) + (this._options.showPreHeaderPanel ? this._options.preHeaderPanelHeight! : 0));
+    let topHeightOffset = Utils.height(this._paneHeaderL);
+    if (topHeightOffset) {
+      topHeightOffset += (this._options.showTopHeaderPanel ? this._options.topHeaderPanelHeight! : 0);
+    } else {
+      topHeightOffset = (this._options.showHeaderRow ? this._options.headerRowHeight! : 0) + (this._options.showPreHeaderPanel ? this._options.preHeaderPanelHeight! : 0);
+    }
+    Utils.setStyleSize(this._paneTopL, 'top', topHeightOffset || topHeightOffset);
     Utils.height(this._paneTopL, this.paneTopH);
 
     const paneBottomTop = this._paneTopL.offsetTop + this.paneTopH;
@@ -4340,7 +4397,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     if (this.hasFrozenColumns()) {
-      Utils.setStyleSize(this._paneTopR, 'top', Utils.height(this._paneHeaderL) as number);
+      let topHeightOffset = Utils.height(this._paneHeaderL);
+      if (topHeightOffset) {
+        topHeightOffset += (this._options.showTopHeaderPanel ? this._options.topHeaderPanelHeight! : 0);
+      }
+      Utils.setStyleSize(this._paneTopR, 'top', topHeightOffset as number);
       Utils.height(this._paneTopR, this.paneTopH);
       Utils.height(this._viewportTopR, this.viewportTopH);
 
@@ -4912,6 +4973,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.handleElementScroll(this._preHeaderPanelScroller);
   }
 
+  protected handleTopHeaderPanelScroll() {
+    this.handleElementScroll(this._topHeaderPanelScroller);
+  }
+
   protected handleElementScroll(element: HTMLElement) {
     const scrollLeft = element.scrollLeft;
     if (scrollLeft !== this._viewportScrollContainerX.scrollLeft) {
@@ -4961,6 +5026,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         } else {
           this._preHeaderPanelScroller.scrollLeft = this.scrollLeft;
         }
+      }
+      if (this._options.createTopHeaderPanel) {
+        this._topHeaderPanelScroller.scrollLeft = this.scrollLeft;
       }
 
       if (this.hasFrozenColumns()) {

--- a/src/styles/slick-alpine-theme.scss
+++ b/src/styles/slick-alpine-theme.scss
@@ -259,7 +259,8 @@
   filter: alpha(opacity = 70);
 }
 
-.slick-preheader-panel {
+.slick-preheader-panel,
+.slick-topheader-panel {
   .slick-header-column {
     border-style: solid;
     border-color: var(--alpine-preheader-border-color, $alpine-preheader-border-color);

--- a/src/styles/slick-default-theme.scss
+++ b/src/styles/slick-default-theme.scss
@@ -29,7 +29,8 @@ classes should alter those!
   height: 100%;
 }
 
-.slick-preheader-panel {
+.slick-preheader-panel,
+.slick-topheader-panel {
   border: 1px solid #d3d3d3;
 }
 


### PR DESCRIPTION
- prior to this PR, we could not use Draggable Grouping & Header Grouping because both features were using the pre-header and it would have conflict, now to avoid this I am adding an extra Top-Header that will show over all header and pre-header.
- NOTE: Draggable Grouping can now be displayed in either the new Top-Header OR the Pre-Header. However, the users who do want to use both features will need to explicitely enable both top/pre headers.
- I was getting a little out of ideas to get a name (since "pre" is already taken), so I decided to go with Top-Header which is completely on the top and even before the pre-header. 
- Another note is that this new Top-Header is not following the frozen columns (like header & pre-header do) and is rather always the same width as the grid. I purposely did not want this top-header to follow the grid frozen columns because I wanted a simpler header and also because I expect this to be mostly (and only) be used by the Draggable Grouping.
- also created a new [example-draggable-header-grouping.html](https://6pac.github.io/SlickGrid/examples/example-draggable-header-grouping.html)
![brave_A3hjT55ZFU](https://github.com/6pac/SlickGrid/assets/643976/bcc09442-9e42-4610-87a0-cd21b12768f4)
