### PR TITLE
fix: enable momentum scrolling on iOS to prevent scroll interruption at horizontal boundaries

### DIFF
--- a/dist/styles/sass/slick-alpine-theme.scss
+++ b/dist/styles/sass/slick-alpine-theme.scss
@@ -44,6 +44,8 @@
 
 .slick-viewport {
   background-color: var(--alpine-bg-color, v.$alpine-bg-color);
+  -webkit-overflow-scrolling: touch;
+  touch-action: manipulation;
 
   .grid-canvas {
     position: relative;


### PR DESCRIPTION
fixes #1055

_vibe coded a fix with Copilot_

## Description
Fixes issue #1055 where vertical scrolling stops on iOS when the horizontal scrollbar reaches the left edge. This issue only affects iOS browsers (Safari, Chrome) and does not occur on Android or desktop browsers.

## Root Cause
iOS requires explicit CSS properties to enable momentum (inertia) scrolling. Without these, touch scrolling can be interrupted when conflicting with other scroll container boundaries.

## Solution
Added two CSS properties to `.slick-viewport` in the Alpine theme:
- `-webkit-overflow-scrolling: touch;` - Enables momentum scrolling on WebKit browsers (iOS)
- `touch-action: manipulation;` - Allows natural touch gestures without interference

## Changes
- Modified `dist/styles/sass/slick-alpine-theme.scss` to add momentum scrolling support

## Testing
iOS users should test with iPad/iPhone on any example with horizontal scrolling (e.g., example-trading-esm.html):
1. Scroll down/right to move the horizontal scrollbar to the left edge
2. Verify that vertical scrolling (inertia/momentum) continues smoothly instead of stopping
3. Confirm horizontal scrolling still works normally

## Browser Support
- Safari on iOS: ✅
- Chrome on iOS: ✅
- Desktop browsers: ✅ (no negative impact)
- Android browsers: ✅ (no negative impact)
