### PR TITLE
fix: auto-scroll outside the viewport should stop Row Move dragging

### DIFF
--- a/src/plugins/slick.cellrangeselector.ts
+++ b/src/plugins/slick.cellrangeselector.ts
@@ -367,22 +367,23 @@ export class SlickCellRangeSelector implements SlickPlugin {
 
   protected handleDragEnd(e: SlickEventData, dd: DragPosition) {
     this._decorator.hide();
-    if (!this._dragging) {
-      return;
+
+    if (this._dragging && dd.range) {
+      this._dragging = false;
+      e.stopImmediatePropagation();
+
+      this.stopIntervalTimer();
+      this.onCellRangeSelected.notify({
+        range: new SlickRange(
+          dd.range.start.row ?? 0,
+          dd.range.start.cell ?? 0,
+          dd.range.end.row,
+          dd.range.end.cell
+        )
+      });
+    } else if (this._autoScrollTimerId) {
+      this.stopIntervalTimer(); // stop the auto-scroll timer if it was running
     }
-
-    this._dragging = false;
-    e.stopImmediatePropagation();
-
-    this.stopIntervalTimer();
-    this.onCellRangeSelected.notify({
-      range: new SlickRange(
-        dd.range.start.row ?? 0,
-        dd.range.start.cell ?? 0,
-        dd.range.end.row,
-        dd.range.end.cell
-      )
-    });
   }
 
   getCurrentRange() {

--- a/src/slick.interactions.ts
+++ b/src/slick.interactions.ts
@@ -99,9 +99,10 @@ export function Draggable(options: DraggableOption) {
         if (result !== false) {
           document.body.addEventListener('mousemove', userMoved);
           document.body.addEventListener('touchmove', userMoved);
-          document.body.addEventListener('mouseup', userReleased);
-          document.body.addEventListener('touchend', userReleased);
-          document.body.addEventListener('touchcancel', userReleased);
+          // register mouseup/... events on the window object so that we can catch them even if the user moves the mouse outside the container element
+          window.addEventListener('mouseup', userReleased);
+          window.addEventListener('touchend', userReleased);
+          window.addEventListener('touchcancel', userReleased);
         }
       }
     }
@@ -128,9 +129,9 @@ export function Draggable(options: DraggableOption) {
   function userReleased(event: MouseEvent | TouchEvent) {
     document.body.removeEventListener('mousemove', userMoved);
     document.body.removeEventListener('touchmove', userMoved);
-    document.body.removeEventListener('mouseup', userReleased);
-    document.body.removeEventListener('touchend', userReleased);
-    document.body.removeEventListener('touchcancel', userReleased);
+    window.removeEventListener('mouseup', userReleased);
+    window.removeEventListener('touchend', userReleased);
+    window.removeEventListener('touchcancel', userReleased);
 
     // trigger a dragEnd event only after dragging started and stopped
     if (dragStarted) {


### PR DESCRIPTION
- when grid has RowMove enabled and user starts dragging with auto-scroll but releases the mouse when outside the body viewport, the `mouseup` event was never triggering because we were falling outside the `document.body` which was the event registered. We can simply register the `mouseup` on `window` instead of `document.body` so that it would still get triggered even if the user is outside the document body/viewport. This will avoid the issue reported in the comment above and demoed below.

#### before the fix, the auto-scroll never stops (or briefly pauses if we over hover the grid but still doesn't stop)

![explorer_BTLOhDsakG](https://github.com/user-attachments/assets/e7e09b90-032b-4cee-8858-e3773a881eba)

#### after the fix, releasing the mouse outside the browser window/body will correctly stop the auto-scroll

![explorer_iMR91yPfh7](https://github.com/user-attachments/assets/ff8bf174-e311-4170-9562-eeed21e29406)
