### PR TITLE
fix: ExternalCopyManager shouldn't change body scroll pos, fixes #1078

### DIFF
--- a/src/plugins/slick.cellexternalcopymanager.ts
+++ b/src/plugins/slick.cellexternalcopymanager.ts
@@ -162,11 +162,12 @@ export class SlickCellExternalCopyManager implements SlickPlugin {
 
 
   protected _createTextBox(innerText: string) {
+    const scrollPos = document.documentElement.scrollTop || document.body.scrollTop;
     const ta = document.createElement('textarea');
     ta.style.position = 'absolute';
-    ta.style.left = '-1000px';
-    ta.style.top = document.body.scrollTop + 'px';
+    ta.style.opacity = '0';
     ta.value = innerText;
+    ta.style.top = `${scrollPos}px`;
     this._bodyElement.appendChild(ta);
     ta.select();
 


### PR DESCRIPTION
fixes #1078 
- using SlickExternalCopyManager plugin shouldn't change scroll position when copy/pasting values in the grid

![Code_ekFXu2AffX](https://github.com/user-attachments/assets/bf43056e-dc06-44b6-bd5a-f810e82442e1)
