### PR TITLE
fix: column freeze + reorder same order could cause columns misalignment

### DIFF
--- a/src/models/gridEvents.interface.ts
+++ b/src/models/gridEvents.interface.ts
@@ -18,7 +18,7 @@ export interface OnBeforeSetColumnsEventArgs extends SlickGridArg { previousColu
 export interface OnCellChangeEventArgs extends SlickGridArg { row: number; cell: number; item: any; column: Column; }
 export interface OnCellCssStylesChangedEventArgs extends SlickGridArg { key: string; hash: CssStyleHash; }
 export interface OnColumnsDragEventArgs extends SlickGridArg { triggeredByColumn: string; resizeHandle: HTMLDivElement; }
-export interface OnColumnsReorderedEventArgs extends SlickGridArg { impactedColumns: Column[]; }
+export interface OnColumnsReorderedEventArgs extends SlickGridArg { impactedColumns: Column[]; previousColumnOrder: Array<string | number>; }
 export interface OnColumnsResizedEventArgs extends SlickGridArg { triggeredByColumn: string; }
 export interface OnColumnsResizeDblClickEventArgs extends SlickGridArg { triggeredByColumn: string; }
 export interface OnCompositeEditorChangeEventArgs extends SlickGridArg { row?: number; cell?: number; item: any; column: Column; formValues: any; editors: { [columnId: string]: Editor; }; triggeredBy?: 'user' | 'system'; }


### PR DESCRIPTION
- when a grid has a frozen/pinned column and the right section had a scroll in the middle, if the user started dragging a column but ended up with the exact same column order, it was causing a column header misalignment. So to fix this, I simply ignore any code execution (when column order changes, SlickGrid calls its `grid.setColumns()` with the new order and that triggers a bunch of other things). Basically, if the column order is exactly the same as before, then there's no point in re-executing all the internal code change logic because nothing changed.
- while at it, I also added `previousColumnOrder` in the `onColumnsReordered` event, so now it's `{ impactedColumns: Column[]; previousColumnOrder: Array<string | number>; }` which can be useful to know what was the original order Ids before the change happened

<img width="1814" height="445" alt="image" src="https://github.com/user-attachments/assets/b9f34d4e-e5db-489a-a816-0e87469b4674" />
