### PR TITLE
feat: add `params.editorOptions` to change Flatpickr Editor date format

### DIFF
--- a/src/models/column.interface.ts
+++ b/src/models/column.interface.ts
@@ -149,6 +149,9 @@ export interface Column<TData = any> {
   /** column offset width */
   offsetWidth?: number;
 
+  /** extra custom generic parameters that could be used by your Formatter/Editor or anything else */
+  params?: any | any[];
+
   /** column previous width */
   previousWidth?: number;
 

--- a/src/slick.editors.ts
+++ b/src/slick.editors.ts
@@ -343,12 +343,13 @@ export class FlatpickrEditor<TData = any, C extends Column<TData> = Column<TData
     this.input = Utils.createDomElement('input', { type: 'text', className: 'editor-text' }, this.args.container);
     this.input.focus();
     this.input.select();
+    const editorOptions = this.args.column.params?.editorOptions; // i.e.: { id: 'start', params: { editorOptions: {altFormat: 'd/m/Y', dateFormat: 'd/m/Y'}} }
     this.flatpickrInstance = flatpickr(this.input, {
       closeOnSelect: true,
       allowInput: true,
       altInput: true,
-      altFormat: 'm/d/Y',
-      dateFormat: 'm/d/Y',
+      altFormat: editorOptions?.altFormat ?? 'm/d/Y',
+      dateFormat: editorOptions?.dateFormat ?? 'm/d/Y',
       onChange: () => {
         // trigger onCompositeEditorChange event when input changes and it's a Composite Editor
         if (this.args.compositeEditorOptions) {


### PR DESCRIPTION
Add a generic `params` in Column interface so that user can provide extra and untyped options, for example `params.editorOptions` to add extra settings to some Editors like the Flatpickr date format

For example 
```
columns = [
  {
    id: "finish", name: "Finish", field: "finish", 
    editor: Editors.Flatpickr, 
    params: { editorOptions: {altFormat: 'Y-m-d', dateFormat: 'Y-m-d'}}, 
]
```