### PR TITLE
fix(core): Initial Bug Fix 2: compute scrollTo page before deriving the paging offset

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -6645,8 +6645,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     y = Math.min(y, (this.th || 0) - (Utils.height(this._viewportScrollContainerY) as number) + ((this.viewportHasHScroll || this.hasFrozenColumns()) ? (this.scrollbarDimensions?.height ?? 0) : 0));
 
     const oldOffset = this.offset;
+    // determine the page for the target position first, then derive the offset from that page
+    // (computing the offset from the previous page would lag one scroll event behind on jumps)
+    this.page = Math.min((this.n || 0) - 1, this.ph ? Math.floor(y / this.ph) : 0);
     this.offset = Math.round(this.page * (this.cj || 0));
-    this.page = Math.min((this.n || 0) - 1, Math.floor(y / (this.ph || 0)));
     const newScrollTop = (y - this.offset) as number;
 
     if (this.offset !== oldOffset) {


### PR DESCRIPTION
## Problem

In `scrollTo(y)` the virtual-scrolling offset is derived from the **previous** page before the page is updated for the target position:

```ts
this.offset = Math.round(this.page * (this.cj || 0));                       // uses the page from BEFORE this scroll
this.page = Math.min((this.n || 0) - 1, Math.floor(y / (this.ph || 0)));   // page updated too late
```

So after a programmatic jump that crosses pages (`scrollRowToTop`, `scrollRowIntoView`, `updateRowCount`'s scroll restoration) the `page`/`offset` pair lags one scroll event behind, and the first render after the jump runs with the old page's offset. Reproduced on a 1.5M-row grid (paging engaged, `n = 117`): after `scrollRowToTop(750000)` the grid reported `page: 58` with `offset: 0` until the next scroll event corrected it.

This only affects grids tall enough to enter paging mode (content beyond `maxSupportedCssHeight`); everything self-corrects on the next scroll event, which is why it goes unnoticed in normal wheel/drag scrolling.

## Fix

Restore the original SlickGrid order — compute the page for the target position first, then derive the offset from that page. Also replaces the `y / (this.ph || 0)` division (which relies on `Math.min` to mop up the resulting `Infinity`) with an explicit `ph` guard.

## Verification

- 1.5M-row grid, jumps to rows 750k / 0 / 1.49M / 400k: immediately after each `scrollRowToTop`, `offset === Math.round(page * cj)` and `page === floor(y / ph)` now hold (previously the offset was one event stale).
- Full Cypress suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
