### PR TITLE
fix(core): Initial Bug Fix 1: probe positioned-child limit in getMaxSupportedCssHeight

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -7665,8 +7665,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /**
-   * Dynamically doubles a test height on a temporary element until the element no longer accepts the height
-   * (or exceeds a browser-specific maximum). Returns the highest supported CSS height in pixels.
+   * Dynamically doubles a test height on a temporary element until the element no longer accepts the height,
+   * a child positioned at the bottom of the element no longer lands where it was asked,
+   * or a browser-specific maximum is exceeded. Returns the highest supported CSS height in pixels.
    *
    * @returns {number} The highest supported CSS height in pixels.
    */
@@ -7675,14 +7676,19 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // FF reports the height back but still renders blank after ~6M px
     // let testUpTo = navigator.userAgent.toLowerCase().match(/firefox/) ? 6000000 : 1000000000;
     const testUpTo = navigator.userAgent.toLowerCase().match(/firefox/) ? this._options.ffMaxSupportedCssHeight : this._options.maxSupportedCssHeight;
-    const div = Utils.createDomElement('div', { style: { display: 'hidden' } }, document.body);
+    const div = Utils.createDomElement('div', { style: { display: 'hidden', position: 'relative' } }, document.body);
+    // grid rows are absolutely positioned inside the canvas, and browsers clamp positioned layout at a
+    // much lower limit than the maximum element height (e.g. Blink saturates positioned offsets at
+    // 2^24 px while a plain height read-back survives to ~32M px), so a positioned child is probed too
+    const marker = Utils.createDomElement('div', { style: { position: 'absolute', height: '1px' } }, div);
 
     while (true) {
       const test = supportedHeight * 2;
       Utils.height(div, test);
       const height = Utils.height(div);
+      marker.style.top = `${test - 1}px`;
 
-      if (test > testUpTo! || height !== test) {
+      if (test > testUpTo! || height !== test || marker.offsetTop !== test - 1) {
         break;
       } else {
         supportedHeight = test;


### PR DESCRIPTION
## Problem

`getMaxSupportedCssHeight()` probes the browser's height limit by doubling a div's height and reading it back. On Chromium that read-back survives to 32,000,000px — but Blink separately clamps **absolutely-positioned layout** at 16,777,214px (2²⁴−2). Since grid rows are absolutely-positioned children of the canvas, any grid whose canvas exceeds ~16.7M px silently misplaces every row past that boundary.

Reproduced on a 1.5M-row grid at the default 25px row height (canvas capped at the probed 32M px):

```
row 1,499,964:  style.top: 26,703,000px   →   offsetTop: 16,777,214
```

Every row between ~16.7M and 32M canvas px stacks up at the clamp. At 25px rows this hits any grid beyond ~671k rows; the virtual-paging machinery that exists precisely to avoid the browser limit never engages because the probe reports a limit the browser can't actually position at.

## Fix

Probe what the grid actually depends on: alongside the height read-back, position a 1px marker child at `top: test - 1` and require `marker.offsetTop === test - 1`. The probe stops at the first height where either check fails.

On Blink the doubling sequence (1M → 2M → … → 16M → 32M) now fails at the 32M step and returns **16,000,000**, safely inside the real limit, so the existing page-switching machinery simply engages earlier. Firefox is unaffected (`ffMaxSupportedCssHeight` caps the probe at 6M, below the clamp). The `options.maxSupportedCssHeight` / `ffMaxSupportedCssHeight` escape hatches are unchanged.

## Verification

- Chromium now probes 16,000,000 (was 32,000,000).
- The 1.5M-row repro above renders correctly: for rendered rows at every scroll position, `offsetTop` equals the requested `style.top` (paging keeps in-canvas positions under 16M).
- Full Cypress suite passes (grids in the examples are far below the threshold, so no behaviour change for them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
