### PR TITLE
fix: use numeric sort in deleteItems to prevent data loss, fixes #1178

### DIFF
--- a/src/slick.dataview.ts
+++ b/src/slick.dataview.ts
@@ -698,7 +698,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
       }
 
       // Remove from back to front
-      indexesToDelete.sort();
+      indexesToDelete.sort((a, b) => a - b);
       for (let i = indexesToDelete.length - 1; i >= 0; --i) {
         this.items.splice(indexesToDelete[i], 1);
       }


### PR DESCRIPTION
fixes #1178

_vibe coded a fix with Copilot_

## Description
Fixes incorrect array sorting in `deleteItems()` method that could cause data loss when deleting multiple items.

## Problem
The `indexesToDelete` array was sorted without a comparator using `sort()`, which defaults to lexicographic (string) ordering instead of numeric ordering. This caused incorrect item deletion when array indices contained multi-digit numbers.

**Example:**
- Indices: `[10, 2, 3, 20]`
- Without comparator: `['10', '2', '20', '3']` → incorrect order
- With comparator: `[2, 3, 10, 20]` → correct numeric order

Since items are deleted from back to front based on these indices, incorrect ordering resulted in wrong items being removed from the dataset.

## Solution
Added numeric comparator to `sort()` call: `sort((a, b) => a - b)`

## Files Changed
- `packages/common/src/core/slickDataview.ts` - Fixed `deleteItems()` method

## Testing
Existing unit tests cover this functionality and should pass with the fix applied.