### PR TITLE
fix: double-clicking a checkmark icon should keep current cell selection

### DIFF
--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -9,7 +9,7 @@
 // we will also use the name to create a CSS variable so that user could override any of the icon
 // by providing the full url string without needing else since it was already created
 @mixin createSvgStyle($cssVarName, $svgPath) {
-  --#{$cssVarName}: url('data:image/svg+xml;utf8,%3Csvg viewBox="0 0 24 24" display="inline-block" height="1em" width="1em" vertical-align="text-bottom" xmlns="http://www.w3.org/2000/svg" %3E%3Cpath fill="currentColor" d="#{$svgPath}"/%3E%3C/svg%3E');
+  --#{$cssVarName}: url('data:image/svg+xml;utf8,%3Csvg viewBox="0 0 24 24" height="1em" width="1em" vertical-align="text-bottom" xmlns="http://www.w3.org/2000/svg" %3E%3Cpath fill="currentColor" d="#{$svgPath}"/%3E%3C/svg%3E');
   -webkit-mask: var(--#{$cssVarName}) no-repeat;
   mask: var(--#{$cssVarName}) no-repeat;
   mask-size: 100% 100%;

--- a/src/styles/slick-icons.scss
+++ b/src/styles/slick-icons.scss
@@ -45,7 +45,7 @@ $slick-icon-width-max-size: 30 !default;
 @include m.createSvgClass("sgi-user", "M12,4A4,4 0 0,1 16,8A4,4 0 0,1 12,12A4,4 0 0,1 8,8A4,4 0 0,1 12,4M12,14C16.42,14 20,15.79 20,18V20H4V18C4,15.79 7.58,14 12,14Z");
 
 .sgi {
-  display: inline-block;
+  display: inline-flex;
   background-color: currentColor;
   color: inherit;
   font-size: 18px;


### PR DESCRIPTION
not exactly sure why but changing `inline-block` to `inline-flex` fixes the issue.  
`user-select: none` is another possible fix, but seems too big for the job, so let's use flex

https://github.com/user-attachments/assets/28e8d3db-770f-48c0-8c3a-226a97a04587
