### PR TITLE
fix: Select All checkbox shouldn't disappear w/column toggle, fix #1119

### DIFF
--- a/cypress/e2e/example-checkbox-row-select.cy.ts
+++ b/cypress/e2e/example-checkbox-row-select.cy.ts
@@ -94,5 +94,22 @@ describe('Example - Checkbox Row Select', () => {
       cy.get('#myGrid [data-id=_checkbox_selector] input[type=checkbox]')
         .should('exist');
     });
+
+    it('should expect Select All checkbox to still be rendered even after hiding any of the column', () => {
+      cy.get('#myGrid .slick-header-columns .slick-header-column:nth(3)')
+        .trigger('mouseover')
+        .trigger('contextmenu')
+        .invoke('show');
+
+      cy.get('.slick-columnpicker')
+        .find('.slick-columnpicker-list')
+        .children('li:nth-child(5)')
+        .children('label')
+        .should('contain', 'D')
+        .click();
+
+      cy.get('#myGrid [data-id=_checkbox_selector] input[type=checkbox]')
+        .should('be.visible');
+    });
   });
 });

--- a/src/models/gridEvents.interface.ts
+++ b/src/models/gridEvents.interface.ts
@@ -4,6 +4,7 @@ import type { SlickGrid } from '../slick.grid.js';
 export interface SlickGridArg { grid: SlickGrid; }
 export interface OnActiveCellChangedEventArgs extends SlickGridArg { cell: number; row: number; }
 export interface OnAddNewRowEventArgs extends SlickGridArg { item: any; column: Column; }
+export interface OnAfterSetColumnsEventArgs extends SlickGridArg { newColumns: Column[]; }
 export interface OnAutosizeColumnsEventArgs extends SlickGridArg { columns: Column[]; }
 export interface OnBeforeUpdateColumnsEventArgs extends SlickGridArg { columns: Column[]; }
 export interface OnBeforeAppendCellEventArgs extends SlickGridArg { row: number; cell: number; value: any; dataContext: any; }

--- a/src/plugins/slick.checkboxselectcolumn.ts
+++ b/src/plugins/slick.checkboxselectcolumn.ts
@@ -60,17 +60,14 @@ export class SlickCheckboxSelectColumn<T = any> implements SlickPlugin {
     this._handler
       .subscribe(this._grid.onSelectedRowsChanged, this.handleSelectedRowsChanged.bind(this))
       .subscribe(this._grid.onClick, this.handleClick.bind(this))
-      .subscribe(this._grid.onKeyDown, this.handleKeyDown.bind(this));
+      .subscribe(this._grid.onKeyDown, this.handleKeyDown.bind(this))
+      // whenever columns changed, we need to rerender Select All checkbox
+      .subscribe(grid.onAfterSetColumns, this.handleDataViewSelectedIdsChanged.bind(this));
 
-    if (this._isUsingDataView && this._dataView) {
-      // whenever columns changed, we need to rerender Select All, we can call handler to simulate that
-      this._handler.subscribe(grid.onAfterSetColumns, this.handleDataViewSelectedIdsChanged.bind(this));
-
-      if (this._options.applySelectOnAllPages) {
-        this._handler
-          .subscribe(this._dataView.onSelectedRowIdsChanged, this.handleDataViewSelectedIdsChanged.bind(this))
-          .subscribe(this._dataView.onPagingInfoChanged, this.handleDataViewSelectedIdsChanged.bind(this));
-      }
+    if (this._isUsingDataView && this._dataView && this._options.applySelectOnAllPages) {
+      this._handler
+        .subscribe(this._dataView.onSelectedRowIdsChanged, this.handleDataViewSelectedIdsChanged.bind(this))
+        .subscribe(this._dataView.onPagingInfoChanged, this.handleDataViewSelectedIdsChanged.bind(this));
     }
 
     if (!this._options.hideInFilterHeaderRow) {

--- a/src/plugins/slick.checkboxselectcolumn.ts
+++ b/src/plugins/slick.checkboxselectcolumn.ts
@@ -60,14 +60,17 @@ export class SlickCheckboxSelectColumn<T = any> implements SlickPlugin {
     this._handler
       .subscribe(this._grid.onSelectedRowsChanged, this.handleSelectedRowsChanged.bind(this))
       .subscribe(this._grid.onClick, this.handleClick.bind(this))
-      .subscribe(this._grid.onKeyDown, this.handleKeyDown.bind(this))
-      // whenever columns changed, we need to rerender Select All checkbox
-      .subscribe(this._grid.onAfterSetColumns, () => this.renderSelectAllCheckbox(this._isSelectAllChecked));
+      .subscribe(this._grid.onKeyDown, this.handleKeyDown.bind(this));
 
-    if (this._isUsingDataView && this._dataView && this._options.applySelectOnAllPages) {
-      this._handler
-        .subscribe(this._dataView.onSelectedRowIdsChanged, this.handleDataViewSelectedIdsChanged.bind(this))
-        .subscribe(this._dataView.onPagingInfoChanged, this.handleDataViewSelectedIdsChanged.bind(this));
+    if (this._isUsingDataView && this._dataView) {
+      // whenever columns changed, we need to rerender Select All, we can call handler to simulate that
+      this._handler.subscribe(grid.onAfterSetColumns, this.handleDataViewSelectedIdsChanged.bind(this));
+
+      if (this._options.applySelectOnAllPages) {
+        this._handler
+          .subscribe(this._dataView.onSelectedRowIdsChanged, this.handleDataViewSelectedIdsChanged.bind(this))
+          .subscribe(this._dataView.onPagingInfoChanged, this.handleDataViewSelectedIdsChanged.bind(this));
+      }
     }
 
     if (!this._options.hideInFilterHeaderRow) {

--- a/src/plugins/slick.checkboxselectcolumn.ts
+++ b/src/plugins/slick.checkboxselectcolumn.ts
@@ -62,7 +62,7 @@ export class SlickCheckboxSelectColumn<T = any> implements SlickPlugin {
       .subscribe(this._grid.onClick, this.handleClick.bind(this))
       .subscribe(this._grid.onKeyDown, this.handleKeyDown.bind(this))
       // whenever columns changed, we need to rerender Select All checkbox
-      .subscribe(grid.onAfterSetColumns, this.handleDataViewSelectedIdsChanged.bind(this));
+      .subscribe(this._grid.onAfterSetColumns, () => this.renderSelectAllCheckbox(this._isSelectAllChecked));
 
     if (this._isUsingDataView && this._dataView && this._options.applySelectOnAllPages) {
       this._handler

--- a/src/plugins/slick.checkboxselectcolumn.ts
+++ b/src/plugins/slick.checkboxselectcolumn.ts
@@ -60,7 +60,9 @@ export class SlickCheckboxSelectColumn<T = any> implements SlickPlugin {
     this._handler
       .subscribe(this._grid.onSelectedRowsChanged, this.handleSelectedRowsChanged.bind(this))
       .subscribe(this._grid.onClick, this.handleClick.bind(this))
-      .subscribe(this._grid.onKeyDown, this.handleKeyDown.bind(this));
+      .subscribe(this._grid.onKeyDown, this.handleKeyDown.bind(this))
+      // whenever columns changed, we need to rerender Select All checkbox
+      .subscribe(this._grid.onAfterSetColumns, () => this.renderSelectAllCheckbox(this._isSelectAllChecked));
 
     if (this._isUsingDataView && this._dataView && this._options.applySelectOnAllPages) {
       this._handler
@@ -386,7 +388,7 @@ export class SlickCheckboxSelectColumn<T = any> implements SlickPlugin {
   }
 
   protected addCheckboxToFilterHeaderRow(grid: SlickGrid) {
-    this._handler.subscribe(grid.onHeaderRowCellRendered, (_e: any, args: any) => {
+    this._handler.subscribe(grid.onHeaderRowCellRendered, (_e, args) => {
       if (args.column.field === 'sel') {
         Utils.emptyElement(args.node);
         const spanElm = Utils.createDomElement('span', { id: 'filter-checkbox-selectall-container', ariaChecked: 'false' });

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -31,6 +31,7 @@ import type {
   OnActivateChangedOptionsEventArgs,
   OnActiveCellChangedEventArgs,
   OnAddNewRowEventArgs,
+  OnAfterSetColumnsEventArgs,
   OnAutosizeColumnsEventArgs,
   OnBeforeUpdateColumnsEventArgs,
   OnBeforeAppendCellEventArgs,
@@ -150,6 +151,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   onActiveCellChanged: SlickEvent_<OnActiveCellChangedEventArgs>;
   onActiveCellPositionChanged: SlickEvent_<{ grid: SlickGrid; }>;
   onAddNewRow: SlickEvent_<OnAddNewRowEventArgs>;
+  onAfterSetColumns: SlickEvent_<OnAfterSetColumnsEventArgs>;
   onAutosizeColumns: SlickEvent_<OnAutosizeColumnsEventArgs>;
   onBeforeAppendCell: SlickEvent_<OnBeforeAppendCellEventArgs>;
   onBeforeCellEditorDestroy: SlickEvent_<OnBeforeCellEditorDestroyEventArgs>;
@@ -554,6 +556,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.onActiveCellChanged = new SlickEvent<OnActiveCellChangedEventArgs>('onActiveCellChanged', externalPubSub);
     this.onActiveCellPositionChanged = new SlickEvent<{ grid: SlickGrid; }>('onActiveCellPositionChanged', externalPubSub);
     this.onAddNewRow = new SlickEvent<OnAddNewRowEventArgs>('onAddNewRow', externalPubSub);
+    this.onAfterSetColumns = new SlickEvent<OnAfterSetColumnsEventArgs>('onAfterSetColumns', externalPubSub);
     this.onAutosizeColumns = new SlickEvent<OnAutosizeColumnsEventArgs>('onAutosizeColumns', externalPubSub);
     this.onBeforeAppendCell = new SlickEvent<OnBeforeAppendCellEventArgs>('onBeforeAppendCell', externalPubSub);
     this.onBeforeCellEditorDestroy = new SlickEvent<OnBeforeCellEditorDestroyEventArgs>('onBeforeCellEditorDestroy', externalPubSub);
@@ -3232,6 +3235,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.trigger(this.onBeforeSetColumns, { previousColumns: this.columns, newColumns: columnDefinitions, grid: this });
     this.columns = columnDefinitions;
     this.updateColumnsInternal();
+    this.trigger(this.onAfterSetColumns, { newColumns: columnDefinitions, grid: this });
   }
 
   /** Update columns for when a hidden property has changed but the column list itself has not changed. */


### PR DESCRIPTION
fixes #1119

- Select All disappears whenever reordering a column to another position because again it called the grid set columns and that again rerendered all column headers without the Select All
- to fix issue, I added a new `onAfterSetColumns` SlickEvent which we subscribe to inside the SlickCheckboxSelectColumn plugin, and whenever triggered, we reevaluate the Select All which in term recreates it
