### PR TITLE
fix: scrolling with grouping accounts for group headers

### DIFF
--- a/src/slick.dataview.ts
+++ b/src/slick.dataview.ts
@@ -530,6 +530,66 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return ids;
   }
 
+  /** Get the display row index for a data item index, accounting for group headers */
+  getDisplayRowIndex(dataRowIndex: number): number {
+    if (!this.groupingInfos.length || dataRowIndex < 0 || dataRowIndex >= this.items.length) {
+      return dataRowIndex;
+    }
+
+    // If no groups, display index equals data index
+    if (!this.groups.length) {
+      return dataRowIndex;
+    }
+
+    let displayIndex = 0;
+    const targetItem = this.items[dataRowIndex];
+
+    // Traverse the flattened group structure to find the display index
+    const findItemInGroups = (groups: SlickGroup_[], level: number): boolean => {
+      const gi = this.groupingInfos[level];
+
+      for (let i = 0; i < groups.length; i++) {
+        const g = groups[i];
+
+        // Count the group header
+        displayIndex++;
+
+        if (!g.collapsed) {
+          if (g.groups && g.groups.length > 0) {
+            // Recursively search in subgroups
+            if (findItemInGroups(g.groups, level + 1)) {
+              return true;
+            }
+          } else {
+            // Search in the group's data rows
+            for (let j = 0; j < g.rows.length; j++) {
+              if (g.rows[j] === targetItem) {
+                // Found the item, add the offset within the group
+                displayIndex += j;
+                return true;
+              }
+            }
+            // Add the count of data rows in this group
+            displayIndex += g.rows.length;
+          }
+
+          // Add totals row if present
+          if (g.totals && gi.displayTotalsRow && (!g.collapsed || gi.aggregateCollapsed)) {
+            displayIndex++;
+          }
+        }
+      }
+
+      return false;
+    };
+
+    if (findItemInGroups(this.groups, 0)) {
+      return displayIndex - 1; // -1 because we increment before checking
+    }
+
+    return dataRowIndex; // Fallback
+  }
+
   /**
    * Performs the update operations of a single item by id without
    * triggering any events or refresh operations.

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -7031,6 +7031,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Boolean} doPaging - scroll when pagination is enabled
    */
   scrollRowIntoView(row: number, doPaging?: boolean) {
+    // When grouping is enabled, convert data row index to display row index
+    const dataView = this.getData() as any;
+    if (dataView?.getGrouping && dataView.getGrouping().length > 0) {
+      row = dataView.getDisplayRowIndex(row);
+    }
+
     if (!this.hasFrozenRows ||
       (!this._options.frozenBottom && row > this.actualFrozenRow - 1) ||
       (this._options.frozenBottom && row < this.actualFrozenRow - 1)) {
@@ -7064,6 +7070,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number} row - grid row number
    */
   scrollRowToTop(row: number) {
+    // When grouping is enabled, convert data row index to display row index
+    const dataView = this.getData() as any;
+    if (dataView?.getGrouping && dataView.getGrouping().length > 0) {
+      row = dataView.getDisplayRowIndex(row);
+    }
     this.scrollTo(row * this._options.rowHeight!);
     this.render();
   }


### PR DESCRIPTION
fixes #229

_vibe coded a fix with Copilot_

## Description
Fixes issue #229 where `scrollRowToTop` and `scrollRowIntoView` don't work correctly when grouping is enabled. The methods assumed row indices correspond directly to display positions, but group headers shift the actual positions of data rows.

## Root Cause
When grouping is enabled, the DataView's `rows` array contains group headers interspersed with data rows. A data row at index 500 might actually be at display position 550+ if there are group headers before it. The scroll methods used `row * rowHeight` without accounting for these extra rows.

## Solution
- Added `getDisplayRowIndex(dataRowIndex)` method to DataView that traverses the grouped structure to find the correct display position
- Modified `scrollRowToTop` and `scrollRowIntoView` in Grid to convert data row indices to display row indices when grouping is active
- No impact on non-grouped grids (falls back to original behavior)

## Changes
- [slick.dataview.ts](src/slick.dataview.ts): Added `getDisplayRowIndex()` method
- [slick.grid.ts](src/slick.grid.ts): Modified `scrollRowToTop()` and `scrollRowIntoView()` methods

## Testing
1. Enable grouping on any column
2. Call `grid.scrollRowToTop(dataRowIndex)` or `grid.scrollRowIntoView(dataRowIndex)`
3. Verify the correct data row scrolls into view, accounting for group headers
4. Test with collapsed/expanded groups
5. Verify no regression for non-grouped grids

## Impact
- Fixes scrolling behavior with grouped grids
- Maintains backward compatibility
- Performance: O(n) traversal of group structure (acceptable for typical group counts)