### PR TITLE
feat: Add second css property to RangeDecorator plugin

### DIFF
--- a/src/models/cellRange.interface.ts
+++ b/src/models/cellRange.interface.ts
@@ -3,6 +3,7 @@ import type { SlickCellRangeDecorator } from '../plugins/slick.cellrangedecorato
 export interface CellRangeDecoratorOption {
   selectionCssClass: string;
   selectionCss: CSSStyleDeclaration;
+  copyToSelectionCss: CSSStyleDeclaration;
   offset: { top: number; left: number; height: number; width: number; };
 }
 
@@ -24,4 +25,7 @@ export interface CellRangeSelectorOption {
 
   /** styling (for example blue background on cell) */
   selectionCss: CSSStyleDeclaration;
+
+  /** styling for drag-fill rangel marker (optional) */
+  copyToSelectionCss: CSSStyleDeclaration;
 }

--- a/src/plugins/slick.cellrangedecorator.ts
+++ b/src/plugins/slick.cellrangedecorator.ts
@@ -25,21 +25,35 @@ export class SlickCellRangeDecorator implements SlickPlugin {
   // protected props
   protected _options: CellRangeDecoratorOption;
   protected _elem?: HTMLDivElement | null;
+  protected _selectionCss: CSSStyleDeclaration;
   protected _defaults = {
     selectionCssClass: 'slick-range-decorator',
     selectionCss: {
       zIndex: '9999',
       border: '2px dashed red'
     },
+    copyToSelectionCss : {
+        "zIndex": "9999",
+        "border": "2px dashed blue"
+    },
     offset: { top: -1, left: -1, height: -2, width: -2 }
   } as CellRangeDecoratorOption;
 
   constructor(protected readonly grid: SlickGrid, options?: Partial<CellRangeDecoratorOption>) {
     this._options = Utils.extend(true, {}, this._defaults, options);
+    this._selectionCss = options?.selectionCss || {} as CSSStyleDeclaration;
   }
 
   destroy() {
     this.hide();
+  }
+
+  getSelectionCss() {
+    return this._selectionCss;
+  }
+
+  setSelectionCss(cssProps: CSSStyleDeclaration) {
+    this._selectionCss = cssProps;
   }
 
   init() { }
@@ -49,19 +63,23 @@ export class SlickCellRangeDecorator implements SlickPlugin {
     this._elem = null;
   }
 
-  show(range: SlickRange) {
+  show(range: SlickRange, isCopyTo?: boolean) {
     if (!this._elem) {
       this._elem = document.createElement('div');
       this._elem.className = this._options.selectionCssClass;
-      Object.keys(this._options.selectionCss as CSSStyleDeclaration).forEach((cssStyleKey) => {
-        this._elem!.style[cssStyleKey as CSSStyleDeclarationWritable] = this._options.selectionCss[cssStyleKey as CSSStyleDeclarationWritable];
-      });
       this._elem.style.position = 'absolute';
       const canvasNode = this.grid.getActiveCanvasNode();
       if (canvasNode) {
         canvasNode.appendChild(this._elem);
       }
     }
+
+    const css = isCopyTo && this._options.copyToSelectionCss ? this._options.copyToSelectionCss :this._options.selectionCss;
+    Object.keys(css).forEach((cssStyleKey) => {
+      if (this._elem!.style[cssStyleKey as CSSStyleDeclarationWritable] !== css[cssStyleKey as CSSStyleDeclarationWritable]) {
+        this._elem!.style[cssStyleKey as CSSStyleDeclarationWritable] = css[cssStyleKey as CSSStyleDeclarationWritable];
+      }
+    });
 
     const from = this.grid.getCellNodeBox(range.fromRow, range.fromCell);
     const to = this.grid.getCellNodeBox(range.toRow, range.toCell);


### PR DESCRIPTION
Add second range selector css property to allow visual difference in selection between initial select and drag-expand select.