### PR TITLE
feat: add Custom Global Item Data Provider, closes #262

### DIFF
--- a/src/models/groupItemMetadataProviderOption.interface.ts
+++ b/src/models/groupItemMetadataProviderOption.interface.ts
@@ -1,5 +1,9 @@
 import type { Formatter } from './index.js';
 
+export interface ItemMetadataProvider {
+  getRowMetadata(item: any, row: number): any;
+}
+
 export interface GroupItemMetadataProviderOption {
   /** Whether or not we want to use group select checkbox. */
   checkboxSelect?: boolean;

--- a/src/slick.dataview.ts
+++ b/src/slick.dataview.ts
@@ -7,6 +7,7 @@ import type {
   Grouping,
   GroupingFormatterItem,
   ItemMetadata,
+  ItemMetadataProvider,
   OnGroupCollapsedEventArgs,
   OnGroupExpandedEventArgs,
   OnRowCountChangedEventArgs,
@@ -37,6 +38,9 @@ const Utils = IIFE_ONLY ? Slick.Utils : Utils_;
 const SlickGroupItemMetadataProvider = IIFE_ONLY ? Slick.Data?.GroupItemMetadataProvider ?? {} : SlickGroupItemMetadataProvider_;
 
 export interface DataViewOption {
+  /** global override for all rows */
+  globalItemMetadataProvider: ItemMetadataProvider | null;
+
   /** Optionally provide a GroupItemMetadataProvider in order to use Grouping/DraggableGrouping features */
   groupItemMetadataProvider: SlickGroupItemMetadataProvider_ | null;
 
@@ -63,6 +67,7 @@ export type GroupGetterFn = (val: any) => string | number;
   */
 export class SlickDataView<TData extends SlickDataItem = any> implements CustomDataView {
   protected defaults: DataViewOption = {
+    globalItemMetadataProvider: null,
     groupItemMetadataProvider: null,
     inlineFilters: false,
     useCSPSafeFilter: false,
@@ -775,20 +780,25 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return item;
   }
 
-  getItemMetadata(i: number): ItemMetadata | null {
-    const item = this.rows[i];
+  getItemMetadata(row: number): ItemMetadata | null {
+    const item = this.rows[row];
     if (item === undefined) {
       return null;
     }
 
+    // global override for all regular rows
+    if (this._options.globalItemMetadataProvider?.getRowMetadata) {
+      return this._options.globalItemMetadataProvider.getRowMetadata(item, row);
+    }
+
     // overrides for grouping rows
-    if ((item as SlickGroup_).__group) {
-      return this._options.groupItemMetadataProvider!.getGroupRowMetadata(item as GroupingFormatterItem);
+    if ((item as SlickGroup_).__group && this._options.groupItemMetadataProvider?.getGroupRowMetadata) {
+      return this._options.groupItemMetadataProvider.getGroupRowMetadata(item as GroupingFormatterItem, row);
     }
 
     // overrides for totals rows
-    if ((item as SlickGroupTotals_).__groupTotals) {
-      return this._options.groupItemMetadataProvider!.getTotalsRowMetadata(item as { group: GroupingFormatterItem });
+    if ((item as SlickGroupTotals_).__groupTotals && this._options.groupItemMetadataProvider?.getTotalsRowMetadata) {
+      return this._options.groupItemMetadataProvider.getTotalsRowMetadata(item as { group: GroupingFormatterItem }, row);
     }
 
     return null;

--- a/src/slick.groupitemmetadataprovider.ts
+++ b/src/slick.groupitemmetadataprovider.ts
@@ -164,7 +164,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     }
   }
 
-  getGroupRowMetadata(item: GroupingFormatterItem): ItemMetadata {
+  getGroupRowMetadata(item: GroupingFormatterItem, _row: number): ItemMetadata {
     const groupLevel = item?.level;
     return {
       selectable: false,
@@ -181,7 +181,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     };
   }
 
-  getTotalsRowMetadata(item: { group: GroupingFormatterItem }): ItemMetadata | null {
+  getTotalsRowMetadata(item: { group: GroupingFormatterItem }, _row: number): ItemMetadata | null {
     const groupLevel = item?.group?.level;
     return {
       selectable: false,


### PR DESCRIPTION
- allow providing a custom global item metadata provider by passing it through the `groupItemMetadataProvider` DataView constructor option
- implementation copied from https://github.com/GerHobbelt/SlickGrid fork