### PR TITLE
fix: remove "active" CSS classes before navigating to another cell

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -5860,6 +5860,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   //////////////////////////////////////////////////////////////////////////////////////////////
   // Cell switching
 
+  /** Resets active cell by making cell normal and other internal resets. */
+  resetActiveCell() {
+    this.setActiveCellInternal(null, false);
+  }
+
   /** Clear active cell by making cell normal & removing "active" CSS class. */
   unsetActiveCell() {
     if (Utils.isDefined(this.activeCellNode)) {
@@ -5867,11 +5872,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.activeCellNode.classList.remove('active');
       this.rowsCache[this.activeRow]?.rowNode?.forEach((node) => node.classList.remove('active'));
     }
-  }
-
-  /** Resets active cell by making cell normal and other internal resets. */
-  resetActiveCell() {
-    this.setActiveCellInternal(null, false);
   }
 
   /** @alias `setFocus` */

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -6670,14 +6670,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Navigate to coordinate 0,0 (top left home) */
   navigateTopStart(): boolean | undefined {
-    this.unsetActiveCell();
     this.navigateToRow(0);
     return this.navigate('home');
   }
 
   /** Navigate to bottom row end (bottom right end) */
   navigateBottomEnd(): boolean | undefined {
-    this.unsetActiveCell();
     this.navigateBottom();
     return this.navigate('end');
   }
@@ -6699,6 +6697,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       return true;
     }
     this.setFocus();
+    this.unsetActiveCell();
 
     const tabbingDirections = {
       'up': -1,

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -5861,7 +5861,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   // Cell switching
 
   /** Clear active cell by making cell normal & removing "active" CSS class. */
-  clearActiveCell() {
+  unsetActiveCell() {
     if (Utils.isDefined(this.activeCellNode)) {
       this.makeActiveCellNormal();
       this.activeCellNode.classList.remove('active');
@@ -5923,7 +5923,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   protected setActiveCellInternal(newCell: HTMLDivElement | null, opt_editMode?: boolean | null, preClickModeOn?: boolean | null, suppressActiveCellChangedEvent?: boolean, e?: Event | SlickEvent_) {
     // make current active cell as normal cell & remove "active" CSS classes
-    this.clearActiveCell();
+    this.unsetActiveCell();
 
     // let activeCellChanged = (this.activeCellNode !== newCell);
     this.activeCellNode = newCell;
@@ -6356,13 +6356,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Navigate to the top of the grid */
   navigateTop() {
-    this.clearActiveCell();
+    this.unsetActiveCell();
     this.navigateToRow(0);
   }
 
   /** Navigate to the bottom of the grid */
   navigateBottom() {
-    this.clearActiveCell();
+    this.unsetActiveCell();
     this.navigateToRow(this.getDataLength() - 1);
   }
 
@@ -6670,14 +6670,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Navigate to coordinate 0,0 (top left home) */
   navigateTopStart(): boolean | undefined {
-    this.clearActiveCell();
+    this.unsetActiveCell();
     this.navigateToRow(0);
     return this.navigate('home');
   }
 
   /** Navigate to bottom row end (bottom right end) */
   navigateBottomEnd(): boolean | undefined {
-    this.clearActiveCell();
+    this.unsetActiveCell();
     this.navigateBottom();
     return this.navigate('end');
   }

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -5860,7 +5860,16 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   //////////////////////////////////////////////////////////////////////////////////////////////
   // Cell switching
 
-  /**  Resets active cell. */
+  /** Clear active cell by making cell normal & removing "active" CSS class. */
+  clearActiveCell() {
+    if (Utils.isDefined(this.activeCellNode)) {
+      this.makeActiveCellNormal();
+      this.activeCellNode.classList.remove('active');
+      this.rowsCache[this.activeRow]?.rowNode?.forEach((node) => node.classList.remove('active'));
+    }
+  }
+
+  /** Resets active cell by making cell normal and other internal resets. */
   resetActiveCell() {
     this.setActiveCellInternal(null, false);
   }
@@ -5913,11 +5922,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   protected setActiveCellInternal(newCell: HTMLDivElement | null, opt_editMode?: boolean | null, preClickModeOn?: boolean | null, suppressActiveCellChangedEvent?: boolean, e?: Event | SlickEvent_) {
-    if (Utils.isDefined(this.activeCellNode)) {
-      this.makeActiveCellNormal();
-      this.activeCellNode.classList.remove('active');
-      this.rowsCache[this.activeRow]?.rowNode?.forEach((node) => node.classList.remove('active'));
-    }
+    // make current active cell as normal cell & remove "active" CSS classes
+    this.clearActiveCell();
 
     // let activeCellChanged = (this.activeCellNode !== newCell);
     this.activeCellNode = newCell;
@@ -6350,11 +6356,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Navigate to the top of the grid */
   navigateTop() {
+    this.clearActiveCell();
     this.navigateToRow(0);
   }
 
   /** Navigate to the bottom of the grid */
   navigateBottom() {
+    this.clearActiveCell();
     this.navigateToRow(this.getDataLength() - 1);
   }
 
@@ -6662,12 +6670,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Navigate to coordinate 0,0 (top left home) */
   navigateTopStart(): boolean | undefined {
+    this.clearActiveCell();
     this.navigateToRow(0);
     return this.navigate('home');
   }
 
   /** Navigate to bottom row end (bottom right end) */
   navigateBottomEnd(): boolean | undefined {
+    this.clearActiveCell();
     this.navigateBottom();
     return this.navigate('end');
   }


### PR DESCRIPTION
- certain nav commands are navigating away from current viewport and when re-navigating back to another cell that is in the same viewport (like 0,0 with Ctrl+Home) then it sometimes has 2 active cells instead of never more than 1.
- this can probably occur a little more after recent PR #1093 