### PR TITLE
fix: SlickCellExternalCopyManager should work w/hidden cols

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -5687,7 +5687,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     let w = 0;
     for (let i = 0; i < this.columns.length && w <= x; i++) {
-      if (!this.columns[i] || this.columns[i].hidden) {
+      if (!this.columns[i]) {
         continue;
       }
       w += this.columns[i].width as number;


### PR DESCRIPTION
- prior to this PR, the hidden columns were being counted as column indexes when pasting and also when starting a cell selection

![brave_gC4wQ7pe3V](https://github.com/user-attachments/assets/6a8c4cc9-ab6e-4739-a4b6-a43f6fd77a55)
