### PR TITLE
fix: typo in `setColumnVisibiliy`, fixes #1056

### DIFF
--- a/examples/example-column-hidden.html
+++ b/examples/example-column-hidden.html
@@ -73,7 +73,7 @@
       </ul>
         <h2>View Source:</h2>
         <ul>
-            <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-column-visible.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+            <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example-column-hidden.html" target="_sourcewindow"> View the source for this example on Github</a></li>
         </ul>
 
     </div>
@@ -265,7 +265,7 @@ document.addEventListener("DOMContentLoaded", function() {
     var hideCol = document.querySelector('#chkHideColumn').checked || false;
 
     // use the columnpicker since it keeps a full list of columns, hidden and visible
-    columnpicker.setColumnVisibiliy('duration', !hideCol);
+    columnpicker.setColumnVisibility('duration', !hideCol);
   });
 
   // initialize the model after all the events have been hooked up

--- a/src/controls/slick.columnmenu.ts
+++ b/src/controls/slick.columnmenu.ts
@@ -294,7 +294,12 @@ export class SlickColumnMenu {
     }
   }
 
+  /** @deprecated because of a typo @use `setColumnVisibility()` instead */
   setColumnVisibiliy(idxOrId: number | string, show: boolean) {
+    this.setColumnVisibility(idxOrId, show);
+  }
+
+  setColumnVisibility(idxOrId: number | string, show: boolean) {
     const idx = typeof idxOrId === 'number' ? idxOrId : this.getColumnIndexbyId(idxOrId);
     let visibleColumns: Column[] = this.getVisibleColumns();
     const col = this.columns[idx];

--- a/src/controls/slick.columnpicker.ts
+++ b/src/controls/slick.columnpicker.ts
@@ -301,7 +301,12 @@ export class SlickColumnPicker {
     }
   }
 
+  /** @deprecated because of a typo @use `setColumnVisibility()` instead */
   setColumnVisibiliy(idxOrId: number | string, show: boolean) {
+    this.setColumnVisibility(idxOrId, show);
+  }
+
+  setColumnVisibility(idxOrId: number | string, show: boolean) {
     const idx = typeof idxOrId === 'number' ? idxOrId : this.getColumnIndexbyId(idxOrId);
     let visibleColumns = this.getVisibleColumns();
     const col = this.columns[idx];


### PR DESCRIPTION
fixes #1056
- keep previous method around to avoid breaking users but deprecate it