### PR TITLE
fix: restore individual cell values on undo for multi-cell paste

### DIFF
--- a/src/plugins/slick.cellexternalcopymanager.ts
+++ b/src/plugins/slick.cellexternalcopymanager.ts
@@ -311,17 +311,21 @@ export class SlickCellExternalCopyManager implements SlickPlugin {
       },
       undo: () => {
         for (let y = 0; y < clipCommand.destH; y++) {
+          let xOffset = 0;
           for (let x = 0; x < clipCommand.destW; x++) {
             const desty = activeRow + y;
             const destx = activeCell + x;
+            const column = columns[destx];
+
+            if (column.hidden) {
+              xOffset++;
+              continue;
+            }
 
             if (desty < clipCommand.maxDestY && destx < clipCommand.maxDestX) {
               const dt = grid.getDataItem(desty);
-              if (oneCellToMultiple) {
-                clipCommand.setDataItemValueForColumn(dt, columns[destx], clipCommand.oldValues[0][0]);
-              } else {
-                clipCommand.setDataItemValueForColumn(dt, columns[destx], clipCommand.oldValues[y][x]);
-              }
+              // Always restore from the stored old value for each cell, regardless of oneCellToMultiple
+              clipCommand.setDataItemValueForColumn(dt, column, clipCommand.oldValues[y][x - xOffset]);
               grid.updateCell(desty, destx);
               grid.onCellChange.notify({
                 row: desty,


### PR DESCRIPTION
fixes #917

_vibe coded a fix with Copilot_

## Description
Fixes issue #917 where undoing a multi-cell paste operation in CellExternalCopyManager incorrectly restores all cells to the same value instead of their individual previous values.

## Root Cause
When pasting a single cell value to multiple cells (`oneCellToMultiple`), the undo function was incorrectly retrieving the old value. It used `oldValues[0][0]` for all cells instead of `oldValues[y][x - xOffset]`, causing all cells to be restored to the first cell's previous value.

## Reproduction Steps
1. Open example-excel-compatible-spreadsheet.html
2. Copy a single cell value
3. Select a range of multiple cells
4. Paste the single value (applies to all selected cells as expected)
5. Press Ctrl+Z to undo
6. **Bug:** All cells are incorrectly restored to the same value

## Solution
- Removed the `oneCellToMultiple` condition from the undo function
- Added proper `xOffset` tracking to handle hidden columns correctly (consistent with the execute function)
- Each cell now restores from its own stored old value: `oldValues[y][x - xOffset]`

## Testing
1. Copy a single cell with value "A"
2. Select a range of 4 cells (e.g., containing "B", "C", "D", "E")
3. Paste (all 4 cells now contain "A")
4. Undo (all 4 cells should be restored to their original values "B", "C", "D", "E")
5. Verify each cell is restored correctly

## Impact
- Fixes undo behavior for multi-cell paste operations
- No breaking changes
- Properly handles hidden columns in the restore process
