### PR TITLE
fix: use dataItemColumnValueExtractor for grouping with nested objects

### DIFF
--- a/src/slick.dataview.ts
+++ b/src/slick.dataview.ts
@@ -1,6 +1,7 @@
 import type {
   Aggregator,
   AnyFunction,
+  Column,
   CssStyleHash,
   CustomDataView,
   DataViewHints,
@@ -901,6 +902,27 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return this.groups;
   }
 
+  /** Helper method to get grouping value, using grid's dataItemColumnValueExtractor if available */
+  protected getGroupingValue(item: TData, groupingInfo: any): any {
+    if (groupingInfo.getterIsAFn) {
+      return (groupingInfo.getter as GroupGetterFn)(item);
+    }
+
+    const fieldName = groupingInfo.getter as string;
+
+    // Try to use grid's dataItemColumnValueExtractor if available
+    if (this._grid && typeof (this._grid as any)._options?.dataItemColumnValueExtractor === 'function') {
+      const gridColumns = (this._grid as any).getColumns?.();
+      const column = gridColumns?.find((col: Column) => col.field === fieldName);
+      if (column) {
+        return (this._grid as any)._options.dataItemColumnValueExtractor(item, column);
+      }
+    }
+
+    // Fallback to direct field access
+    return item[fieldName as keyof TData];
+  }
+
   protected extractGroups(rows: any[], parentGroup?: SlickGroup_) {
     let group: SlickGroup_;
     let val: any;
@@ -925,7 +947,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
 
     for (let i = 0, l = rows.length; i < l; i++) {
       r = rows[i];
-      val = gi.getterIsAFn ? (gi.getter as GroupGetterFn)(r) : r[gi.getter as keyof TData];
+      val = this.getGroupingValue(r, gi);
       group = groupsByVal[val];
       if (!group) {
         group = new SlickGroup();


### PR DESCRIPTION
fixes #227 

_vibe coded a fix with Copilot_

## Description
Fixes issue #227 where grouping does not work with `dataItemColumnValueExtractor` for accessing nested object properties.

## Root Cause
When a column uses a custom `dataItemColumnValueExtractor` to access nested objects and grouping is applied to that column, the DataView's grouping logic ignored the extractor and tried to access the field directly, resulting in `undefined` values for grouping.

## Reproduction Steps
1. Define nested objects in data: `{ security: { fullName: 'foo' } }`
2. Create a column with `field: 'security'` and `dataItemColumnValueExtractor` to extract `security.fullName`
3. Set grouping on that column
4. **Bug:** Grouping shows as `undefined` instead of grouping by the extracted values

## Solution
- Added `getGroupingValue()` helper method to DataView that:
  - Checks if a grid reference is available with `dataItemColumnValueExtractor`
  - Finds the column definition matching the grouping field
  - Uses the extractor to get the value if available
  - Falls back to direct field access if no extractor or grid reference
- Modified `extractGroups()` to use this helper for string field getters

## Changes
- [slick.dataview.ts](src/slick.dataview.ts): Added `Column` import and `getGroupingValue()` method

## Testing
1. Create a grid with nested object data
2. Use `dataItemColumnValueExtractor` to expose nested properties
3. Add column grouping for a nested property
4. Verify grouping works correctly with extracted values
5. Verify grouping still works for non-extractor columns

## Impact
- Fixes grouping with custom extractors
- No breaking changes
- Grid reference must be available for this to work (set via `syncGridSelection()` or used by draggable grouping plugin)
- Fallback to direct field access for DataView-only usage without grid reference