### PR TITLE
fix: 'getColContentSize' for single row with 0 as value

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -2735,6 +2735,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const rowInfo = {} as RowInfo;
     rowInfo.colIndex = colIndex;
     rowInfo.rowCount = this.getDataLength();
+
+    if (rowInfo.rowCount === 0) {
+      return autoSize.headerWidthPx;
+    }
+
     rowInfo.startIndex = 0;
     rowInfo.endIndex = rowInfo.rowCount - 1;
     rowInfo.valueArr = null;

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -2769,7 +2769,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (autoSize.valueFilterMode === ValueFilterMode.GetGreatestAndSub) {
       // get greatest abs value in data
       let maxVal;
-      let maxAbsVal = 0;
+      let maxAbsVal = -1;
       for (i = rowInfo.startIndex; i <= rowInfo.endIndex; i++) {
         tempVal = rowInfo.getRowVal(i);
         if (Math.abs(tempVal) > maxAbsVal) {


### PR DESCRIPTION
Fixes https://github.com/6pac/SlickGrid/issues/1221

Note: I have also added an early return in case of no rows at all.