### PR TITLE
chore: remove unnecessary fs-util function

### DIFF
--- a/scripts/changelog.mjs
+++ b/scripts/changelog.mjs
@@ -1,6 +1,5 @@
 import conventionalChangelog from 'conventional-changelog';
-import { pathExistsSync } from './fs-utils.mjs';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 const projectRootLocation = process.cwd();
@@ -29,7 +28,7 @@ export function updateChangelog(args, newVersion) {
 
     // read changelog.md if it exist or else we'll create it
     const changelogLocation = path.resolve(projectRootLocation, infile);
-    const fileExist = pathExistsSync(changelogLocation);
+    const fileExist = existsSync(changelogLocation);
     if (fileExist) {
       oldContent = readFileSync(path.resolve(projectRootLocation, infile), 'utf8');
     }

--- a/scripts/fs-utils.mjs
+++ b/scripts/fs-utils.mjs
@@ -15,10 +15,6 @@ export function outputFileSync(file, ...args) {
   writeFileSync(file, ...args);
 }
 
-export function pathExistsSync(path) {
-  return existsSync(path);
-}
-
 export function readJSONSync(file, options = {}) {
   if (typeof options === 'string') {
     options = { encoding: options };


### PR DESCRIPTION
we can do this function with plain `node:fs` code