### PR TITLE
fix: only toggle title and data-slick-tooltip if value is defined

### DIFF
--- a/src/plugins/slick.customtooltip.ts
+++ b/src/plugins/slick.customtooltip.ts
@@ -306,7 +306,7 @@ export class SlickCustomTooltip {
     const titleElm = inputTitleElm || (this._cellNodeElm && ((this._cellNodeElm.hasAttribute('title') && this._cellNodeElm.getAttribute('title')) ? this._cellNodeElm : this._cellNodeElm.querySelector('[title]')));
 
     // flip tooltip text from `title` to `data-slick-tooltip`
-    if (titleElm) {
+    if (titleElm && tooltipText) {
       titleElm.setAttribute('data-slick-tooltip', tooltipText || '');
       if (titleElm.hasAttribute('title')) {
         titleElm.setAttribute('title', '');


### PR DESCRIPTION
this PR makes sure that the toggling of the title and data-slick-tooltip attributes of the customTooltip plugin only happens if there is a value to set.