### PR TITLE
fix(build): pass sources and destination to copyfiles as a single array

### DIFF
--- a/scripts/builds.mjs
+++ b/scripts/builds.mjs
@@ -171,9 +171,9 @@ export function runBuild(options) {
 
 /** Copy all SASS input files to the dist output folder */
 function copySassFiles() {
+  // native-copyfiles expects the source glob(s) and the output directory together in a single array
   copyfiles(
-    'src/styles/*.scss',
-    'dist/styles/sass',
+    ['src/styles/*.scss', 'dist/styles/sass'],
     { flat: true, stat: true },
     () => console.log(`[${styleText('magenta', 'SASS')}] SASS files copied`)
   );


### PR DESCRIPTION
## Problem

`npm run build:prod` crashes at the final SASS-source copy step:

```
TypeError: paths.pop is not a function
    at copyfiles (node_modules/native-copyfiles/dist/index.js:116:25)
    at copySassFiles (scripts/builds.mjs)
```

Because `copySassFiles()` runs before `build:types` in `runProdBuildWithTypes()`, the crash also prevents the type declarations from being built.

## Root cause

`native-copyfiles` expects the source glob(s) and the output directory together in **one** `paths` array (its implementation does `paths.slice(0, -1)` / `paths.pop()`):

```js
copyfiles(paths, options, callback)
```

`copySassFiles()` was passing them as two separate string arguments, so the options object landed in the `callback` slot and the first string had no `.pop()`.

## Fix

Pass `['src/styles/*.scss', 'dist/styles/sass']` as a single array. No behaviour change otherwise.

## Verification

With this change, `node scripts/builds.mjs --prod` completes the entire pipeline: all bundles (cjs/esm/mjs/iife), the SASS build, the SASS source copy (`[SASS] SASS files copied`, 17 files landing in `dist/styles/sass`), and `build:types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
