### PR TITLE
fix: change to stopPropagation to avoid browser scrolling

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -3943,7 +3943,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
     const handled = this._handleScroll('mousewheel');
     if (handled) {
-      e.preventDefault();
+      e.stopPropagation();
     }
   }
 


### PR DESCRIPTION
related to Slickgrid-Universal [issue](https://github.com/ghiscoding/slickgrid-universal/issues/2034)