### PR TITLE
fix: CellExternalCopyManager shouldn't throw when out of bound

### DIFF
--- a/cypress/e2e/example-excel-compatible-spreadsheet.cy.ts
+++ b/cypress/e2e/example-excel-compatible-spreadsheet.cy.ts
@@ -59,5 +59,24 @@ describe('Example - Excel-compatible spreadsheet and Cell Selection', { retries:
       cy.get('@active_cell').type('{ctrl}{end}');
       cy.get('#myGrid [data-row=99] > .slick-cell.l26.r26.active').should('have.length', 1);
     });
+
+    it('should ignore pasted cells outside grid column bounds when clipboard data exceeds available grid columns', () => {
+      cy.get('#myGrid .slick-viewport-top.slick-viewport-left').scrollTo(200, 0).wait(10);
+      cy.get('#myGrid [data-row=0] .slick-cell.l22.r22').click();
+
+      cy.window().then((win: any) => {
+        const plugin = win.grid.getPluginByName('CellExternalCopyManager');
+        expect(plugin).to.exist;
+
+        const ta = win.document.createElement('textarea');
+        ta.value = 'p1\tp2\tp3\tp4\tp5\tp6\tp7\tp8\tp9\tp10';
+        win.document.body.appendChild(ta);
+
+        expect(() => plugin._decodeTabularData(win.grid, ta)).not.to.throw();
+      });
+
+      cy.get('#myGrid [data-row=0] .slick-cell.l22.r22').should('have.text', 'p1');
+      cy.get('#myGrid [data-row=0] .slick-cell.l26.r26').should('have.text', 'p5');
+    });
   });
 });

--- a/src/plugins/slick.cellexternalcopymanager.ts
+++ b/src/plugins/slick.cellexternalcopymanager.ts
@@ -268,6 +268,10 @@ export class SlickCellExternalCopyManager implements SlickPlugin {
             const destx = activeCell + x;
             const column = columns[destx];
 
+            if (!column) {
+              break;
+            }
+
             // paste on hidden column will be skipped, but we need to paste 1 cell further on X axis
             // we'll increase our X and increase the offset`
             if (column.hidden) {
@@ -316,6 +320,10 @@ export class SlickCellExternalCopyManager implements SlickPlugin {
             const desty = activeRow + y;
             const destx = activeCell + x;
             const column = columns[destx];
+
+            if (!column) {
+              break;
+            }
 
             if (column.hidden) {
               xOffset++;


### PR DESCRIPTION
fixes #1225