### PR TITLE
feat: add new `autoEditByKeypress` to open editor by typing a char

### DIFF
--- a/cypress/e2e/example3-editing.cy.ts
+++ b/cypress/e2e/example3-editing.cy.ts
@@ -109,7 +109,7 @@ describe('Example3 Editing', () => {
     cy.get('[data-test="auto-edit-key-on-btn"]').click();
   });
 
-  it('should be able to edit "Duration" when "autoEditByKey" is enabled and by clicking once on second row and expect next row to become editable', () => {
+  it('should be able to edit "Duration" when "autoEditByKeypress" is enabled and by clicking once on second row and expect next row to become editable', () => {
     cy.get('[data-row="2"] .slick-cell.l2.r2').should('contain', '5 days');
     cy.get('[data-row="2"] .slick-cell.l2.r2').click();
     cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
@@ -127,7 +127,7 @@ describe('Example3 Editing', () => {
     cy.get('[data-test="auto-edit-key-off-btn"]').click();
   });
 
-  it('should NOT be able to edit "Duration" when "autoEditByKey" is disabled', () => {
+  it('should NOT be able to edit "Duration" when "autoEditByKeypress" is disabled', () => {
     cy.get('[data-row="3"] .slick-cell.l2.r2').should('contain', '5 days');
     cy.get('[data-row="3"] .slick-cell.l2.r2').click();
     cy.get('[data-row="3"] .slick-cell.l2.r2.active.editable').should('have.length', 0);

--- a/cypress/e2e/example3b-editing-with-undo.cy.ts
+++ b/cypress/e2e/example3b-editing-with-undo.cy.ts
@@ -147,7 +147,7 @@ describe('Example3 Editing', () => {
     cy.get('[data-test="auto-edit-key-on-btn"]').click();
   });
 
-  it('should be able to edit "Duration" when "autoEditByKey" is enabled and by clicking once on second row and expect next row to become editable', () => {
+  it('should be able to edit "Duration" when "autoEditByKeypress" is enabled and by clicking once on second row and expect next row to become editable', () => {
     cy.get('[data-row="2"] .slick-cell.l2.r2').should('contain', '5 days');
     cy.get('[data-row="2"] .slick-cell.l2.r2').click();
     cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
@@ -165,7 +165,7 @@ describe('Example3 Editing', () => {
     cy.get('[data-test="auto-edit-key-off-btn"]').click();
   });
 
-  it('should NOT be able to edit "Duration" when "autoEditByKey" is disabled', () => {
+  it('should NOT be able to edit "Duration" when "autoEditByKeypress" is disabled', () => {
     cy.get('[data-row="3"] .slick-cell.l2.r2').should('contain', '5 days');
     cy.get('[data-row="3"] .slick-cell.l2.r2').click();
     cy.get('[data-row="3"] .slick-cell.l2.r2.active.editable').should('have.length', 0);

--- a/examples/example3-editing.html
+++ b/examples/example3-editing.html
@@ -50,11 +50,11 @@
       <button data-test="auto-edit-off-btn" onclick="grid.setOptions({autoEdit:false})">Auto-edit OFF</button>
     </p>
     <p>
-      <code>autoEditByKey</code> to start editing by typing a character on an active cell
+      <code>autoEditByKeypress</code> to start editing by typing a character on an active cell
       <br/>
-      <button data-test="auto-edit-key-on-btn" onclick="grid.setOptions({autoEditByKey:true})">Auto-edit by keyboard ON</button>
+      <button data-test="auto-edit-key-on-btn" onclick="grid.setOptions({autoEditByKeypress:true})">Auto-edit by keyboard ON</button>
       &nbsp;
-      <button data-test="auto-edit-key-off-btn" onclick="grid.setOptions({autoEditByKey:false})">Auto-edit by keyboard OFF</button>
+      <button data-test="auto-edit-key-off-btn" onclick="grid.setOptions({autoEditByKeypress:false})">Auto-edit by keyboard OFF</button>
     </p>
     <p>
       <button data-test="auto-commit-on-btn"  onclick="grid.setOptions({autoCommitEdit:true})">AutoCommitEdit ON</button>

--- a/examples/example3b-editing-with-undo.html
+++ b/examples/example3b-editing-with-undo.html
@@ -44,11 +44,11 @@
       <button data-test="auto-edit-off-btn" onclick="grid.setOptions({autoEdit:false})">Auto-edit OFF</button>
     </p>
     <p>
-      <code>autoEditByKey</code> to start editing by typing a character on an active cell
+      <code>autoEditByKeypress</code> to start editing by typing a character on an active cell
       <br/>
-      <button data-test="auto-edit-key-on-btn" onclick="grid.setOptions({autoEditByKey:true})">Auto-edit by keyboard ON</button>
+      <button data-test="auto-edit-key-on-btn" onclick="grid.setOptions({autoEditByKeypress:true})">Auto-edit by keyboard ON</button>
       &nbsp;
-      <button data-test="auto-edit-key-off-btn" onclick="grid.setOptions({autoEditByKey:false})">Auto-edit by keyboard OFF</button>
+      <button data-test="auto-edit-key-off-btn" onclick="grid.setOptions({autoEditByKeypress:false})">Auto-edit by keyboard OFF</button>
     </p>
 
     <h2>View Source:</h2>

--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -71,7 +71,7 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   autoEdit?: boolean;
 
   /** Defaults to false, when enabled will automatically open the inlined editor as soon as user starts typing in an active cell (can be combined with "enableCellNavigation: true"). */
-  autoEditByKey?: boolean;
+  autoEditByKeypress?: boolean;
 
   /**
    * Defaults to true, when enabled it will automatically open the editor when clicking on cell that has a defined editor.

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -4196,7 +4196,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     const cell = this.getActiveCell();
     const isChar = /^[\p{L}\p{N}\p{P}\p{S}\s]$/u.test(e.key); // make sure it's a character being typed
-    if (!handled && this._options.autoEditByKey && cell && isChar && this.isCellEditable(cell.row, cell.cell) && !this.currentEditor) {
+    if (!handled && this._options.autoEditByKeypress && cell && isChar && this.isCellEditable(cell.row, cell.cell) && !this.currentEditor) {
       this.makeActiveCellEditable(undefined, false, e);
     }
 


### PR DESCRIPTION
When using and enabling both `autoEdit` and `enableExcelCopyBuffer`, starting a cell selection can conflict with the editing part. What this PR does, is to provide another grid option `autoEditByKeypress`, which only starts editing when user starts typing a character via the keyboard, this avoid conflicting with with cell selection.

as you can see below, I focus on the cell, then start typing "123", Enter, .... and I assume that is the behavior you were looking for

![brave_5FBheS9REP](https://github.com/user-attachments/assets/61a1abd7-9944-403d-99d4-e9e4e4e5c4e4)
