### PR TITLE
fix: RowDetail plugin > Remove console.log

### DIFF
--- a/src/plugins/slick.rowdetailview.ts
+++ b/src/plugins/slick.rowdetailview.ts
@@ -582,7 +582,6 @@ export class SlickRowDetailView {
     const item: any = {};
 
     Object.keys(this._dataView).forEach(prop => {
-      console.log(item[prop]);
       item[prop] = null;
     });
     item[this._dataViewIdProperty] = parent[this._dataViewIdProperty] + '.' + offset;


### PR DESCRIPTION
fixes #1066
Removes a console.log of property value in RowDetail plugin. Closes issue #1066.