### PR TITLE
fix: Column Header Menu should be on top of grid not inside

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -681,7 +681,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     };
 
     Utils.emptyElement(this._container);
-    this._container.style.overflow = 'hidden';
     this._container.style.outline = String(0);
     this._container.classList.add(this.uid);
     this._container.classList.add('ui-widget');

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -141,3 +141,4 @@ $alpine-menu-border-radius:                       2px !default;
 $alpine-menu-box-shadow:                          none !default;
 $alpine-menu-close-btn-background:                transparent !default;
 $alpine-menu-close-btn-border:                    1px solid #babfc7 !default;
+$alpine-menu-content-margin:                      2px 4px !default;

--- a/src/styles/slick-alpine-theme.scss
+++ b/src/styles/slick-alpine-theme.scss
@@ -542,6 +542,9 @@
 }
 
 .slick-header-menuitem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   border: 1px solid transparent;
   list-style: none;
   margin: 0;
@@ -577,16 +580,17 @@
     }
   }
 
+  .slick-header-menucontent {
+    display: inline-block;
+    vertical-align: middle;
+    flex-grow: 1;
+    margin: var(--alpine-menu-content-margin, $alpine-menu-content-margin);
+    font-size: var(--alpine-font-size, $alpine-font-size);
+  }
+
   &:hover {
     border-color: var(--alpine-border-color, $alpine-border-color);
   }
-}
-
-.slick-header-menucontent {
-  display: inline-block;
-  vertical-align: middle;
-  margin: 5px;
-  font-size: var(--alpine-font-size, $alpine-font-size);
 }
 
 .slick-pane {


### PR DESCRIPTION
- also while at it, let's fix some alignment issues with menu items as well

#### before fix
![image](https://github.com/6pac/SlickGrid/assets/643976/8bd9974c-c8f9-4b4a-88d7-6d1bab78cd3b)

#### after fix
![image](https://github.com/6pac/SlickGrid/assets/643976/77493001-4262-427c-96ca-a9229275f0d4)
