### PR TITLE
perf: decrease virtual scroll render throttling to 5ms

### DIFF
--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -285,7 +285,7 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   /** Optional sanitizer function to use for sanitizing data to avoid XSS attacks */
   sanitizer?: (dirtyHtml: string) => string;
 
-  /** Defaults to 50, render throttling when scrolling large dataset */
+  /** Defaults to 5(ms), render throttling when using virtual scroll on large dataset */
   scrollRenderThrottling?: number;
 
   /** CSS class name used when cell is selected */

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -287,7 +287,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     doPaging: true,
     autosizeColsMode: GridAutosizeColsMode.LegacyOff,
     autosizeColPaddingPx: 4,
-    scrollRenderThrottling: 50,
+    scrollRenderThrottling: 5,
     autosizeTextAvgToMWidthRatio: 0.75,
     viewportSwitchToScrollModeWidthPercent: undefined,
     viewportMinWidthPx: undefined,


### PR DESCRIPTION
- see this [comment](https://github.com/6pac/SlickGrid/issues/219#issuecomment-1630077429) for more info
- a lower thottling delay (5ms instead of previously 50ms) will show blank area for a much shorter period whenever we scroll to an uncached scroll position (for example completely scroll to bottom of large grid)
- NOTE: a throttling of 0ms causes flickering and/or other issues in some cases, but 5ms seems like a good number to use