### PR TITLE
refactor: Frozen Rows/Cols Mod Part 2: encapsulate frozen rows/columns pane management behind ViewportMgr + opt-in lazyPanes

### DIFF
--- a/cypress/e2e/dom-shape-characterization.cy.ts
+++ b/cypress/e2e/dom-shape-characterization.cy.ts
@@ -1,0 +1,164 @@
+/**
+ * DOM-shape characterization test (Phase 0 baseline for the ViewportMgr refactor).
+ *
+ * Captures the EXACT pane/viewport/canvas DOM structure the grid builds today —
+ * 6 panes, 4 viewports, 4 canvases, always created regardless of frozen options,
+ * with visibility and row routing varying by freeze state — so that the Phase 1
+ * refactor (building the same DOM through ViewportMgr) can prove it produces an
+ * identical structure.
+ *
+ * Do NOT loosen these assertions to make a refactor pass; a failure here means the
+ * DOM contract changed. Only update them when the contract change is deliberate
+ * (e.g. Phase 3 lazy panes behind the opt-in option).
+ */
+
+const PANE_CLASSES = [
+  ['slick-pane', 'slick-pane-header', 'slick-pane-left'],
+  ['slick-pane', 'slick-pane-header', 'slick-pane-right'],
+  ['slick-pane', 'slick-pane-top', 'slick-pane-left'],
+  ['slick-pane', 'slick-pane-top', 'slick-pane-right'],
+  ['slick-pane', 'slick-pane-bottom', 'slick-pane-left'],
+  ['slick-pane', 'slick-pane-bottom', 'slick-pane-right'],
+];
+
+const SIDES = ['left', 'right'] as const;
+const BANDS = ['top', 'bottom'] as const;
+
+/** Asserts the canonical structure every grid builds today, frozen or not. */
+function assertCanonicalShape() {
+  // 6 panes as direct children of the container, in exact creation order
+  cy.get('#myGrid > .slick-pane')
+    .should('have.length', 6)
+    .then(($panes) => {
+      PANE_CLASSES.forEach((classes, i) => {
+        classes.forEach((cls) => expect($panes.eq(i), `pane ${i} has .${cls}`).to.have.class(cls));
+      });
+    });
+
+  // 4 viewports and 4 canvases, each nested in its matching pane/viewport
+  cy.get('#myGrid .slick-viewport').should('have.length', 4);
+  cy.get('#myGrid .grid-canvas').should('have.length', 4);
+  BANDS.forEach((band) => {
+    SIDES.forEach((side) => {
+      cy.get(`#myGrid .slick-pane-${band}.slick-pane-${side} > .slick-viewport.slick-viewport-${band}.slick-viewport-${side}`)
+        .should('have.length', 1);
+      cy.get(`#myGrid .slick-viewport-${band}.slick-viewport-${side} > .grid-canvas.grid-canvas-${band}.grid-canvas-${side}`)
+        .should('have.length', 1);
+    });
+  });
+
+  // one header scroller + one header-columns container per side, in the header panes
+  cy.get('#myGrid .slick-pane-header.slick-pane-left > .slick-header.slick-header-left').should('have.length', 1);
+  cy.get('#myGrid .slick-pane-header.slick-pane-right > .slick-header.slick-header-right').should('have.length', 1);
+  cy.get('#myGrid .slick-header-left > .slick-header-columns.slick-header-columns-left').should('have.length', 1);
+  cy.get('#myGrid .slick-header-right > .slick-header-columns.slick-header-columns-right').should('have.length', 1);
+
+  // header-row and top-panel scrollers live in the TOP panes, one per side,
+  // created before the viewport (child order: headerrow, top-panel, viewport)
+  SIDES.forEach((side) => {
+    cy.get(`#myGrid .slick-pane-top.slick-pane-${side} > .slick-headerrow`).should('have.length', 1);
+    cy.get(`#myGrid .slick-pane-top.slick-pane-${side} > .slick-top-panel-scroller`).should('have.length', 1);
+  });
+  cy.get('#myGrid .slick-pane-top.slick-pane-left').children().then(($children) => {
+    const classNames = $children.toArray().map((el) => el.className);
+    const idxHeaderRow = classNames.findIndex((c) => c.includes('slick-headerrow'));
+    const idxTopPanel = classNames.findIndex((c) => c.includes('slick-top-panel-scroller'));
+    const idxViewport = classNames.findIndex((c) => c.includes('slick-viewport'));
+    expect(idxHeaderRow, 'headerrow before top-panel').to.be.lessThan(idxTopPanel);
+    expect(idxTopPanel, 'top-panel before viewport').to.be.lessThan(idxViewport);
+  });
+}
+
+/** Asserts which of the 6 panes are visible for a given freeze state. */
+function assertPaneVisibility(visible: { headerR: boolean; topR: boolean; bottomL: boolean; bottomR: boolean; }) {
+  cy.get('#myGrid .slick-pane-header.slick-pane-left').should('be.visible');
+  cy.get('#myGrid .slick-pane-top.slick-pane-left').should('be.visible');
+  cy.get('#myGrid .slick-pane-header.slick-pane-right').should(visible.headerR ? 'be.visible' : 'not.be.visible');
+  cy.get('#myGrid .slick-pane-top.slick-pane-right').should(visible.topR ? 'be.visible' : 'not.be.visible');
+  cy.get('#myGrid .slick-pane-bottom.slick-pane-left').should(visible.bottomL ? 'be.visible' : 'not.be.visible');
+  cy.get('#myGrid .slick-pane-bottom.slick-pane-right').should(visible.bottomR ? 'be.visible' : 'not.be.visible');
+}
+
+/** Asserts which canvases receive row elements for a given freeze state. */
+function assertRowRouting(populated: { topL: boolean; topR: boolean; bottomL: boolean; bottomR: boolean; }) {
+  const expectRows = (band: string, side: string, hasRows: boolean) => {
+    cy.get(`#myGrid .grid-canvas-${band}.grid-canvas-${side} .slick-row`)
+      .should(hasRows ? 'have.length.greaterThan' : 'have.length', 0);
+  };
+  expectRows('top', 'left', populated.topL);
+  expectRows('top', 'right', populated.topR);
+  expectRows('bottom', 'left', populated.bottomL);
+  expectRows('bottom', 'right', populated.bottomR);
+}
+
+describe('DOM shape characterization - non-frozen grid (example1-simple)', () => {
+  it('should load the example', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example1-simple.html`);
+  });
+
+  it('should build the canonical 6-pane / 4-viewport / 4-canvas structure', () => {
+    assertCanonicalShape();
+  });
+
+  it('should show only the left header and top-left panes', () => {
+    assertPaneVisibility({ headerR: false, topR: false, bottomL: false, bottomR: false });
+  });
+
+  it('should render all rows into the top-left canvas only', () => {
+    assertRowRouting({ topL: true, topR: false, bottomL: false, bottomR: false });
+  });
+});
+
+describe('DOM shape characterization - frozen columns only (example-frozen-columns)', () => {
+  it('should load the example', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-frozen-columns.html`);
+  });
+
+  it('should build the canonical 6-pane / 4-viewport / 4-canvas structure', () => {
+    assertCanonicalShape();
+  });
+
+  it('should show header and top panes on both sides, bottom panes hidden', () => {
+    assertPaneVisibility({ headerR: true, topR: true, bottomL: false, bottomR: false });
+  });
+
+  it('should render rows into the two top canvases only', () => {
+    assertRowRouting({ topL: true, topR: true, bottomL: false, bottomR: false });
+  });
+});
+
+describe('DOM shape characterization - frozen rows only, frozenBottom (example-frozen-rows)', () => {
+  it('should load the example', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-frozen-rows.html`);
+  });
+
+  it('should build the canonical 6-pane / 4-viewport / 4-canvas structure', () => {
+    assertCanonicalShape();
+  });
+
+  it('should show left panes only, including the bottom-left pane', () => {
+    assertPaneVisibility({ headerR: false, topR: false, bottomL: true, bottomR: false });
+  });
+
+  it('should render rows into the two left canvases only', () => {
+    assertRowRouting({ topL: true, topR: false, bottomL: true, bottomR: false });
+  });
+});
+
+describe('DOM shape characterization - frozen columns and rows (example-frozen-columns-and-rows)', () => {
+  it('should load the example', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-frozen-columns-and-rows.html`);
+  });
+
+  it('should build the canonical 6-pane / 4-viewport / 4-canvas structure', () => {
+    assertCanonicalShape();
+  });
+
+  it('should show all six panes', () => {
+    assertPaneVisibility({ headerR: true, topR: true, bottomL: true, bottomR: true });
+  });
+
+  it('should render rows into all four canvases', () => {
+    assertRowRouting({ topL: true, topR: true, bottomL: true, bottomR: true });
+  });
+});

--- a/cypress/e2e/dom-shape-lazy-panes.cy.ts
+++ b/cypress/e2e/dom-shape-lazy-panes.cy.ts
@@ -1,0 +1,57 @@
+/**
+ * DOM-shape characterization for the lazyPanes opt-in (Phase 3 of the ViewportMgr
+ * refactor). A grid built with `lazyPanes: true` and no frozen rows/columns must
+ * create ONLY the top-left pane set — 2 panes (header-left, top-left), 1 viewport,
+ * 1 canvas — instead of the historical 6/4/4 structure, while remaining fully
+ * functional. Companion to dom-shape-characterization.cy.ts (the default mode).
+ */
+
+describe('DOM shape - lazyPanes single-pane build (example-lazy-panes)', () => {
+  it('should load the example', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-lazy-panes.html`);
+  });
+
+  it('should build only the header-left and top-left panes, in order', () => {
+    cy.get('#myGrid > .slick-pane')
+      .should('have.length', 2)
+      .then(($panes) => {
+        expect($panes.eq(0)).to.have.class('slick-pane-header');
+        expect($panes.eq(0)).to.have.class('slick-pane-left');
+        expect($panes.eq(1)).to.have.class('slick-pane-top');
+        expect($panes.eq(1)).to.have.class('slick-pane-left');
+      });
+    cy.get('#myGrid .slick-pane-right').should('have.length', 0);
+    cy.get('#myGrid .slick-pane-bottom').should('have.length', 0);
+  });
+
+  it('should build exactly one viewport and one canvas, correctly nested', () => {
+    cy.get('#myGrid .slick-viewport').should('have.length', 1);
+    cy.get('#myGrid .grid-canvas').should('have.length', 1);
+    cy.get('#myGrid .slick-pane-top.slick-pane-left > .slick-viewport.slick-viewport-top.slick-viewport-left').should('have.length', 1);
+    cy.get('#myGrid .slick-viewport-top.slick-viewport-left > .grid-canvas.grid-canvas-top.grid-canvas-left').should('have.length', 1);
+  });
+
+  it('should build only left-side header chrome', () => {
+    cy.get('#myGrid .slick-header').should('have.length', 1);
+    cy.get('#myGrid .slick-header-columns').should('have.length', 1);
+    cy.get('#myGrid .slick-headerrow').should('have.length', 1);
+    cy.get('#myGrid .slick-top-panel-scroller').should('have.length', 1);
+  });
+
+  it('should render header columns and rows normally', () => {
+    cy.get('#myGrid .slick-header-columns .slick-header-column').should('have.length', 6);
+    cy.get('#myGrid .grid-canvas-top.grid-canvas-left .slick-row').should('have.length.greaterThan', 0);
+    cy.get('#myGrid .grid-canvas .slick-row .slick-cell').first().should('contain', 'Task 0');
+  });
+
+  it('should support basic navigation (click makes a cell active)', () => {
+    cy.get('#myGrid .slick-row .slick-cell').first().click();
+    cy.get('#myGrid .slick-cell.active').should('have.length', 1);
+  });
+
+  it('should scroll vertically and keep rendering rows', () => {
+    cy.get('#myGrid .slick-viewport').scrollTo(0, 2000);
+    cy.get('#myGrid .grid-canvas .slick-row').should('have.length.greaterThan', 0);
+    cy.get('#myGrid .slick-viewport').scrollTo(0, 0);
+  });
+});

--- a/cypress/e2e/viewportmgr-lazy-materialization.cy.ts
+++ b/cypress/e2e/viewportmgr-lazy-materialization.cy.ts
@@ -1,0 +1,87 @@
+/**
+ * Runtime materialization tests for the lazyPanes opt-in (Phase 3, ViewportMgr
+ * refactor): enabling frozen rows/columns on a lazy single-pane grid must build
+ * the missing panes on the fly at their canonical positions and wire their events.
+ *
+ * NOTE: this spec is deliberately named to sort AFTER the example-* specs, keeping
+ * its freeze/unfreeze churn away from the timing-sensitive native-clipboard test in
+ * example-excel-compatible-spreadsheet (testIsolation is false, so all specs share
+ * one browser session).
+ */
+
+describe('DOM shape - lazyPanes dynamic materialization on runtime freeze', () => {
+  it('should load the lazy example in its single-pane state', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-lazy-panes.html`);
+    cy.get('#myGrid > .slick-pane').should('have.length', 2);
+  });
+
+  it('should materialize the full pane set when frozen columns are enabled at runtime', () => {
+    cy.window().then((win: any) => {
+      win.grid.setOptions({ frozenColumn: 1 });
+    });
+
+    cy.get('#myGrid > .slick-pane').should('have.length', 6).then(($panes) => {
+      // canonical sibling order must match the non-lazy build
+      const expected = [
+        ['slick-pane-header', 'slick-pane-left'],
+        ['slick-pane-header', 'slick-pane-right'],
+        ['slick-pane-top', 'slick-pane-left'],
+        ['slick-pane-top', 'slick-pane-right'],
+        ['slick-pane-bottom', 'slick-pane-left'],
+        ['slick-pane-bottom', 'slick-pane-right'],
+      ];
+      expected.forEach((classes, i) => {
+        classes.forEach((cls) => expect($panes.eq(i), `pane ${i} has .${cls}`).to.have.class(cls));
+      });
+    });
+    cy.get('#myGrid .slick-viewport').should('have.length', 4);
+    cy.get('#myGrid .grid-canvas').should('have.length', 4);
+  });
+
+  it('should split header columns and route rows into both top canvases', () => {
+    cy.get('#myGrid .slick-pane-header.slick-pane-right').should('be.visible');
+    cy.get('#myGrid .slick-header-columns-left .slick-header-column').should('have.length', 2);
+    cy.get('#myGrid .slick-header-columns-right .slick-header-column').should('have.length', 4);
+    cy.get('#myGrid .grid-canvas-top.grid-canvas-left .slick-row').should('have.length.greaterThan', 0);
+    cy.get('#myGrid .grid-canvas-top.grid-canvas-right .slick-row').should('have.length.greaterThan', 0);
+    cy.get('#myGrid .grid-canvas-top.grid-canvas-left .slick-cell').first().should('contain', 'Task 0');
+  });
+
+  it('should unfreeze again, hiding the right panes but keeping them in the DOM', () => {
+    cy.window().then((win: any) => {
+      win.grid.setOptions({ frozenColumn: -1 });
+    });
+
+    cy.get('#myGrid > .slick-pane').should('have.length', 6);
+    cy.get('#myGrid .slick-pane-header.slick-pane-right').should('not.be.visible');
+    cy.get('#myGrid .grid-canvas-top.grid-canvas-right .slick-row').should('have.length', 0);
+    cy.get('#myGrid .grid-canvas-top.grid-canvas-left .slick-row').should('have.length.greaterThan', 0);
+    cy.get('#myGrid .slick-header-columns-left .slick-header-column').should('have.length', 6);
+  });
+
+  it('should enable frozen rows on the already-materialized grid', () => {
+    cy.window().then((win: any) => {
+      win.grid.setOptions({ frozenRow: 3, frozenBottom: false });
+    });
+
+    cy.get('#myGrid .slick-pane-bottom.slick-pane-left').should('be.visible');
+    cy.get('#myGrid .grid-canvas-top.grid-canvas-left .slick-row').should('have.length', 3);
+    cy.get('#myGrid .grid-canvas-bottom.grid-canvas-left .slick-row').should('have.length.greaterThan', 0);
+  });
+
+  it('should materialize directly from lazy state when frozen rows are enabled first', () => {
+    // fresh page load back into lazy single-pane state
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-lazy-panes.html`);
+    cy.get('#myGrid > .slick-pane').should('have.length', 2);
+
+    cy.window().then((win: any) => {
+      win.grid.setOptions({ frozenRow: 2, frozenBottom: false });
+    });
+
+    cy.get('#myGrid > .slick-pane').should('have.length', 6);
+    cy.get('#myGrid .slick-pane-bottom.slick-pane-left').should('be.visible');
+    cy.get('#myGrid .slick-pane-header.slick-pane-right').should('not.be.visible');
+    cy.get('#myGrid .grid-canvas-top.grid-canvas-left .slick-row').should('have.length', 2);
+    cy.get('#myGrid .grid-canvas-bottom.grid-canvas-left .slick-row').should('have.length.greaterThan', 0);
+  });
+});

--- a/examples/example-lazy-panes.html
+++ b/examples/example-lazy-panes.html
@@ -1,0 +1,74 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
+  <title>SlickGrid example: lazyPanes single-pane build</title>
+  <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css"/>
+  <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css"/>
+</head>
+<body>
+<h2 class="title">Example: lazyPanes - single pane/viewport/canvas build</h2>
+<table width="100%">
+  <tr>
+    <td valign="top" width="50%">
+      <div id="myGrid" class="slick-container" style="width:600px;height:500px;"></div>
+    </td>
+    <td valign="top">
+      <div>
+        <h2>
+          <a href="/examples/index.html" style="text-decoration: none; font-size: 22px">&#x2302;</a>
+          Demonstrates:
+        </h2>
+      </div>
+      <ul>
+        <li>basic grid with minimal configuration</li>
+      </ul>
+        <h2>View Source:</h2>
+        <ul>
+            <li><A href="https://github.com/6pac/SlickGrid/blob/master/examples/example1-simple.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+        </ul>
+    </td>
+  </tr>
+</table>
+
+<script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
+<script src="sortable-cdn-fallback.js"></script>
+
+<script src="../dist/browser/slick.core.js"></script>
+<script src="../dist/browser/slick.interactions.js"></script>
+<script src="../dist/browser/slick.grid.js"></script>
+
+<script>
+  var grid;
+  var columns = [
+    {id: "title", name: "Title", field: "title"},
+    {id: "duration", name: "Duration", field: "duration"},
+    {id: "%", name: "% Complete", field: "percentComplete", width: 90 },
+    {id: "start", name: "Start", field: "start"},
+    {id: "finish", name: "Finish", field: "finish"},
+    {id: "effort-driven", name: "Effort Driven", field: "effortDriven", width: 90 }
+  ];
+
+  var options = {
+    enableCellNavigation: true,
+    enableColumnReorder: false,
+    lazyPanes: true
+  };
+
+  var data = [];
+  for (var i = 0; i < 500; i++) {
+    data[i] = {
+      title: "Task " + i,
+      duration: "5 days",
+      percentComplete: Math.round(Math.random() * 100),
+      start: "01/01/2009",
+      finish: "01/05/2009",
+      effortDriven: (i % 5 == 0)
+    };
+  }
+
+  grid = new Slick.Grid("#myGrid", data, columns, options);
+</script>
+</body>
+</html>

--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -251,6 +251,14 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
    */
   frozenRightViewportMinWidth?: number;
 
+  /**
+   * Defaults to false. When enabled AND the grid is created without frozen rows/columns, only the
+   * single top-left pane/viewport/canvas is built instead of the historical 6-pane/4-viewport/4-canvas
+   * structure; the extra panes materialize on the fly if freezing is later enabled via setOptions().
+   * Opt-in because it changes the DOM for consumers that style/query the unused right/bottom panes.
+   */
+  lazyPanes?: boolean;
+
   /** Defaults to false, which leads to have row(s) taking full width */
   fullWidthRows?: boolean;
 

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -513,6 +513,21 @@ class ViewportMgr {
     return colIdx <= this.freeze.frozenColumnIdx;
   }
 
+  /** True when frozen columns are on AND the column index falls right of the freeze. */
+  isColumnRightOfFreeze(colIdx: number): boolean {
+    return this.hasFrozenColumns() && colIdx > this.freeze.frozenColumnIdx;
+  }
+
+  /** Column index local to its side container (right-side children are indexed after the freeze). */
+  sideLocalColumnIdx(colIdx: number): number {
+    return this.isColumnRightOfFreeze(colIdx) ? colIdx - this.freeze.frozenColumnIdx - 1 : colIdx;
+  }
+
+  /** Pick the left or right element of an [L, R] pair for the given column. */
+  sideForColumn<T>(colIdx: number, left: T, right: T): T {
+    return this.isColumnRightOfFreeze(colIdx) ? right : left;
+  }
+
   /** add/remove frozen class to left headers/footer when defined */
   applyPaneFrozenClasses(): void {
     const classAction = this.hasFrozenColumns() ? 'add' : 'remove';
@@ -2216,10 +2231,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    */
   getHeader(columnDef: C) {
     if (!columnDef) {
-      return this.hasFrozenColumns() ? this._headers : this._headerL;
+      return this._viewportMgr.hasFrozenColumns() ? this._headers : this._headerL;
     }
     const idx = this.getColumnIndex(columnDef.id);
-    return this.hasFrozenColumns() ? ((idx <= this._options.frozenColumn!) ? this._headerL : this._headerR) : this._headerL;
+    return this._viewportMgr.sideForColumn(idx, this._headerL, this._headerR);
   }
 
   /**
@@ -2228,20 +2243,20 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    */
   getHeaderColumn(columnIdOrIdx: number | string) {
     const idx = (typeof columnIdOrIdx === 'number' ? columnIdOrIdx : this.getColumnIndex(columnIdOrIdx));
-    const targetHeader = this.hasFrozenColumns() ? ((idx <= this._options.frozenColumn!) ? this._headerL : this._headerR) : this._headerL;
-    const targetIndex = this.hasFrozenColumns() ? ((idx <= this._options.frozenColumn!) ? idx : idx - this._options.frozenColumn! - 1) : idx;
+    const targetHeader = this._viewportMgr.sideForColumn(idx, this._headerL, this._headerR);
+    const targetIndex = this._viewportMgr.sideLocalColumnIdx(idx);
 
     return targetHeader.children[targetIndex] as HTMLDivElement;
   }
 
   /** Get the Header Row DOM element */
   getHeaderRow() {
-    return this.hasFrozenColumns() ? this._headerRows : this._headerRows[0];
+    return this._viewportMgr.hasFrozenColumns() ? this._headerRows : this._headerRows[0];
   }
 
   /** Get the Footer DOM element */
   getFooterRow() {
-    return this.hasFrozenColumns() ? this._footerRow : this._footerRow[0];
+    return this._viewportMgr.hasFrozenColumns() ? this._footerRow : this._footerRow[0];
   }
 
   /**
@@ -2249,21 +2264,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number|String} columnIdOrIdx - column Id or index
    */
   getHeaderRowColumn(columnIdOrIdx: number | string) {
-    let idx = (typeof columnIdOrIdx === 'number' ? columnIdOrIdx : this.getColumnIndex(columnIdOrIdx));
-    let headerRowTarget: HTMLDivElement;
+    const idx = (typeof columnIdOrIdx === 'number' ? columnIdOrIdx : this.getColumnIndex(columnIdOrIdx));
+    const headerRowTarget = this._viewportMgr.sideForColumn(idx, this._headerRowL, this._headerRowR);
 
-    if (this.hasFrozenColumns()) {
-      if (idx <= this._options.frozenColumn!) {
-        headerRowTarget = this._headerRowL;
-      } else {
-        headerRowTarget = this._headerRowR;
-        idx -= this._options.frozenColumn! + 1;
-      }
-    } else {
-      headerRowTarget = this._headerRowL;
-    }
-
-    return headerRowTarget.children[idx] as HTMLDivElement;
+    return headerRowTarget.children[this._viewportMgr.sideLocalColumnIdx(idx)] as HTMLDivElement;
   }
 
   /**
@@ -2271,22 +2275,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number|String} columnIdOrIdx - column Id or index
    */
   getFooterRowColumn(columnIdOrIdx: number | string) {
-    let idx = (typeof columnIdOrIdx === 'number' ? columnIdOrIdx : this.getColumnIndex(columnIdOrIdx));
-    let footerRowTarget: HTMLDivElement;
+    const idx = (typeof columnIdOrIdx === 'number' ? columnIdOrIdx : this.getColumnIndex(columnIdOrIdx));
+    const footerRowTarget = this._viewportMgr.sideForColumn(idx, this._footerRowL, this._footerRowR);
 
-    if (this.hasFrozenColumns()) {
-      if (idx <= this._options.frozenColumn!) {
-        footerRowTarget = this._footerRowL;
-      } else {
-        footerRowTarget = this._footerRowR;
-
-        idx -= this._options.frozenColumn! + 1;
-      }
-    } else {
-      footerRowTarget = this._footerRowL;
-    }
-
-    return footerRowTarget.children[idx] as HTMLDivElement;
+    return footerRowTarget.children[this._viewportMgr.sideLocalColumnIdx(idx)] as HTMLDivElement;
   }
 
   /**
@@ -5394,7 +5386,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       const width = this.columns[i].width;
 
-      if ((this._options.frozenColumn!) > -1 && (i > this._options.frozenColumn!)) {
+      if (this._viewportMgr.isColumnRightOfFreeze(i)) {
         this.headersWidthR += width || 0;
       } else {
         this.headersWidthL += width || 0;
@@ -5402,14 +5394,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     if (includeScrollbar) {
-      if ((this._options.frozenColumn!) > -1 && (i > this._options.frozenColumn!)) {
+      if (this._viewportMgr.isColumnRightOfFreeze(i)) {
         this.headersWidthR += this.scrollbarDimensions?.width ?? 0;
       } else {
         this.headersWidthL += this.scrollbarDimensions?.width ?? 0;
       }
     }
 
-    if (this.hasFrozenColumns()) {
+    if (this._viewportMgr.hasFrozenColumns()) {
       this.headersWidthL = this.headersWidthL + 1000;
 
       this.headersWidthR = Math.max(this.headersWidthR, this.viewportW) + this.headersWidthL;
@@ -5438,7 +5430,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     while (i--) {
       if (!this.columns[i] || this.columns[i].hidden) { continue; }
 
-      if (this.hasFrozenColumns() && (i > this._options.frozenColumn!)) {
+      if (this._viewportMgr.isColumnRightOfFreeze(i)) {
         this.canvasWidthR += this.columns[i].width || 0;
       } else {
         this.canvasWidthL += this.columns[i].width || 0;
@@ -5449,7 +5441,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       const extraWidth = Math.max(totalRowWidth, availableWidth) - totalRowWidth;
       if (extraWidth > 0) {
         totalRowWidth += extraWidth;
-        if (this.hasFrozenColumns()) {
+        if (this._viewportMgr.hasFrozenColumns()) {
           this.canvasWidthR += extraWidth;
         } else {
           this.canvasWidthL += extraWidth;
@@ -5939,7 +5931,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     let rowDivR: HTMLElement | undefined;
     divArrayL.push(rowDiv);
-    if (this.hasFrozenColumns()) {
+    if (this._viewportMgr.hasFrozenColumns()) {
       // it has to be a deep copy otherwise we will have issues with pass by reference in js since
       // attempting to add the same element to 2 different arrays will just move 1 item to the other array
       rowDivR = rowDiv.cloneNode(true) as HTMLElement;
@@ -5993,10 +5985,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
         // All columns to the right are outside the range, so no need to render them
         if (isRenderCell) {
-          const targetedRowDiv = (this.hasFrozenColumns() && (i > this._options.frozenColumn!) ? rowDivR! : rowDiv);
+          const targetedRowDiv = this._viewportMgr.sideForColumn(i, rowDiv, rowDivR!);
           this.appendCellHtml(targetedRowDiv, row, i, ncolspan, rowspan, columnData, d);
         }
-      } else if (m.alwaysRenderColumn || (this.hasFrozenColumns() && i <= this._options.frozenColumn!)) {
+      } else if (m.alwaysRenderColumn || this._viewportMgr.isColumnInFrozenBand(i)) {
         this.appendCellHtml(rowDiv, row, i, ncolspan, rowspan, columnData, d);
       }
 
@@ -6032,7 +6024,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       + (rowspan > 1 ? ' rowspan' : '')
       + (columnMetadata?.cssClass ? ` ${columnMetadata.cssClass}` : '');
 
-    if (this.hasFrozenColumns() && cell <= this._options.frozenColumn!) {
+    if (this._viewportMgr.isColumnInFrozenBand(cell)) {
       cellCss += ' frozen';
     }
 
@@ -6854,7 +6846,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         if (!node) {
           continue;
         }
-        if (this.hasFrozenColumns() && (columnIdx > this._options.frozenColumn!)) {
+        if (this._viewportMgr.isColumnRightOfFreeze(columnIdx)) {
           cacheEntry.rowNode![1].appendChild(node);
         } else {
           cacheEntry.rowNode![0].appendChild(node);

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -146,6 +146,233 @@ interface RowCaching {
   cellRenderQueue: any[];
 }
 
+/** Options consumed by ViewportMgr when constructing the pane/viewport/canvas DOM. */
+interface ViewportMgrBuildOptions {
+  createPreHeaderPanel?: boolean;
+  showPreHeaderPanel?: boolean;
+  createFooterRow?: boolean;
+  showFooterRow?: boolean;
+  showColumnHeader?: boolean;
+  showTopPanel?: boolean;
+  showHeaderRow?: boolean;
+  viewportClass?: string;
+}
+
+/**
+ * ViewportMgr — owns the construction of the grid's pane/viewport/canvas DOM.
+ *
+ * Phase 1 of the frozen rows/columns encapsulation refactor: this class builds the
+ * exact same 6-pane / 4-viewport / 4-canvas structure the grid has always built
+ * (characterized by cypress/e2e/dom-shape-characterization.cy.ts) and SlickGrid keeps
+ * aliases to every element, so all existing logic is unchanged. Later phases move pane
+ * selection, geometry distribution and scroll synchronization in here.
+ */
+class ViewportMgr {
+  // panes
+  paneHeaderL!: HTMLDivElement;
+  paneHeaderR!: HTMLDivElement;
+  paneTopL!: HTMLDivElement;
+  paneTopR!: HTMLDivElement;
+  paneBottomL!: HTMLDivElement;
+  paneBottomR!: HTMLDivElement;
+
+  // pre-header panels (only when createPreHeaderPanel)
+  preHeaderPanelScroller!: HTMLDivElement;
+  preHeaderPanel!: HTMLDivElement;
+  preHeaderPanelSpacer!: HTMLDivElement;
+  preHeaderPanelScrollerR!: HTMLDivElement;
+  preHeaderPanelR!: HTMLDivElement;
+  preHeaderPanelSpacerR!: HTMLDivElement;
+
+  // header scrollers and header column containers
+  headerScrollerL!: HTMLDivElement;
+  headerScrollerR!: HTMLDivElement;
+  headerScroller: HTMLDivElement[] = [];
+  headerL!: HTMLDivElement;
+  headerR!: HTMLDivElement;
+  headers: HTMLDivElement[] = [];
+
+  // header rows
+  headerRowScrollerL!: HTMLDivElement;
+  headerRowScrollerR!: HTMLDivElement;
+  headerRowScroller: HTMLDivElement[] = [];
+  headerRowSpacerL!: HTMLDivElement;
+  headerRowSpacerR!: HTMLDivElement;
+  headerRowL!: HTMLDivElement;
+  headerRowR!: HTMLDivElement;
+  headerRows: HTMLDivElement[] = [];
+
+  // top panels
+  topPanelScrollerL!: HTMLDivElement;
+  topPanelScrollerR!: HTMLDivElement;
+  topPanelScrollers: HTMLDivElement[] = [];
+  topPanelL!: HTMLDivElement;
+  topPanelR!: HTMLDivElement;
+  topPanels: HTMLDivElement[] = [];
+
+  // viewports and canvases
+  viewportTopL!: HTMLDivElement;
+  viewportTopR!: HTMLDivElement;
+  viewportBottomL!: HTMLDivElement;
+  viewportBottomR!: HTMLDivElement;
+  viewport: HTMLDivElement[] = [];
+  canvasTopL!: HTMLDivElement;
+  canvasTopR!: HTMLDivElement;
+  canvasBottomL!: HTMLDivElement;
+  canvasBottomR!: HTMLDivElement;
+  canvas: HTMLDivElement[] = [];
+
+  // footer rows (only when createFooterRow)
+  footerRowScrollerL!: HTMLDivElement;
+  footerRowScrollerR!: HTMLDivElement;
+  footerRowScroller: HTMLDivElement[] = [];
+  footerRowSpacerL!: HTMLDivElement;
+  footerRowSpacerR!: HTMLDivElement;
+  footerRowL!: HTMLDivElement;
+  footerRowR!: HTMLDivElement;
+  footerRow: HTMLDivElement[] = [];
+
+  /**
+   * Builds the pane/viewport/canvas DOM inside the given container.
+   * The construction order and every class/style is identical to the historical
+   * inline construction in SlickGrid.initialize().
+   */
+  buildPanes(container: HTMLElement, o: ViewportMgrBuildOptions) {
+    // Containers used for scrolling frozen columns and rows
+    this.paneHeaderL = Utils.createDomElement('div', { className: 'slick-pane slick-pane-header slick-pane-left', tabIndex: 0 }, container);
+    this.paneHeaderR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-header slick-pane-right', tabIndex: 0 }, container);
+    this.paneTopL = Utils.createDomElement('div', { className: 'slick-pane slick-pane-top slick-pane-left', tabIndex: 0 }, container);
+    this.paneTopR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-top slick-pane-right', tabIndex: 0 }, container);
+    this.paneBottomL = Utils.createDomElement('div', { className: 'slick-pane slick-pane-bottom slick-pane-left', tabIndex: 0 }, container);
+    this.paneBottomR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-bottom slick-pane-right', tabIndex: 0 }, container);
+
+    if (o.createPreHeaderPanel) {
+      this.preHeaderPanelScroller = Utils.createDomElement('div', { className: 'slick-preheader-panel ui-state-default slick-state-default', style: { overflow: 'hidden', position: 'relative' } }, this.paneHeaderL);
+      this.preHeaderPanelScroller.appendChild(document.createElement('div'));
+      this.preHeaderPanel = Utils.createDomElement('div', null, this.preHeaderPanelScroller);
+      this.preHeaderPanelSpacer = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.preHeaderPanelScroller);
+
+      this.preHeaderPanelScrollerR = Utils.createDomElement('div', { className: 'slick-preheader-panel ui-state-default slick-state-default', style: { overflow: 'hidden', position: 'relative' } }, this.paneHeaderR);
+      this.preHeaderPanelR = Utils.createDomElement('div', null, this.preHeaderPanelScrollerR);
+      this.preHeaderPanelSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.preHeaderPanelScrollerR);
+
+      if (!o.showPreHeaderPanel) {
+        Utils.hide(this.preHeaderPanelScroller);
+        Utils.hide(this.preHeaderPanelScrollerR);
+      }
+    }
+
+    // Append the header scroller containers
+    this.headerScrollerL = Utils.createDomElement('div', { className: 'slick-header ui-state-default slick-state-default slick-header-left' }, this.paneHeaderL);
+    this.headerScrollerR = Utils.createDomElement('div', { className: 'slick-header ui-state-default slick-state-default slick-header-right' }, this.paneHeaderR);
+
+    // Cache the header scroller containers
+    this.headerScroller.push(this.headerScrollerL);
+    this.headerScroller.push(this.headerScrollerR);
+
+    // Append the columnn containers to the headers
+    this.headerL = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-left', role: 'row', style: { left: '-1000px' } }, this.headerScrollerL);
+    this.headerR = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-right', role: 'row', style: { left: '-1000px' } }, this.headerScrollerR);
+
+    // Cache the header columns
+    this.headers = [this.headerL, this.headerR];
+
+    this.headerRowScrollerL = Utils.createDomElement('div', { className: 'slick-headerrow ui-state-default slick-state-default' }, this.paneTopL);
+    this.headerRowScrollerR = Utils.createDomElement('div', { className: 'slick-headerrow ui-state-default slick-state-default' }, this.paneTopR);
+
+    this.headerRowScroller = [this.headerRowScrollerL, this.headerRowScrollerR];
+
+    this.headerRowSpacerL = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.headerRowScrollerL);
+    this.headerRowSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.headerRowScrollerR);
+
+    this.headerRowL = Utils.createDomElement('div', { className: 'slick-headerrow-columns slick-headerrow-columns-left' }, this.headerRowScrollerL);
+    this.headerRowR = Utils.createDomElement('div', { className: 'slick-headerrow-columns slick-headerrow-columns-right' }, this.headerRowScrollerR);
+
+    this.headerRows = [this.headerRowL, this.headerRowR];
+
+    // Append the top panel scroller
+    this.topPanelScrollerL = Utils.createDomElement('div', { className: 'slick-top-panel-scroller ui-state-default slick-state-default' }, this.paneTopL);
+    this.topPanelScrollerR = Utils.createDomElement('div', { className: 'slick-top-panel-scroller ui-state-default slick-state-default' }, this.paneTopR);
+
+    this.topPanelScrollers = [this.topPanelScrollerL, this.topPanelScrollerR];
+
+    // Append the top panel
+    this.topPanelL = Utils.createDomElement('div', { className: 'slick-top-panel', style: { width: '10000px' } }, this.topPanelScrollerL);
+    this.topPanelR = Utils.createDomElement('div', { className: 'slick-top-panel', style: { width: '10000px' } }, this.topPanelScrollerR);
+
+    this.topPanels = [this.topPanelL, this.topPanelR];
+
+    if (!o.showColumnHeader) {
+      this.headerScroller.forEach((el) => {
+        Utils.hide(el);
+      });
+    }
+
+    if (!o.showTopPanel) {
+      this.topPanelScrollers.forEach((scroller) => {
+        Utils.hide(scroller);
+      });
+    }
+
+    if (!o.showHeaderRow) {
+      this.headerRowScroller.forEach((scroller) => {
+        Utils.hide(scroller);
+      });
+    }
+
+    // Append the viewport containers
+    this.viewportTopL = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-top slick-viewport-left', tabIndex: 0 }, this.paneTopL);
+    this.viewportTopR = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-top slick-viewport-right', tabIndex: 0 }, this.paneTopR);
+    this.viewportBottomL = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-bottom slick-viewport-left', tabIndex: 0 }, this.paneBottomL);
+    this.viewportBottomR = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-bottom slick-viewport-right', tabIndex: 0 }, this.paneBottomR);
+
+    // Cache the viewports
+    this.viewport = [this.viewportTopL, this.viewportTopR, this.viewportBottomL, this.viewportBottomR];
+    if (o.viewportClass) {
+      this.viewport.forEach((view) => {
+        view.classList.add(...Utils.classNameToList((o.viewportClass)));
+      });
+    }
+
+    // Append the canvas containers
+    this.canvasTopL = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-top grid-canvas-left', tabIndex: 0 }, this.viewportTopL);
+    this.canvasTopR = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-top grid-canvas-right', tabIndex: 0 }, this.viewportTopR);
+    this.canvasBottomL = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-bottom grid-canvas-left', tabIndex: 0 }, this.viewportBottomL);
+    this.canvasBottomR = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-bottom grid-canvas-right', tabIndex: 0 }, this.viewportBottomR);
+
+    // Cache the canvases
+    this.canvas = [this.canvasTopL, this.canvasTopR, this.canvasBottomL, this.canvasBottomR];
+  }
+
+  /**
+   * Builds the footer-row containers (only called when the createFooterRow option is on).
+   * Identical construction to the historical inline code, including the R-before-L
+   * scroller creation order and spacer widths.
+   */
+  buildFooterRows(o: ViewportMgrBuildOptions, canvasWithScrollbarWidth: number) {
+    this.footerRowScrollerR = Utils.createDomElement('div', { className: 'slick-footerrow ui-state-default slick-state-default' }, this.paneTopR);
+    this.footerRowScrollerL = Utils.createDomElement('div', { className: 'slick-footerrow ui-state-default slick-state-default' }, this.paneTopL);
+
+    this.footerRowScroller = [this.footerRowScrollerL, this.footerRowScrollerR];
+
+    this.footerRowSpacerL = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.footerRowScrollerL);
+    Utils.width(this.footerRowSpacerL, canvasWithScrollbarWidth);
+    this.footerRowSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.footerRowScrollerR);
+    Utils.width(this.footerRowSpacerR, canvasWithScrollbarWidth);
+
+    this.footerRowL = Utils.createDomElement('div', { className: 'slick-footerrow-columns slick-footerrow-columns-left' }, this.footerRowScrollerL);
+    this.footerRowR = Utils.createDomElement('div', { className: 'slick-footerrow-columns slick-footerrow-columns-right' }, this.footerRowScrollerR);
+
+    this.footerRow = [this.footerRowL, this.footerRowR];
+
+    if (!o.showFooterRow) {
+      this.footerRowScroller.forEach((scroller) => {
+        Utils.hide(scroller);
+      });
+    }
+  }
+}
+
 export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O extends BaseGridOption<C> = BaseGridOption<C>> {
   //////////////////////////////////////////////////////////////////////////////////////////////
   // Public API
@@ -382,6 +609,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected dragReplaceEl = new DragExtendHandle(this.uid);
   protected _focusSink!: HTMLDivElement;
   protected _focusSink2!: HTMLDivElement;
+  protected _viewportMgr!: ViewportMgr;
   protected _groupHeaders: HTMLDivElement[] = [];
   protected _headerScroller: HTMLDivElement[] = [];
   protected _headers: HTMLDivElement[] = [];
@@ -711,113 +939,64 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       }
     }
 
-    // Containers used for scrolling frozen columns and rows
-    this._paneHeaderL = Utils.createDomElement('div', { className: 'slick-pane slick-pane-header slick-pane-left', tabIndex: 0 }, this._container);
-    this._paneHeaderR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-header slick-pane-right', tabIndex: 0 }, this._container);
-    this._paneTopL = Utils.createDomElement('div', { className: 'slick-pane slick-pane-top slick-pane-left', tabIndex: 0 }, this._container);
-    this._paneTopR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-top slick-pane-right', tabIndex: 0 }, this._container);
-    this._paneBottomL = Utils.createDomElement('div', { className: 'slick-pane slick-pane-bottom slick-pane-left', tabIndex: 0 }, this._container);
-    this._paneBottomR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-bottom slick-pane-right', tabIndex: 0 }, this._container);
+    // Containers used for scrolling frozen columns and rows.
+    // The pane/viewport/canvas DOM is built by ViewportMgr (identical structure to the
+    // historical inline construction); the grid keeps aliases to every element so all
+    // existing logic operates unchanged.
+    this._viewportMgr = new ViewportMgr();
+    this._viewportMgr.buildPanes(this._container, this._options);
 
-    if (this._options.createPreHeaderPanel) {
-      this._preHeaderPanelScroller = Utils.createDomElement('div', { className: 'slick-preheader-panel ui-state-default slick-state-default', style: { overflow: 'hidden', position: 'relative' } }, this._paneHeaderL);
-      this._preHeaderPanelScroller.appendChild(document.createElement('div'));
-      this._preHeaderPanel = Utils.createDomElement('div', null, this._preHeaderPanelScroller);
-      this._preHeaderPanelSpacer = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this._preHeaderPanelScroller);
+    this._paneHeaderL = this._viewportMgr.paneHeaderL;
+    this._paneHeaderR = this._viewportMgr.paneHeaderR;
+    this._paneTopL = this._viewportMgr.paneTopL;
+    this._paneTopR = this._viewportMgr.paneTopR;
+    this._paneBottomL = this._viewportMgr.paneBottomL;
+    this._paneBottomR = this._viewportMgr.paneBottomR;
 
-      this._preHeaderPanelScrollerR = Utils.createDomElement('div', { className: 'slick-preheader-panel ui-state-default slick-state-default', style: { overflow: 'hidden', position: 'relative' } }, this._paneHeaderR);
-      this._preHeaderPanelR = Utils.createDomElement('div', null, this._preHeaderPanelScrollerR);
-      this._preHeaderPanelSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this._preHeaderPanelScrollerR);
+    this._preHeaderPanelScroller = this._viewportMgr.preHeaderPanelScroller;
+    this._preHeaderPanel = this._viewportMgr.preHeaderPanel;
+    this._preHeaderPanelSpacer = this._viewportMgr.preHeaderPanelSpacer;
+    this._preHeaderPanelScrollerR = this._viewportMgr.preHeaderPanelScrollerR;
+    this._preHeaderPanelR = this._viewportMgr.preHeaderPanelR;
+    this._preHeaderPanelSpacerR = this._viewportMgr.preHeaderPanelSpacerR;
 
-      if (!this._options.showPreHeaderPanel) {
-        Utils.hide(this._preHeaderPanelScroller);
-        Utils.hide(this._preHeaderPanelScrollerR);
-      }
-    }
+    this._headerScrollerL = this._viewportMgr.headerScrollerL;
+    this._headerScrollerR = this._viewportMgr.headerScrollerR;
+    this._headerScroller = this._viewportMgr.headerScroller;
+    this._headerL = this._viewportMgr.headerL;
+    this._headerR = this._viewportMgr.headerR;
+    this._headers = this._viewportMgr.headers;
 
-    // Append the header scroller containers
-    this._headerScrollerL = Utils.createDomElement('div', { className: 'slick-header ui-state-default slick-state-default slick-header-left' }, this._paneHeaderL);
-    this._headerScrollerR = Utils.createDomElement('div', { className: 'slick-header ui-state-default slick-state-default slick-header-right' }, this._paneHeaderR);
+    this._headerRowScrollerL = this._viewportMgr.headerRowScrollerL;
+    this._headerRowScrollerR = this._viewportMgr.headerRowScrollerR;
+    this._headerRowScroller = this._viewportMgr.headerRowScroller;
+    this._headerRowSpacerL = this._viewportMgr.headerRowSpacerL;
+    this._headerRowSpacerR = this._viewportMgr.headerRowSpacerR;
+    this._headerRowL = this._viewportMgr.headerRowL;
+    this._headerRowR = this._viewportMgr.headerRowR;
+    this._headerRows = this._viewportMgr.headerRows;
 
-    // Cache the header scroller containers
-    this._headerScroller.push(this._headerScrollerL);
-    this._headerScroller.push(this._headerScrollerR);
+    this._topPanelScrollerL = this._viewportMgr.topPanelScrollerL;
+    this._topPanelScrollerR = this._viewportMgr.topPanelScrollerR;
+    this._topPanelScrollers = this._viewportMgr.topPanelScrollers;
+    this._topPanelL = this._viewportMgr.topPanelL;
+    this._topPanelR = this._viewportMgr.topPanelR;
+    this._topPanels = this._viewportMgr.topPanels;
 
-    // Append the columnn containers to the headers
-    this._headerL = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-left', role: 'row', style: { left: '-1000px' } }, this._headerScrollerL);
-    this._headerR = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-right', role: 'row', style: { left: '-1000px' } }, this._headerScrollerR);
+    this._viewportTopL = this._viewportMgr.viewportTopL;
+    this._viewportTopR = this._viewportMgr.viewportTopR;
+    this._viewportBottomL = this._viewportMgr.viewportBottomL;
+    this._viewportBottomR = this._viewportMgr.viewportBottomR;
+    this._viewport = this._viewportMgr.viewport;
 
-    // Cache the header columns
-    this._headers = [this._headerL, this._headerR];
-
-    this._headerRowScrollerL = Utils.createDomElement('div', { className: 'slick-headerrow ui-state-default slick-state-default' }, this._paneTopL);
-    this._headerRowScrollerR = Utils.createDomElement('div', { className: 'slick-headerrow ui-state-default slick-state-default' }, this._paneTopR);
-
-    this._headerRowScroller = [this._headerRowScrollerL, this._headerRowScrollerR];
-
-    this._headerRowSpacerL = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this._headerRowScrollerL);
-    this._headerRowSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this._headerRowScrollerR);
-
-    this._headerRowL = Utils.createDomElement('div', { className: 'slick-headerrow-columns slick-headerrow-columns-left' }, this._headerRowScrollerL);
-    this._headerRowR = Utils.createDomElement('div', { className: 'slick-headerrow-columns slick-headerrow-columns-right' }, this._headerRowScrollerR);
-
-    this._headerRows = [this._headerRowL, this._headerRowR];
-
-    // Append the top panel scroller
-    this._topPanelScrollerL = Utils.createDomElement('div', { className: 'slick-top-panel-scroller ui-state-default slick-state-default' }, this._paneTopL);
-    this._topPanelScrollerR = Utils.createDomElement('div', { className: 'slick-top-panel-scroller ui-state-default slick-state-default' }, this._paneTopR);
-
-    this._topPanelScrollers = [this._topPanelScrollerL, this._topPanelScrollerR];
-
-    // Append the top panel
-    this._topPanelL = Utils.createDomElement('div', { className: 'slick-top-panel', style: { width: '10000px' } }, this._topPanelScrollerL);
-    this._topPanelR = Utils.createDomElement('div', { className: 'slick-top-panel', style: { width: '10000px' } }, this._topPanelScrollerR);
-
-    this._topPanels = [this._topPanelL, this._topPanelR];
-
-    if (!this._options.showColumnHeader) {
-      this._headerScroller.forEach((el) => {
-        Utils.hide(el);
-      });
-    }
-
-    if (!this._options.showTopPanel) {
-      this._topPanelScrollers.forEach((scroller) => {
-        Utils.hide(scroller);
-      });
-    }
-
-    if (!this._options.showHeaderRow) {
-      this._headerRowScroller.forEach((scroller) => {
-        Utils.hide(scroller);
-      });
-    }
-
-    // Append the viewport containers
-    this._viewportTopL = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-top slick-viewport-left', tabIndex: 0 }, this._paneTopL);
-    this._viewportTopR = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-top slick-viewport-right', tabIndex: 0 }, this._paneTopR);
-    this._viewportBottomL = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-bottom slick-viewport-left', tabIndex: 0 }, this._paneBottomL);
-    this._viewportBottomR = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-bottom slick-viewport-right', tabIndex: 0 }, this._paneBottomR);
-
-    // Cache the viewports
-    this._viewport = [this._viewportTopL, this._viewportTopR, this._viewportBottomL, this._viewportBottomR];
-    if (this._options.viewportClass) {
-      this._viewport.forEach((view) => {
-        view.classList.add(...Utils.classNameToList((this._options.viewportClass)));
-      });
-    }
+    this._canvasTopL = this._viewportMgr.canvasTopL;
+    this._canvasTopR = this._viewportMgr.canvasTopR;
+    this._canvasBottomL = this._viewportMgr.canvasBottomL;
+    this._canvasBottomR = this._viewportMgr.canvasBottomR;
+    this._canvas = this._viewportMgr.canvas;
 
     // Default the active viewport to the top left
     this._activeViewportNode = this._viewportTopL;
-
-    // Append the canvas containers
-    this._canvasTopL = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-top grid-canvas-left', tabIndex: 0 }, this._viewportTopL);
-    this._canvasTopR = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-top grid-canvas-right', tabIndex: 0 }, this._viewportTopR);
-    this._canvasBottomL = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-bottom grid-canvas-left', tabIndex: 0 }, this._viewportBottomL);
-    this._canvasBottomR = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-bottom grid-canvas-right', tabIndex: 0 }, this._viewportBottomR);
-
-    // Cache the canvases
-    this._canvas = [this._canvasTopL, this._canvasTopR, this._canvasBottomL, this._canvasBottomR];
 
     this.scrollbarDimensions = this.scrollbarDimensions || this.measureScrollbar();
     const canvasWithScrollbarWidth = this.getCanvasWidth() + this.scrollbarDimensions.width;
@@ -844,26 +1023,16 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     // footer Row
     if (this._options.createFooterRow) {
-      this._footerRowScrollerR = Utils.createDomElement('div', { className: 'slick-footerrow ui-state-default slick-state-default' }, this._paneTopR);
-      this._footerRowScrollerL = Utils.createDomElement('div', { className: 'slick-footerrow ui-state-default slick-state-default' }, this._paneTopL);
+      this._viewportMgr.buildFooterRows(this._options, canvasWithScrollbarWidth);
 
-      this._footerRowScroller = [this._footerRowScrollerL, this._footerRowScrollerR];
-
-      this._footerRowSpacerL = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this._footerRowScrollerL);
-      Utils.width(this._footerRowSpacerL, canvasWithScrollbarWidth);
-      this._footerRowSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this._footerRowScrollerR);
-      Utils.width(this._footerRowSpacerR, canvasWithScrollbarWidth);
-
-      this._footerRowL = Utils.createDomElement('div', { className: 'slick-footerrow-columns slick-footerrow-columns-left' }, this._footerRowScrollerL);
-      this._footerRowR = Utils.createDomElement('div', { className: 'slick-footerrow-columns slick-footerrow-columns-right' }, this._footerRowScrollerR);
-
-      this._footerRow = [this._footerRowL, this._footerRowR];
-
-      if (!this._options.showFooterRow) {
-        this._footerRowScroller.forEach((scroller) => {
-          Utils.hide(scroller);
-        });
-      }
+      this._footerRowScrollerL = this._viewportMgr.footerRowScrollerL;
+      this._footerRowScrollerR = this._viewportMgr.footerRowScrollerR;
+      this._footerRowScroller = this._viewportMgr.footerRowScroller;
+      this._footerRowSpacerL = this._viewportMgr.footerRowSpacerL;
+      this._footerRowSpacerR = this._viewportMgr.footerRowSpacerR;
+      this._footerRowL = this._viewportMgr.footerRowL;
+      this._footerRowR = this._viewportMgr.footerRowR;
+      this._footerRow = this._viewportMgr.footerRow;
     }
 
     this._focusSink2 = this._focusSink.cloneNode(true) as HTMLDivElement;

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -446,6 +446,73 @@ class ViewportMgr {
     return (isBottomSide ? 2 : 0) + (isRightSide ? 1 : 0);
   }
 
+  /**
+   * Get frozen (pinned) row offset
+   *
+   * Returns the vertical pixel offset to apply for frozen rows.
+   * Depending on whether frozen rows are pinned at the bottom or top and based on grid height,
+   * it returns either a fixed frozen rows height or a calculated offset.
+   *
+   * @param {Number} row - grid row number
+   */
+  frozenRowOffset(row: number, g: { h: number; viewportTopH: number; frozenRowsHeight: number; rowHeight: number; }): number {
+    // let offset = ( hasFrozenRows ) ? ( this._options.frozenBottom ) ? ( row >= actualFrozenRow ) ? ( h < viewportTopH ) ? ( actualFrozenRow * this._options.rowHeight ) : h : 0 : ( row >= actualFrozenRow ) ? frozenRowsHeight : 0 : 0; // WTF?
+    let offset = 0;
+    if (this.freeze.hasFrozenRows) {
+      if (this.freeze.frozenBottom) {
+        if (row >= this.freeze.actualFrozenRow) {
+          if (g.h < g.viewportTopH) {
+            offset = (this.freeze.actualFrozenRow * g.rowHeight);
+          } else {
+            offset = g.h;
+          }
+        } else {
+          offset = 0;
+        }
+      }
+      else {
+        if (row >= this.freeze.actualFrozenRow) {
+          offset = g.frozenRowsHeight;
+        } else {
+          offset = 0;
+        }
+      }
+    } else {
+      offset = 0;
+    }
+
+    return offset;
+  }
+
+  /**
+   * Whether the row lives in a frozen band and must therefore be kept out of row
+   * virtualization cleanup (historical cleanupRows predicate).
+   */
+  isRowInFrozenBand(row: number): boolean {
+    return this.freeze.hasFrozenRows
+      && ((this.freeze.frozenBottom && row >= this.freeze.actualFrozenRow) // Frozen bottom rows
+        || (!this.freeze.frozenBottom && row <= this.freeze.actualFrozenRow) // Frozen top rows
+      );
+  }
+
+  /**
+   * Whether cell-level cleanup must skip the row entirely (historical cleanUpCells
+   * predicate). NOTE: transcribed verbatim — the second disjunct is NOT guarded by
+   * !frozenBottom, so for frozenBottom grids every row is exempt; that quirk is
+   * long-standing upstream behaviour and is deliberately preserved.
+   */
+  isRowCellCleanupExempt(row: number): boolean {
+    return this.freeze.hasFrozenRows
+      && ((this.freeze.frozenBottom && row > this.freeze.actualFrozenRow) // Frozen bottom rows
+        || (row <= this.freeze.actualFrozenRow)                     // Frozen top rows
+      );
+  }
+
+  /** Whether the column index falls inside the left frozen band. */
+  isColumnInFrozenBand(colIdx: number): boolean {
+    return colIdx <= this.freeze.frozenColumnIdx;
+  }
+
   /** add/remove frozen class to left headers/footer when defined */
   applyPaneFrozenClasses(): void {
     const classAction = this.hasFrozenColumns() ? 'add' : 'remove';
@@ -6072,11 +6139,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         let i = +rowId;
         let removeFrozenRow = true;
 
-        if (this.hasFrozenRows
-          && ((this._options.frozenBottom && (i as unknown as number) >= this.actualFrozenRow) // Frozen bottom rows
-            || (!this._options.frozenBottom && (i as unknown as number) <= this.actualFrozenRow) // Frozen top rows
-          )
-        ) {
+        if (this._viewportMgr.isRowInFrozenBand(i)) {
           removeFrozenRow = false;
         }
 
@@ -6632,11 +6695,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    */
   protected cleanUpCells(range: CellViewportRange, row: number) {
     // Ignore frozen rows
-    if (this.hasFrozenRows
-      && ((this._options.frozenBottom && row > this.actualFrozenRow) // Frozen bottom rows
-        || (row <= this.actualFrozenRow)                     // Frozen top rows
-      )
-    ) {
+    if (this._viewportMgr.isRowCellCleanupExempt(row)) {
       return;
     }
 
@@ -6655,7 +6714,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       const i = +cellNodeIdx;
 
       // Ignore frozen columns
-      if (i <= this._options.frozenColumn!) {
+      if (this._viewportMgr.isColumnInFrozenBand(i)) {
         return;
       }
 
@@ -6972,32 +7031,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number} row - grid row number
    */
   getFrozenRowOffset(row: number) {
-    // let offset = ( hasFrozenRows ) ? ( this._options.frozenBottom ) ? ( row >= actualFrozenRow ) ? ( h < viewportTopH ) ? ( actualFrozenRow * this._options.rowHeight ) : h : 0 : ( row >= actualFrozenRow ) ? frozenRowsHeight : 0 : 0; // WTF?
-    let offset = 0;
-    if (this.hasFrozenRows) {
-      if (this._options.frozenBottom) {
-        if (row >= this.actualFrozenRow) {
-          if (this.h < this.viewportTopH) {
-            offset = (this.actualFrozenRow * this._options.rowHeight!);
-          } else {
-            offset = this.h;
-          }
-        } else {
-          offset = 0;
-        }
-      }
-      else {
-        if (row >= this.actualFrozenRow) {
-          offset = this.frozenRowsHeight;
-        } else {
-          offset = 0;
-        }
-      }
-    } else {
-      offset = 0;
-    }
-
-    return offset;
+    return this._viewportMgr.frozenRowOffset(row, {
+      h: this.h,
+      viewportTopH: this.viewportTopH,
+      frozenRowsHeight: this.frozenRowsHeight,
+      rowHeight: this._options.rowHeight!,
+    });
   }
 
   ////////////////////////////////////////////////////////

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -170,6 +170,25 @@ interface CanvasWidthsGeometry {
   preHeaderPanelWidth?: number | string;
 }
 
+/** Geometry inputs for ViewportMgr.applyPaneHeights — computed by the grid, distributed by the manager. */
+interface PaneHeightsGeometry {
+  viewportH: number;
+  frozenRowsHeight: number;
+  scrollbarHeight: number;
+  topPanelH: number;
+  headerRowH: number;
+  footerRowH: number;
+  /** lazily computed to avoid an unconditional style recalc; only read on the autoHeight+frozen path */
+  getContainerVBoxDelta: () => number;
+  autoHeight?: boolean;
+  showPreHeaderPanel?: boolean;
+  preHeaderPanelHeight?: number;
+  showTopHeaderPanel?: boolean;
+  topHeaderPanelHeight?: number;
+  showHeaderRow?: boolean;
+  headerRowHeight?: number;
+}
+
 /** Options consumed by ViewportMgr when constructing the pane/viewport/canvas DOM. */
 interface ViewportMgrBuildOptions {
   createPreHeaderPanel?: boolean;
@@ -192,6 +211,9 @@ interface ViewportMgrBuildOptions {
  * selection, geometry distribution and scroll synchronization in here.
  */
 class ViewportMgr {
+  /** the grid container, captured by buildPanes */
+  protected container!: HTMLElement;
+
   // panes
   paneHeaderL!: HTMLDivElement;
   paneHeaderR!: HTMLDivElement;
@@ -262,6 +284,8 @@ class ViewportMgr {
    * inline construction in SlickGrid.initialize().
    */
   buildPanes(container: HTMLElement, o: ViewportMgrBuildOptions) {
+    this.container = container;
+
     // Containers used for scrolling frozen columns and rows
     this.paneHeaderL = Utils.createDomElement('div', { className: 'slick-pane slick-pane-header slick-pane-left', tabIndex: 0 }, container);
     this.paneHeaderR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-header slick-pane-right', tabIndex: 0 }, container);
@@ -574,6 +598,115 @@ class ViewportMgr {
       Utils.width(this.footerRowSpacerL, g.canvasWidth + (g.viewportHasVScroll ? g.scrollbarWidth : 0));
       Utils.width(this.footerRowSpacerR, g.canvasWidth + (g.viewportHasVScroll ? g.scrollbarWidth : 0));
     }
+  }
+
+  /**
+   * Computes the pane/viewport heights from the freeze configuration and distributes them
+   * onto the pane, viewport and canvas elements. Transcribed from the historical middle
+   * section of SlickGrid.resizeCanvas(); returns the computed heights for the grid to keep.
+   */
+  applyPaneHeights(g: PaneHeightsGeometry): { paneTopH: number; paneBottomH: number; viewportTopH: number; viewportBottomH: number; } {
+    let paneTopH = 0;
+    let paneBottomH = 0;
+    let viewportTopH = 0;
+    const viewportBottomH = 0;
+
+    // Account for Frozen Rows
+    if (this.freeze.hasFrozenRows) {
+      if (this.freeze.frozenBottom) {
+        paneTopH = g.viewportH - g.frozenRowsHeight - g.scrollbarHeight;
+        paneBottomH = g.frozenRowsHeight + g.scrollbarHeight;
+      } else {
+        paneTopH = g.frozenRowsHeight;
+        paneBottomH = g.viewportH - g.frozenRowsHeight;
+      }
+    } else {
+      paneTopH = g.viewportH;
+    }
+
+    // The top pane includes the top panel and the header row
+    paneTopH += g.topPanelH + g.headerRowH + g.footerRowH;
+
+    if (this.hasFrozenColumns() && g.autoHeight) {
+      paneTopH += g.scrollbarHeight;
+    }
+
+    // The top viewport does not contain the top panel or header row
+    viewportTopH = paneTopH - g.topPanelH - g.headerRowH - g.footerRowH;
+
+    if (g.autoHeight) {
+      if (this.hasFrozenColumns()) {
+        let fullHeight = paneTopH + this.headerScrollerL.offsetHeight;
+        fullHeight += g.getContainerVBoxDelta();
+        if (g.showPreHeaderPanel) {
+          fullHeight += g.preHeaderPanelHeight!;
+        }
+        Utils.height(this.container, fullHeight);
+      }
+
+      this.paneTopL.style.position = 'relative';
+    }
+
+    let topHeightOffset = Utils.height(this.paneHeaderL);
+    if (topHeightOffset) {
+      topHeightOffset += (g.showTopHeaderPanel ? g.topHeaderPanelHeight! : 0);
+    } else {
+      topHeightOffset = (g.showHeaderRow ? g.headerRowHeight! : 0) + (g.showPreHeaderPanel ? g.preHeaderPanelHeight! : 0);
+    }
+    Utils.setStyleSize(this.paneTopL, 'top', topHeightOffset || topHeightOffset);
+    Utils.height(this.paneTopL, paneTopH);
+
+    const paneBottomTop = this.paneTopL.offsetTop + paneTopH;
+
+    if (!g.autoHeight) {
+      Utils.height(this.viewportTopL, viewportTopH);
+    }
+
+    if (this.hasFrozenColumns()) {
+      let topHeightOffset = Utils.height(this.paneHeaderL);
+      if (topHeightOffset) {
+        topHeightOffset += (g.showTopHeaderPanel ? g.topHeaderPanelHeight! : 0);
+      }
+      Utils.setStyleSize(this.paneTopR, 'top', topHeightOffset as number);
+      Utils.height(this.paneTopR, paneTopH);
+      Utils.height(this.viewportTopR, viewportTopH);
+
+      if (this.freeze.hasFrozenRows) {
+        Utils.setStyleSize(this.paneBottomL, 'top', paneBottomTop);
+        Utils.height(this.paneBottomL, paneBottomH);
+        Utils.setStyleSize(this.paneBottomR, 'top', paneBottomTop);
+        Utils.height(this.paneBottomR, paneBottomH);
+        Utils.height(this.viewportBottomR, paneBottomH);
+      }
+    } else {
+      if (this.freeze.hasFrozenRows) {
+        Utils.width(this.paneBottomL, '100%');
+        Utils.height(this.paneBottomL, paneBottomH);
+        Utils.setStyleSize(this.paneBottomL, 'top', paneBottomTop);
+      }
+    }
+
+    if (this.freeze.hasFrozenRows) {
+      Utils.height(this.viewportBottomL, paneBottomH);
+
+      if (this.freeze.frozenBottom) {
+        Utils.height(this.canvasBottomL, g.frozenRowsHeight);
+
+        if (this.hasFrozenColumns()) {
+          Utils.height(this.canvasBottomR, g.frozenRowsHeight);
+        }
+      } else {
+        Utils.height(this.canvasTopL, g.frozenRowsHeight);
+
+        if (this.hasFrozenColumns()) {
+          Utils.height(this.canvasTopR, g.frozenRowsHeight);
+        }
+      }
+    } else {
+      Utils.height(this.viewportTopR, viewportTopH);
+    }
+
+    return { paneTopH, paneBottomH, viewportTopH, viewportBottomH };
   }
 
   selectScrollContainers(): { x: HTMLDivElement; y: HTMLDivElement; header: HTMLDivElement; headerRow: HTMLDivElement; footerRow: HTMLDivElement; } {
@@ -6160,108 +6293,32 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    */
   resizeCanvas() {
     if (!this.initialized) { return; }
-    this.paneTopH = 0;
-    this.paneBottomH = 0;
-    this.viewportTopH = 0;
-    this.viewportBottomH = 0;
 
     this.getViewportWidth();
     this.getViewportHeight();
 
-    // Account for Frozen Rows
-    if (this.hasFrozenRows) {
-      if (this._options.frozenBottom) {
-        this.paneTopH = this.viewportH - this.frozenRowsHeight - (this.scrollbarDimensions?.height ?? 0);
-        this.paneBottomH = this.frozenRowsHeight + (this.scrollbarDimensions?.height ?? 0);
-      } else {
-        this.paneTopH = this.frozenRowsHeight;
-        this.paneBottomH = this.viewportH - this.frozenRowsHeight;
-      }
-    } else {
-      this.paneTopH = this.viewportH;
-    }
-
-    // The top pane includes the top panel and the header row
-    this.paneTopH += this.topPanelH + this.headerRowH + this.footerRowH;
-
-    if (this.hasFrozenColumns() && this._options.autoHeight) {
-      this.paneTopH += (this.scrollbarDimensions?.height ?? 0);
-    }
-
-    // The top viewport does not contain the top panel or header row
-    this.viewportTopH = this.paneTopH - this.topPanelH - this.headerRowH - this.footerRowH;
-
-    if (this._options.autoHeight) {
-      if (this.hasFrozenColumns()) {
-        let fullHeight = this.paneTopH + this._headerScrollerL.offsetHeight;
-        fullHeight += this.getVBoxDelta(this._container);
-        if (this._options.showPreHeaderPanel) {
-          fullHeight += this._options.preHeaderPanelHeight!;
-        }
-        Utils.height(this._container, fullHeight);
-      }
-
-      this._paneTopL.style.position = 'relative';
-    }
-
-    let topHeightOffset = Utils.height(this._paneHeaderL);
-    if (topHeightOffset) {
-      topHeightOffset += (this._options.showTopHeaderPanel ? this._options.topHeaderPanelHeight! : 0);
-    } else {
-      topHeightOffset = (this._options.showHeaderRow ? this._options.headerRowHeight! : 0) + (this._options.showPreHeaderPanel ? this._options.preHeaderPanelHeight! : 0);
-    }
-    Utils.setStyleSize(this._paneTopL, 'top', topHeightOffset || topHeightOffset);
-    Utils.height(this._paneTopL, this.paneTopH);
-
-    const paneBottomTop = this._paneTopL.offsetTop + this.paneTopH;
-
-    if (!this._options.autoHeight) {
-      Utils.height(this._viewportTopL, this.viewportTopH);
-    }
-
-    if (this.hasFrozenColumns()) {
-      let topHeightOffset = Utils.height(this._paneHeaderL);
-      if (topHeightOffset) {
-        topHeightOffset += (this._options.showTopHeaderPanel ? this._options.topHeaderPanelHeight! : 0);
-      }
-      Utils.setStyleSize(this._paneTopR, 'top', topHeightOffset as number);
-      Utils.height(this._paneTopR, this.paneTopH);
-      Utils.height(this._viewportTopR, this.viewportTopH);
-
-      if (this.hasFrozenRows) {
-        Utils.setStyleSize(this._paneBottomL, 'top', paneBottomTop);
-        Utils.height(this._paneBottomL, this.paneBottomH);
-        Utils.setStyleSize(this._paneBottomR, 'top', paneBottomTop);
-        Utils.height(this._paneBottomR, this.paneBottomH);
-        Utils.height(this._viewportBottomR, this.paneBottomH);
-      }
-    } else {
-      if (this.hasFrozenRows) {
-        Utils.width(this._paneBottomL, '100%');
-        Utils.height(this._paneBottomL, this.paneBottomH);
-        Utils.setStyleSize(this._paneBottomL, 'top', paneBottomTop);
-      }
-    }
-
-    if (this.hasFrozenRows) {
-      Utils.height(this._viewportBottomL, this.paneBottomH);
-
-      if (this._options.frozenBottom) {
-        Utils.height(this._canvasBottomL, this.frozenRowsHeight);
-
-        if (this.hasFrozenColumns()) {
-          Utils.height(this._canvasBottomR, this.frozenRowsHeight);
-        }
-      } else {
-        Utils.height(this._canvasTopL, this.frozenRowsHeight);
-
-        if (this.hasFrozenColumns()) {
-          Utils.height(this._canvasTopR, this.frozenRowsHeight);
-        }
-      }
-    } else {
-      Utils.height(this._viewportTopR, this.viewportTopH);
-    }
+    // compute and distribute the pane/viewport/canvas heights, keeping the results
+    // on the grid for the rest of the layout pipeline
+    const heights = this._viewportMgr.applyPaneHeights({
+      viewportH: this.viewportH,
+      frozenRowsHeight: this.frozenRowsHeight,
+      scrollbarHeight: this.scrollbarDimensions?.height ?? 0,
+      topPanelH: this.topPanelH,
+      headerRowH: this.headerRowH,
+      footerRowH: this.footerRowH,
+      getContainerVBoxDelta: () => this.getVBoxDelta(this._container),
+      autoHeight: this._options.autoHeight,
+      showPreHeaderPanel: this._options.showPreHeaderPanel,
+      preHeaderPanelHeight: this._options.preHeaderPanelHeight,
+      showTopHeaderPanel: this._options.showTopHeaderPanel,
+      topHeaderPanelHeight: this._options.topHeaderPanelHeight,
+      showHeaderRow: this._options.showHeaderRow,
+      headerRowHeight: this._options.headerRowHeight,
+    });
+    this.paneTopH = heights.paneTopH;
+    this.paneBottomH = heights.paneBottomH;
+    this.viewportTopH = heights.viewportTopH;
+    this.viewportBottomH = heights.viewportBottomH;
 
     if (!this.scrollbarDimensions || !this.scrollbarDimensions.width) {
       this.scrollbarDimensions = this.measureScrollbar();

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -199,6 +199,9 @@ interface ViewportMgrBuildOptions {
   showTopPanel?: boolean;
   showHeaderRow?: boolean;
   viewportClass?: string;
+  lazyPanes?: boolean;
+  frozenColumn?: number;
+  frozenRow?: number;
 }
 
 /**
@@ -213,6 +216,12 @@ interface ViewportMgrBuildOptions {
 class ViewportMgr {
   /** the grid container, captured by buildPanes */
   protected container!: HTMLElement;
+
+  /**
+   * True when the grid opted into lazyPanes AND no rows/columns were frozen at build
+   * time — only the top-left pane set exists until freezing is enabled.
+   */
+  protected lazy = false;
 
   // panes
   paneHeaderL!: HTMLDivElement;
@@ -285,14 +294,22 @@ class ViewportMgr {
    */
   buildPanes(container: HTMLElement, o: ViewportMgrBuildOptions) {
     this.container = container;
+    this.lazy = !!o.lazyPanes && !(((o.frozenColumn ?? -1) > -1) || ((o.frozenRow ?? -1) > -1));
 
-    // Containers used for scrolling frozen columns and rows
+    // Containers used for scrolling frozen columns and rows.
+    // Under lazyPanes with nothing frozen, only the top-left pane set is built;
+    // the creation ORDER of the conditional elements must stay canonical so both
+    // modes produce the same sibling sequence for whatever exists.
     this.paneHeaderL = Utils.createDomElement('div', { className: 'slick-pane slick-pane-header slick-pane-left', tabIndex: 0 }, container);
-    this.paneHeaderR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-header slick-pane-right', tabIndex: 0 }, container);
+    if (!this.lazy) {
+      this.paneHeaderR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-header slick-pane-right', tabIndex: 0 }, container);
+    }
     this.paneTopL = Utils.createDomElement('div', { className: 'slick-pane slick-pane-top slick-pane-left', tabIndex: 0 }, container);
-    this.paneTopR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-top slick-pane-right', tabIndex: 0 }, container);
-    this.paneBottomL = Utils.createDomElement('div', { className: 'slick-pane slick-pane-bottom slick-pane-left', tabIndex: 0 }, container);
-    this.paneBottomR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-bottom slick-pane-right', tabIndex: 0 }, container);
+    if (!this.lazy) {
+      this.paneTopR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-top slick-pane-right', tabIndex: 0 }, container);
+      this.paneBottomL = Utils.createDomElement('div', { className: 'slick-pane slick-pane-bottom slick-pane-left', tabIndex: 0 }, container);
+      this.paneBottomR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-bottom slick-pane-right', tabIndex: 0 }, container);
+    }
 
     if (o.createPreHeaderPanel) {
       this.preHeaderPanelScroller = Utils.createDomElement('div', { className: 'slick-preheader-panel ui-state-default slick-state-default', style: { overflow: 'hidden', position: 'relative' } }, this.paneHeaderL);
@@ -300,55 +317,73 @@ class ViewportMgr {
       this.preHeaderPanel = Utils.createDomElement('div', null, this.preHeaderPanelScroller);
       this.preHeaderPanelSpacer = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.preHeaderPanelScroller);
 
-      this.preHeaderPanelScrollerR = Utils.createDomElement('div', { className: 'slick-preheader-panel ui-state-default slick-state-default', style: { overflow: 'hidden', position: 'relative' } }, this.paneHeaderR);
-      this.preHeaderPanelR = Utils.createDomElement('div', null, this.preHeaderPanelScrollerR);
-      this.preHeaderPanelSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.preHeaderPanelScrollerR);
+      if (!this.lazy) {
+        this.preHeaderPanelScrollerR = Utils.createDomElement('div', { className: 'slick-preheader-panel ui-state-default slick-state-default', style: { overflow: 'hidden', position: 'relative' } }, this.paneHeaderR);
+        this.preHeaderPanelR = Utils.createDomElement('div', null, this.preHeaderPanelScrollerR);
+        this.preHeaderPanelSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.preHeaderPanelScrollerR);
+      }
 
       if (!o.showPreHeaderPanel) {
         Utils.hide(this.preHeaderPanelScroller);
-        Utils.hide(this.preHeaderPanelScrollerR);
+        this.hideIf(this.preHeaderPanelScrollerR);
       }
     }
 
     // Append the header scroller containers
     this.headerScrollerL = Utils.createDomElement('div', { className: 'slick-header ui-state-default slick-state-default slick-header-left' }, this.paneHeaderL);
-    this.headerScrollerR = Utils.createDomElement('div', { className: 'slick-header ui-state-default slick-state-default slick-header-right' }, this.paneHeaderR);
+    if (!this.lazy) {
+      this.headerScrollerR = Utils.createDomElement('div', { className: 'slick-header ui-state-default slick-state-default slick-header-right' }, this.paneHeaderR);
+    }
 
     // Cache the header scroller containers
     this.headerScroller.push(this.headerScrollerL);
-    this.headerScroller.push(this.headerScrollerR);
+    if (!this.lazy) {
+      this.headerScroller.push(this.headerScrollerR);
+    }
 
     // Append the columnn containers to the headers
     this.headerL = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-left', role: 'row', style: { left: '-1000px' } }, this.headerScrollerL);
-    this.headerR = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-right', role: 'row', style: { left: '-1000px' } }, this.headerScrollerR);
+    if (!this.lazy) {
+      this.headerR = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-right', role: 'row', style: { left: '-1000px' } }, this.headerScrollerR);
+    }
 
     // Cache the header columns
-    this.headers = [this.headerL, this.headerR];
+    this.headers = this.lazy ? [this.headerL] : [this.headerL, this.headerR];
 
     this.headerRowScrollerL = Utils.createDomElement('div', { className: 'slick-headerrow ui-state-default slick-state-default' }, this.paneTopL);
-    this.headerRowScrollerR = Utils.createDomElement('div', { className: 'slick-headerrow ui-state-default slick-state-default' }, this.paneTopR);
+    if (!this.lazy) {
+      this.headerRowScrollerR = Utils.createDomElement('div', { className: 'slick-headerrow ui-state-default slick-state-default' }, this.paneTopR);
+    }
 
-    this.headerRowScroller = [this.headerRowScrollerL, this.headerRowScrollerR];
+    this.headerRowScroller = this.lazy ? [this.headerRowScrollerL] : [this.headerRowScrollerL, this.headerRowScrollerR];
 
     this.headerRowSpacerL = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.headerRowScrollerL);
-    this.headerRowSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.headerRowScrollerR);
+    if (!this.lazy) {
+      this.headerRowSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.headerRowScrollerR);
+    }
 
     this.headerRowL = Utils.createDomElement('div', { className: 'slick-headerrow-columns slick-headerrow-columns-left' }, this.headerRowScrollerL);
-    this.headerRowR = Utils.createDomElement('div', { className: 'slick-headerrow-columns slick-headerrow-columns-right' }, this.headerRowScrollerR);
+    if (!this.lazy) {
+      this.headerRowR = Utils.createDomElement('div', { className: 'slick-headerrow-columns slick-headerrow-columns-right' }, this.headerRowScrollerR);
+    }
 
-    this.headerRows = [this.headerRowL, this.headerRowR];
+    this.headerRows = this.lazy ? [this.headerRowL] : [this.headerRowL, this.headerRowR];
 
     // Append the top panel scroller
     this.topPanelScrollerL = Utils.createDomElement('div', { className: 'slick-top-panel-scroller ui-state-default slick-state-default' }, this.paneTopL);
-    this.topPanelScrollerR = Utils.createDomElement('div', { className: 'slick-top-panel-scroller ui-state-default slick-state-default' }, this.paneTopR);
+    if (!this.lazy) {
+      this.topPanelScrollerR = Utils.createDomElement('div', { className: 'slick-top-panel-scroller ui-state-default slick-state-default' }, this.paneTopR);
+    }
 
-    this.topPanelScrollers = [this.topPanelScrollerL, this.topPanelScrollerR];
+    this.topPanelScrollers = this.lazy ? [this.topPanelScrollerL] : [this.topPanelScrollerL, this.topPanelScrollerR];
 
     // Append the top panel
     this.topPanelL = Utils.createDomElement('div', { className: 'slick-top-panel', style: { width: '10000px' } }, this.topPanelScrollerL);
-    this.topPanelR = Utils.createDomElement('div', { className: 'slick-top-panel', style: { width: '10000px' } }, this.topPanelScrollerR);
+    if (!this.lazy) {
+      this.topPanelR = Utils.createDomElement('div', { className: 'slick-top-panel', style: { width: '10000px' } }, this.topPanelScrollerR);
+    }
 
-    this.topPanels = [this.topPanelL, this.topPanelR];
+    this.topPanels = this.lazy ? [this.topPanelL] : [this.topPanelL, this.topPanelR];
 
     if (!o.showColumnHeader) {
       this.headerScroller.forEach((el) => {
@@ -370,12 +405,16 @@ class ViewportMgr {
 
     // Append the viewport containers
     this.viewportTopL = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-top slick-viewport-left', tabIndex: 0 }, this.paneTopL);
-    this.viewportTopR = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-top slick-viewport-right', tabIndex: 0 }, this.paneTopR);
-    this.viewportBottomL = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-bottom slick-viewport-left', tabIndex: 0 }, this.paneBottomL);
-    this.viewportBottomR = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-bottom slick-viewport-right', tabIndex: 0 }, this.paneBottomR);
+    if (!this.lazy) {
+      this.viewportTopR = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-top slick-viewport-right', tabIndex: 0 }, this.paneTopR);
+      this.viewportBottomL = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-bottom slick-viewport-left', tabIndex: 0 }, this.paneBottomL);
+      this.viewportBottomR = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-bottom slick-viewport-right', tabIndex: 0 }, this.paneBottomR);
+    }
 
     // Cache the viewports
-    this.viewport = [this.viewportTopL, this.viewportTopR, this.viewportBottomL, this.viewportBottomR];
+    this.viewport = this.lazy
+      ? [this.viewportTopL]
+      : [this.viewportTopL, this.viewportTopR, this.viewportBottomL, this.viewportBottomR];
     if (o.viewportClass) {
       this.viewport.forEach((view) => {
         view.classList.add(...Utils.classNameToList((o.viewportClass)));
@@ -384,12 +423,16 @@ class ViewportMgr {
 
     // Append the canvas containers
     this.canvasTopL = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-top grid-canvas-left', tabIndex: 0 }, this.viewportTopL);
-    this.canvasTopR = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-top grid-canvas-right', tabIndex: 0 }, this.viewportTopR);
-    this.canvasBottomL = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-bottom grid-canvas-left', tabIndex: 0 }, this.viewportBottomL);
-    this.canvasBottomR = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-bottom grid-canvas-right', tabIndex: 0 }, this.viewportBottomR);
+    if (!this.lazy) {
+      this.canvasTopR = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-top grid-canvas-right', tabIndex: 0 }, this.viewportTopR);
+      this.canvasBottomL = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-bottom grid-canvas-left', tabIndex: 0 }, this.viewportBottomL);
+      this.canvasBottomR = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-bottom grid-canvas-right', tabIndex: 0 }, this.viewportBottomR);
+    }
 
     // Cache the canvases
-    this.canvas = [this.canvasTopL, this.canvasTopR, this.canvasBottomL, this.canvasBottomR];
+    this.canvas = this.lazy
+      ? [this.canvasTopL]
+      : [this.canvasTopL, this.canvasTopR, this.canvasBottomL, this.canvasBottomR];
   }
 
   /**
@@ -398,20 +441,26 @@ class ViewportMgr {
    * scroller creation order and spacer widths.
    */
   buildFooterRows(o: ViewportMgrBuildOptions, canvasWithScrollbarWidth: number) {
-    this.footerRowScrollerR = Utils.createDomElement('div', { className: 'slick-footerrow ui-state-default slick-state-default' }, this.paneTopR);
+    if (!this.lazy) {
+      this.footerRowScrollerR = Utils.createDomElement('div', { className: 'slick-footerrow ui-state-default slick-state-default' }, this.paneTopR);
+    }
     this.footerRowScrollerL = Utils.createDomElement('div', { className: 'slick-footerrow ui-state-default slick-state-default' }, this.paneTopL);
 
-    this.footerRowScroller = [this.footerRowScrollerL, this.footerRowScrollerR];
+    this.footerRowScroller = this.lazy ? [this.footerRowScrollerL] : [this.footerRowScrollerL, this.footerRowScrollerR];
 
     this.footerRowSpacerL = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.footerRowScrollerL);
     Utils.width(this.footerRowSpacerL, canvasWithScrollbarWidth);
-    this.footerRowSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.footerRowScrollerR);
-    Utils.width(this.footerRowSpacerR, canvasWithScrollbarWidth);
+    if (!this.lazy) {
+      this.footerRowSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.footerRowScrollerR);
+      Utils.width(this.footerRowSpacerR, canvasWithScrollbarWidth);
+    }
 
     this.footerRowL = Utils.createDomElement('div', { className: 'slick-footerrow-columns slick-footerrow-columns-left' }, this.footerRowScrollerL);
-    this.footerRowR = Utils.createDomElement('div', { className: 'slick-footerrow-columns slick-footerrow-columns-right' }, this.footerRowScrollerR);
+    if (!this.lazy) {
+      this.footerRowR = Utils.createDomElement('div', { className: 'slick-footerrow-columns slick-footerrow-columns-right' }, this.footerRowScrollerR);
+    }
 
-    this.footerRow = [this.footerRowL, this.footerRowR];
+    this.footerRow = this.lazy ? [this.footerRowL] : [this.footerRowL, this.footerRowR];
 
     if (!o.showFooterRow) {
       this.footerRowScroller.forEach((scroller) => {
@@ -2742,9 +2791,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @returns {HTMLElement[]} - An array of header column elements.
    */
   protected getHeaderChildren() {
-    const a = Array.from(this._headers[0].children);
-    const b = Array.from(this._headers[1].children);
-    return a.concat(b) as HTMLElement[];
+    // _headers only contains the header containers that were actually built
+    // (a single left container under lazyPanes)
+    return this._headers.flatMap((headerEl) => Array.from(headerEl.children)) as HTMLElement[];
   }
 
   /**

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -436,6 +436,20 @@ class ViewportMgr {
     return this.freeze.frozenColumnIdx > -1;
   }
 
+  /** Returns a boolean indicating whether the grid is configured with frozen rows. */
+  hasFrozenRows() {
+    return this.freeze.hasFrozenRows;
+  }
+
+  /**
+   * The left canvas of the scrollable body band: bottom-left while rows are frozen at
+   * the top, top-left otherwise (historical selector used by updateRowCount and
+   * bindAncestorScrollEvents).
+   */
+  bodyCanvasL(): HTMLDivElement {
+    return (this.freeze.hasFrozenRows && !this.freeze.frozenBottom) ? this.canvasBottomL : this.canvasTopL;
+  }
+
   /**
    * Index of the pane owning cell (colIdx, rowIdx) in the 4-slot
    * [TopL, TopR, BottomL, BottomR] element arrays.
@@ -2307,8 +2321,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         const m = this.columns[i];
         if (!m || m.hidden) { continue; }
 
-        const footerRowCell = Utils.createDomElement('div', { className: `ui-state-default slick-state-default slick-footerrow-column l${i} r${i}` }, this.hasFrozenColumns() && (i > this._options.frozenColumn!) ? this._footerRowR : this._footerRowL);
-        const className = this.hasFrozenColumns() && i <= this._options.frozenColumn! ? 'frozen' : null;
+        const footerRowCell = Utils.createDomElement('div', { className: `ui-state-default slick-state-default slick-footerrow-column l${i} r${i}` }, this._viewportMgr.sideForColumn(i, this._footerRowL, this._footerRowR));
+        const className = this._viewportMgr.isColumnInFrozenBand(i) ? 'frozen' : null;
         if (className) {
           footerRowCell.classList.add(className);
         }
@@ -2489,7 +2503,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       });
       Utils.emptyElement(this._footerRowL);
 
-      if (this.hasFrozenColumns()) {
+      if (this._viewportMgr.hasFrozenColumns()) {
         const footerRowRColumnElements = this._footerRowR.querySelectorAll('.slick-footerrow-column');
         footerRowRColumnElements.forEach((column) => {
           const columnDef = Utils.storage.get(column, 'column');
@@ -2509,8 +2523,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       const m: C = this.columns[i];
       if (m.hidden) { continue; }
 
-      const headerTarget = this.hasFrozenColumns() ? ((i <= this._options.frozenColumn!) ? this._headerL : this._headerR) : this._headerL;
-      const headerRowTarget = this.hasFrozenColumns() ? ((i <= this._options.frozenColumn!) ? this._headerRowL : this._headerRowR) : this._headerRowL;
+      const headerTarget = this._viewportMgr.sideForColumn(i, this._headerL, this._headerR);
+      const headerRowTarget = this._viewportMgr.sideForColumn(i, this._headerRowL, this._headerRowR);
 
       const header = Utils.createDomElement('div', { id: `${this.uid + m.id}`, dataset: { id: String(m.id) }, role: 'columnheader', className: 'ui-state-default slick-state-default slick-header-column' }, headerTarget);
       if (m.toolTip) {
@@ -2528,7 +2542,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (classname) {
         header.classList.add(...Utils.classNameToList(classname));
       }
-      classname = this.hasFrozenColumns() && i <= this._options.frozenColumn! ? 'frozen' : null;
+      classname = this._viewportMgr.isColumnInFrozenBand(i) ? 'frozen' : null;
       if (classname) {
         header.classList.add(classname);
       }
@@ -2567,7 +2581,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       if (this._options.showHeaderRow) {
         const headerRowCell = Utils.createDomElement('div', { className: `ui-state-default slick-state-default slick-headerrow-column l${i} r${i}` }, headerRowTarget);
-        const frozenClasses = this.hasFrozenColumns() && i <= this._options.frozenColumn! ? 'frozen' : null;
+        const frozenClasses = this._viewportMgr.isColumnInFrozenBand(i) ? 'frozen' : null;
         if (frozenClasses) {
           headerRowCell.classList.add(frozenClasses);
         }
@@ -2584,7 +2598,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         });
       }
       if (this._options.createFooterRow && this._options.showFooterRow) {
-        const footerRowTarget = this.hasFrozenColumns() ? ((i <= this._options.frozenColumn!) ? this._footerRow[0] : this._footerRow[1]) : this._footerRow[0];
+        const footerRowTarget = this._viewportMgr.sideForColumn(i, this._footerRow[0], this._footerRow[1]);
         const footerRowCell = Utils.createDomElement('div', { className: `ui-state-default slick-state-default slick-footerrow-column l${i} r${i}` }, footerRowTarget);
         Utils.storage.put(footerRowCell, 'column', m);
 
@@ -2633,7 +2647,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       dragoverBubble: false,
       preventOnFilter: false, // allow column to be resized even when they are not orderable
       revertClone: true,
-      scroll: !this.hasFrozenColumns(), // enable auto-scroll
+      scroll: !this._viewportMgr.hasFrozenColumns(), // enable auto-scroll
       // lock unorderable columns by using a combo of filter + onMove
       filter: `.${this._options.unorderableColumnCssClass}`,
       onMove: (event: MouseEvent & { related: HTMLElement; }) => {
@@ -2641,7 +2655,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       },
       onStart: (e: SortableEvent) => {
         e.item.classList.add('slick-header-column-active');
-        canDragScroll = !this.hasFrozenColumns() || Utils.offset(e.item)!.left > Utils.offset(this._viewportScrollContainerX)!.left;
+        canDragScroll = !this._viewportMgr.hasFrozenColumns() || Utils.offset(e.item)!.left > Utils.offset(this._viewportScrollContainerX)!.left;
 
         if (canDragScroll && e.originalEvent.pageX > this._container.clientWidth) {
           if (!(columnScrollTimer)) {
@@ -2874,7 +2888,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
                 c = vc[k];
                 if (!c || c.hidden) { continue; }
 
-                if (this.hasFrozenColumns() && (k > this._options.frozenColumn!)) {
+                if (this._viewportMgr.isColumnRightOfFreeze(k)) {
                   newCanvasWidthR += c.width || 0;
                 } else {
                   newCanvasWidthL += c.width || 0;
@@ -2895,7 +2909,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
                       x = 0;
                     }
 
-                    if (this.hasFrozenColumns() && (j > this._options.frozenColumn!)) {
+                    if (this._viewportMgr.isColumnRightOfFreeze(j)) {
                       newCanvasWidthR += c.width || 0;
                     } else {
                       newCanvasWidthL += c.width || 0;
@@ -2907,7 +2921,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
                   c = vc[j];
                   if (!c || c.hidden) { continue; }
 
-                  if (this.hasFrozenColumns() && (j > this._options.frozenColumn!)) {
+                  if (this._viewportMgr.isColumnRightOfFreeze(j)) {
                     newCanvasWidthR += c.width || 0;
                   } else {
                     newCanvasWidthL += c.width || 0;
@@ -2948,7 +2962,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
                     const newWidth = (c.previousWidth || 0) + x;
                     const resizedCanvasWidthL = this.canvasWidthL + x;
 
-                    if (this.hasFrozenColumns() && (j <= this._options.frozenColumn!)) {
+                    if (this._viewportMgr.isColumnInFrozenBand(j)) {
                       // if we're on the left frozen side, we need to make sure that our left section width never goes over the total viewport width
                       if (newWidth > frozenLeftColMaxWidth && resizedCanvasWidthL < (viewportWidth - this._options.frozenRightViewportMinWidth!)) {
                         frozenLeftColMaxWidth = newWidth; // keep max column width ref, if we go over the limit this number will stop increasing
@@ -2966,7 +2980,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
                 c = vc[k];
                 if (!c || c.hidden) { continue; }
 
-                if (this.hasFrozenColumns() && (k > this._options.frozenColumn!)) {
+                if (this._viewportMgr.isColumnRightOfFreeze(k)) {
                   newCanvasWidthR += c.width || 0;
                 } else {
                   newCanvasWidthL += c.width || 0;
@@ -2988,7 +3002,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
                       x = 0;
                     }
 
-                    if (this.hasFrozenColumns() && (j > this._options.frozenColumn!)) {
+                    if (this._viewportMgr.isColumnRightOfFreeze(j)) {
                       newCanvasWidthR += c.width || 0;
                     } else {
                       newCanvasWidthL += c.width || 0;
@@ -3000,7 +3014,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
                   c = vc[j];
                   if (!c || c.hidden) { continue; }
 
-                  if (this.hasFrozenColumns() && (j > this._options.frozenColumn!)) {
+                  if (this._viewportMgr.isColumnRightOfFreeze(j)) {
                     // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     newCanvasWidthR += c.width || 0;
                   } else {
@@ -3010,7 +3024,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
               }
             }
 
-            if (this.hasFrozenColumns() && newCanvasWidthL !== this.canvasWidthL) {
+            if (this._viewportMgr.hasFrozenColumns() && newCanvasWidthL !== this.canvasWidthL) {
               Utils.width(this._headerL, newCanvasWidthL + 1000);
               Utils.setStyleSize(this._paneHeaderR, 'left', newCanvasWidthL);
             }
@@ -4258,7 +4272,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       let rowOffset = Math.floor(Utils.offset(Utils.parents(this.activeCellNode, '.grid-canvas')[0] as HTMLElement)!.top);
       const isBottom = Utils.parents(this.activeCellNode, '.grid-canvas-bottom').length;
 
-      if (this.hasFrozenRows && isBottom) {
+      if (this._viewportMgr.hasFrozenRows() && isBottom) {
         rowOffset -= (this._options.frozenBottom)
           ? Utils.height(this._canvasTopL) as number
           : this.frozenRowsHeight;
@@ -5235,7 +5249,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     let row = this.getRowFromNode(cellNode.parentNode as HTMLElement);
 
-    if (this.hasFrozenRows) {
+    if (this._viewportMgr.hasFrozenRows()) {
       let rowOffset = 0;
       const c = Utils.offset(Utils.parents(cellNode, '.grid-canvas')[0] as HTMLElement);
       const isBottom = Utils.parents(cellNode, '.grid-canvas-bottom').length;
@@ -5556,7 +5570,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     // recompute the header width split only when the pane widths will be redistributed
     // (preserves the historical conditional side effect on headersWidthL/R)
-    if (widthChanged || this.hasFrozenColumns() || this.hasFrozenRows) {
+    if (widthChanged || this._viewportMgr.hasFrozenColumns() || this._viewportMgr.hasFrozenRows()) {
       this.getHeadersWidth();
     }
 
@@ -5902,7 +5916,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const d = this.getDataItem(row);
     const dataLoading = row < dataLength && !d;
     let rowCss = 'slick-row' +
-      (this.hasFrozenRows && row <= this._options.frozenRow! ? ' frozen' : '') +
+      (this._viewportMgr.hasFrozenRows() && row <= this._options.frozenRow! ? ' frozen' : '') +
       (dataLoading ? ' loading' : '') +
       (row === this.activeRow && this._options.showCellSelection ? ' active' : '') +
       (row % 2 === 1 ? ' odd' : ' even');
@@ -6489,9 +6503,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this._prevDataLength = dataLength;
     const dataLengthIncludingAddNew = this.getDataLengthIncludingAddNew();
     let numberOfRows = 0;
-    let oldH = ((this.hasFrozenRows && !this._options.frozenBottom) ? Utils.height(this._canvasBottomL) : Utils.height(this._canvasTopL)) as number;
+    let oldH = Utils.height(this._viewportMgr.bodyCanvasL()) as number;
 
-    if (this.hasFrozenRows) {
+    if (this._viewportMgr.hasFrozenRows()) {
       numberOfRows = this.getDataLength() - this._options.frozenRow!;
     } else {
       numberOfRows = dataLengthIncludingAddNew + (this._options.leaveSpaceForNewRows ? this.numVisibleRows - 1 : 0);
@@ -6544,10 +6558,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     if (this.h !== oldH || this.enforceFrozenRowHeightRecalc) {
-      if (this.hasFrozenRows && !this._options.frozenBottom) {
+      if (this._viewportMgr.hasFrozenRows() && !this._options.frozenBottom) {
         Utils.height(this._canvasBottomL, this.h);
 
-        if (this.hasFrozenColumns()) {
+        if (this._viewportMgr.hasFrozenColumns()) {
           Utils.height(this._canvasBottomR, this.h);
         }
       } else {
@@ -6874,7 +6888,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const renderingRows = new Set<number>();
 
     for (let i = range.top as number, ii = range.bottom as number; i <= ii; i++) {
-      if (this.rowsCache[i] || (this.hasFrozenRows && this._options.frozenBottom && i === this.getDataLength())) {
+      if (this.rowsCache[i] || (this._viewportMgr.hasFrozenRows() && this._options.frozenBottom && i === this.getDataLength())) {
         continue;
       }
       this.renderedRows++;
@@ -6973,7 +6987,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     // add new rows & missing cells in existing rows
     if (this.lastRenderedScrollLeft !== this.scrollLeft) {
-      if (this.hasFrozenRows) {
+      if (this._viewportMgr.hasFrozenRows()) {
         const renderedFrozenRows = Utils.extend(true, {}, rendered);
 
         if (this._options.frozenBottom) {
@@ -6992,7 +7006,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.renderRows(rendered);
 
     // Render frozen rows
-    if (this.hasFrozenRows) {
+    if (this._viewportMgr.hasFrozenRows()) {
       if (this._options.frozenBottom) {
         this.renderRows({
           top: this.actualFrozenRow, bottom: this.getDataLength() - 1, leftPx: rendered.leftPx, rightPx: rendered.rightPx
@@ -7046,7 +7060,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Also stores these ancestors for later unbinding.
    */
   protected bindAncestorScrollEvents() {
-    let elem: HTMLElement | null = (this.hasFrozenRows && !this._options.frozenBottom) ? this._canvasBottomL : this._canvasTopL;
+    let elem: HTMLElement | null = this._viewportMgr.bodyCanvasL();
     while ((elem = elem!.parentNode as HTMLElement) !== document.body && elem) {
       // bind to scroll containers only
       if (elem === this._viewportTopL || elem.scrollWidth !== elem.clientWidth || elem.scrollHeight !== elem.clientHeight) {
@@ -7090,7 +7104,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    */
   scrollTo(y: number) {
     y = Math.max(y, 0);
-    y = Math.min(y, (this.th || 0) - (Utils.height(this._viewportScrollContainerY) as number) + ((this.viewportHasHScroll || this.hasFrozenColumns()) ? (this.scrollbarDimensions?.height ?? 0) : 0));
+    y = Math.min(y, (this.th || 0) - (Utils.height(this._viewportScrollContainerY) as number) + ((this.viewportHasHScroll || this._viewportMgr.hasFrozenColumns()) ? (this.scrollbarDimensions?.height ?? 0) : 0));
 
     const oldOffset = this.offset;
     this.offset = Math.round(this.page * (this.cj || 0));
@@ -7107,11 +7121,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.vScrollDir = (this.prevScrollTop + oldOffset < newScrollTop + this.offset) ? 1 : -1;
       this.lastRenderedScrollTop = (this.scrollTop = this.prevScrollTop = newScrollTop);
 
-      if (this.hasFrozenColumns()) {
+      if (this._viewportMgr.hasFrozenColumns()) {
         this._viewportTopL.scrollTop = newScrollTop;
       }
 
-      if (this.hasFrozenRows) {
+      if (this._viewportMgr.hasFrozenRows()) {
         this._viewportBottomL.scrollTop = this._viewportBottomR.scrollTop = newScrollTop;
       }
 
@@ -7502,7 +7516,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Boolean} doPaging - scroll when pagination is enabled
    */
   scrollRowIntoView(row: number, doPaging?: boolean) {
-    if (!this.hasFrozenRows ||
+    if (!this._viewportMgr.hasFrozenRows() ||
       (!this._options.frozenBottom && row > this.actualFrozenRow - 1) ||
       (this._options.frozenBottom && row < this.actualFrozenRow - 1)) {
 
@@ -7510,7 +7524,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       // if frozen row on top
       // subtract number of frozen row
-      const rowNumber = (this.hasFrozenRows && !this._options.frozenBottom ? row - this._options.frozenRow! : row);
+      const rowNumber = (this._viewportMgr.hasFrozenRows() && !this._options.frozenBottom ? row - this._options.frozenRow! : row);
 
       const rowAtTop = rowNumber * this._options.rowHeight!;
       const rowAtBottom = (rowNumber + 1) * this._options.rowHeight!
@@ -9097,7 +9111,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    */
   protected navigateToPos(pos: CellPosition | null) {
     if (pos) {
-      if (this.hasFrozenRows && this._options.frozenBottom && pos.row === this.getDataLength()) {
+      if (this._viewportMgr.hasFrozenRows() && this._options.frozenBottom && pos.row === this.getDataLength()) {
         return;
       }
 

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -469,6 +469,104 @@ class ViewportMgr {
     }
   }
 
+  /**
+   * Builds the right/bottom panes, chrome, viewports and canvases that a lazyPanes
+   * grid skipped at init, inserting each pane at its canonical sibling position and
+   * pushing the new elements into the shared caches IN PLACE (the grid's array
+   * aliases keep working). Idempotent: returns false when the grid is not lazy
+   * (already fully built or built non-lazy).
+   */
+  materializeSecondaryPanes(o: ViewportMgrBuildOptions): boolean {
+    if (!this.lazy) {
+      return false;
+    }
+    this.lazy = false;
+
+    const container = this.container;
+
+    // panes, at their canonical sibling positions
+    this.paneHeaderR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-header slick-pane-right', tabIndex: 0 });
+    container.insertBefore(this.paneHeaderR, this.paneTopL);
+    this.paneTopR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-top slick-pane-right', tabIndex: 0 });
+    container.insertBefore(this.paneTopR, this.paneTopL.nextSibling);
+    this.paneBottomL = Utils.createDomElement('div', { className: 'slick-pane slick-pane-bottom slick-pane-left', tabIndex: 0 });
+    container.insertBefore(this.paneBottomL, this.paneTopR.nextSibling);
+    this.paneBottomR = Utils.createDomElement('div', { className: 'slick-pane slick-pane-bottom slick-pane-right', tabIndex: 0 });
+    container.insertBefore(this.paneBottomR, this.paneBottomL.nextSibling);
+
+    if (o.createPreHeaderPanel) {
+      this.preHeaderPanelScrollerR = Utils.createDomElement('div', { className: 'slick-preheader-panel ui-state-default slick-state-default', style: { overflow: 'hidden', position: 'relative' } }, this.paneHeaderR);
+      this.preHeaderPanelR = Utils.createDomElement('div', null, this.preHeaderPanelScrollerR);
+      this.preHeaderPanelSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.preHeaderPanelScrollerR);
+
+      if (!o.showPreHeaderPanel) {
+        Utils.hide(this.preHeaderPanelScrollerR);
+      }
+    }
+
+    // header scroller + header columns
+    this.headerScrollerR = Utils.createDomElement('div', { className: 'slick-header ui-state-default slick-state-default slick-header-right' }, this.paneHeaderR);
+    this.headerScroller.push(this.headerScrollerR);
+    this.headerR = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-right', role: 'row', style: { left: '-1000px' } }, this.headerScrollerR);
+    this.headers.push(this.headerR);
+
+    // header row
+    this.headerRowScrollerR = Utils.createDomElement('div', { className: 'slick-headerrow ui-state-default slick-state-default' }, this.paneTopR);
+    this.headerRowScroller.push(this.headerRowScrollerR);
+    this.headerRowSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.headerRowScrollerR);
+    this.headerRowR = Utils.createDomElement('div', { className: 'slick-headerrow-columns slick-headerrow-columns-right' }, this.headerRowScrollerR);
+    this.headerRows.push(this.headerRowR);
+
+    // top panel
+    this.topPanelScrollerR = Utils.createDomElement('div', { className: 'slick-top-panel-scroller ui-state-default slick-state-default' }, this.paneTopR);
+    this.topPanelScrollers.push(this.topPanelScrollerR);
+    this.topPanelR = Utils.createDomElement('div', { className: 'slick-top-panel', style: { width: '10000px' } }, this.topPanelScrollerR);
+    this.topPanels.push(this.topPanelR);
+
+    if (!o.showColumnHeader) {
+      Utils.hide(this.headerScrollerR);
+    }
+    if (!o.showTopPanel) {
+      Utils.hide(this.topPanelScrollerR);
+    }
+    if (!o.showHeaderRow) {
+      Utils.hide(this.headerRowScrollerR);
+    }
+
+    // viewports (pushed in canonical [TopL, TopR, BottomL, BottomR] order)
+    this.viewportTopR = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-top slick-viewport-right', tabIndex: 0 }, this.paneTopR);
+    this.viewportBottomL = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-bottom slick-viewport-left', tabIndex: 0 }, this.paneBottomL);
+    this.viewportBottomR = Utils.createDomElement('div', { className: 'slick-viewport slick-viewport-bottom slick-viewport-right', tabIndex: 0 }, this.paneBottomR);
+    this.viewport.push(this.viewportTopR, this.viewportBottomL, this.viewportBottomR);
+    if (o.viewportClass) {
+      const viewportClassList = Utils.classNameToList(o.viewportClass);
+      this.viewportTopR.classList.add(...viewportClassList);
+      this.viewportBottomL.classList.add(...viewportClassList);
+      this.viewportBottomR.classList.add(...viewportClassList);
+    }
+
+    // canvases
+    this.canvasTopR = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-top grid-canvas-right', tabIndex: 0 }, this.viewportTopR);
+    this.canvasBottomL = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-bottom grid-canvas-left', tabIndex: 0 }, this.viewportBottomL);
+    this.canvasBottomR = Utils.createDomElement('div', { className: 'grid-canvas grid-canvas-bottom grid-canvas-right', tabIndex: 0 }, this.viewportBottomR);
+    this.canvas.push(this.canvasTopR, this.canvasBottomL, this.canvasBottomR);
+
+    // footer row (right side; the left one was built at init when createFooterRow)
+    if (o.createFooterRow) {
+      this.footerRowScrollerR = Utils.createDomElement('div', { className: 'slick-footerrow ui-state-default slick-state-default' }, this.paneTopR);
+      this.footerRowScroller.push(this.footerRowScrollerR);
+      this.footerRowSpacerR = Utils.createDomElement('div', { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } }, this.footerRowScrollerR);
+      this.footerRowR = Utils.createDomElement('div', { className: 'slick-footerrow-columns slick-footerrow-columns-right' }, this.footerRowScrollerR);
+      this.footerRow.push(this.footerRowR);
+
+      if (!o.showFooterRow) {
+        Utils.hide(this.footerRowScrollerR);
+      }
+    }
+
+    return true;
+  }
+
   //////////////////////////////////////////////////////////////////////////////////////////////
   // Freeze state and pane selection (Phase 2 of the encapsulation refactor)
   //////////////////////////////////////////////////////////////////////////////////////////////
@@ -1573,7 +1671,64 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // existing logic operates unchanged.
     this._viewportMgr = new ViewportMgr();
     this._viewportMgr.buildPanes(this._container, this._options);
+    this.syncViewportMgrAliases();
 
+    // Default the active viewport to the top left
+    this._activeViewportNode = this._viewportTopL;
+
+    this.scrollbarDimensions = this.scrollbarDimensions || this.measureScrollbar();
+    const canvasWithScrollbarWidth = this.getCanvasWidth() + this.scrollbarDimensions.width;
+
+    // Default the active canvas to the top left
+    this._activeCanvasNode = this._canvasTopL;
+
+    // top-header
+    if (this._topHeaderPanelSpacer) {
+      Utils.width(this._topHeaderPanelSpacer, canvasWithScrollbarWidth);
+    }
+
+    // pre-header
+    if (this._preHeaderPanelSpacer) {
+      Utils.width(this._preHeaderPanelSpacer, canvasWithScrollbarWidth);
+    }
+
+    this._headers.forEach((el) => {
+      Utils.width(el, this.getHeadersWidth());
+    });
+
+    Utils.width(this._headerRowSpacerL, canvasWithScrollbarWidth);
+    if (this._headerRowSpacerR) {
+      Utils.width(this._headerRowSpacerR, canvasWithScrollbarWidth);
+    }
+
+    // footer Row
+    if (this._options.createFooterRow) {
+      this._viewportMgr.buildFooterRows(this._options, canvasWithScrollbarWidth);
+      this.syncViewportMgrAliases();
+    }
+
+    this._focusSink2 = this._focusSink.cloneNode(true) as HTMLDivElement;
+    this._container.appendChild(this._focusSink2);
+
+    if (!this._options.explicitInitialization) {
+      this.finishInitialization();
+    }
+  }
+
+  /**
+   * Completes grid initialisation by calculating viewport dimensions, measuring cell padding and border differences,
+   * disabling text selection (except on editable inputs), setting frozen options and pane visibility,
+   * updating column caches, creating column headers and footers, setting up column sorting,
+   * creating CSS rules, binding ancestor scroll events, and binding various event handlers
+   * (e.g. for scrolling, mouse, keyboard, drag-and-drop).
+   * It also starts up any asynchronous post–render processing if enabled.
+   */
+  /**
+   * Copies every pane/viewport/canvas/chrome element reference from the ViewportMgr
+   * onto the grid's historical field names. Called after buildPanes, buildFooterRows
+   * and materializeSecondaryPanes; idempotent.
+   */
+  protected syncViewportMgrAliases() {
     this._paneHeaderL = this._viewportMgr.paneHeaderL;
     this._paneHeaderR = this._viewportMgr.paneHeaderR;
     this._paneTopL = this._viewportMgr.paneTopL;
@@ -1623,38 +1778,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this._canvasBottomR = this._viewportMgr.canvasBottomR;
     this._canvas = this._viewportMgr.canvas;
 
-    // Default the active viewport to the top left
-    this._activeViewportNode = this._viewportTopL;
-
-    this.scrollbarDimensions = this.scrollbarDimensions || this.measureScrollbar();
-    const canvasWithScrollbarWidth = this.getCanvasWidth() + this.scrollbarDimensions.width;
-
-    // Default the active canvas to the top left
-    this._activeCanvasNode = this._canvasTopL;
-
-    // top-header
-    if (this._topHeaderPanelSpacer) {
-      Utils.width(this._topHeaderPanelSpacer, canvasWithScrollbarWidth);
-    }
-
-    // pre-header
-    if (this._preHeaderPanelSpacer) {
-      Utils.width(this._preHeaderPanelSpacer, canvasWithScrollbarWidth);
-    }
-
-    this._headers.forEach((el) => {
-      Utils.width(el, this.getHeadersWidth());
-    });
-
-    Utils.width(this._headerRowSpacerL, canvasWithScrollbarWidth);
-    if (this._headerRowSpacerR) {
-      Utils.width(this._headerRowSpacerR, canvasWithScrollbarWidth);
-    }
-
-    // footer Row
     if (this._options.createFooterRow) {
-      this._viewportMgr.buildFooterRows(this._options, canvasWithScrollbarWidth);
-
       this._footerRowScrollerL = this._viewportMgr.footerRowScrollerL;
       this._footerRowScrollerR = this._viewportMgr.footerRowScrollerR;
       this._footerRowScroller = this._viewportMgr.footerRowScroller;
@@ -1664,23 +1788,116 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this._footerRowR = this._viewportMgr.footerRowR;
       this._footerRow = this._viewportMgr.footerRow;
     }
-
-    this._focusSink2 = this._focusSink.cloneNode(true) as HTMLDivElement;
-    this._container.appendChild(this._focusSink2);
-
-    if (!this._options.explicitInitialization) {
-      this.finishInitialization();
-    }
   }
 
   /**
-   * Completes grid initialisation by calculating viewport dimensions, measuring cell padding and border differences,
-   * disabling text selection (except on editable inputs), setting frozen options and pane visibility,
-   * updating column caches, creating column headers and footers, setting up column sorting,
-   * creating CSS rules, binding ancestor scroll events, and binding various event handlers
-   * (e.g. for scrolling, mouse, keyboard, drag-and-drop).
-   * It also starts up any asynchronous post–render processing if enabled.
+   * Binds the per-element event handlers for pane-level elements. Used by
+   * finishInitialization for the initial element set and by materializeLazyPanes
+   * for elements created later — pass ONLY the elements to wire up (the binding
+   * service does not dedupe).
    */
+  protected bindPaneEvents(els: {
+    viewports?: HTMLDivElement[];
+    canvases?: HTMLDivElement[];
+    headerScrollers?: HTMLDivElement[];
+    headerRowScrollers?: HTMLDivElement[];
+    footerRows?: HTMLDivElement[];
+    footerRowScrollers?: HTMLDivElement[];
+  }) {
+    if (!this._options.enableTextSelectionOnCells) {
+      // disable text selection in grid cells except in input and textarea elements
+      els.viewports?.forEach((view) => {
+        this._bindingEventService.bind(view, 'selectstart', (event) => {
+          if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+            return;
+          }
+          event.preventDefault();
+        });
+      });
+    }
+
+    els.viewports?.forEach((view) => {
+      this._bindingEventService.bind(view, 'scroll', this.handleScroll.bind(this));
+    });
+
+    if (this._options.enableMouseWheelScrollHandler) {
+      els.viewports?.forEach((view) => {
+        this.slickMouseWheelInstances.push(MouseWheel({
+          element: view,
+          onMouseWheel: this.handleMouseWheel.bind(this)
+        }));
+      });
+    }
+
+    els.headerScrollers?.forEach((el) => {
+      this._bindingEventService.bind(el, 'contextmenu', this.handleHeaderContextMenu.bind(this) as EventListener);
+      this._bindingEventService.bind(el, 'click', this.handleHeaderClick.bind(this) as EventListener);
+    });
+
+    els.headerRowScrollers?.forEach((scroller) => {
+      this._bindingEventService.bind(scroller, 'scroll', this.handleHeaderRowScroll.bind(this) as EventListener);
+    });
+
+    if (this._options.createFooterRow) {
+      els.footerRows?.forEach((footer) => {
+        this._bindingEventService.bind(footer, 'contextmenu', this.handleFooterContextMenu.bind(this) as EventListener);
+        this._bindingEventService.bind(footer, 'click', this.handleFooterClick.bind(this) as EventListener);
+      });
+
+      els.footerRowScrollers?.forEach((scroller) => {
+        this._bindingEventService.bind(scroller, 'scroll', this.handleFooterRowScroll.bind(this) as EventListener);
+      });
+    }
+
+    els.canvases?.forEach((element) => {
+      this._bindingEventService.bind(element, 'keydown', this.handleKeyDown.bind(this) as EventListener);
+      this._bindingEventService.bind(element, 'click', this.handleClick.bind(this) as EventListener);
+      this._bindingEventService.bind(element, 'dblclick', this.handleDblClick.bind(this) as EventListener);
+      this._bindingEventService.bind(element, 'contextmenu', this.handleContextMenu.bind(this) as EventListener);
+      this._bindingEventService.bind(element, 'mouseover', this.handleCellMouseOver.bind(this) as EventListener);
+      this._bindingEventService.bind(element, 'mouseout', this.handleCellMouseOut.bind(this) as EventListener);
+    });
+  }
+
+  /**
+   * Materializes the right/bottom panes on a lazyPanes grid the moment freezing is
+   * enabled (invoked from setFrozenOptions, i.e. before setScroller/setColumns run in
+   * the internal_setOptions pipeline). Re-aliases the element fields, wires up events
+   * for the NEW elements only, and re-anchors the ancestor scroll bindings. No-op on
+   * non-lazy grids.
+   */
+  protected materializeLazyPanes() {
+    if (!this._viewportMgr.materializeSecondaryPanes(this._options)) {
+      return;
+    }
+    this.syncViewportMgrAliases();
+
+    if (this.initialized) {
+      this.disableSelection([this._headerR]);
+
+      this.bindPaneEvents({
+        viewports: [this._viewportTopR, this._viewportBottomL, this._viewportBottomR],
+        canvases: [this._canvasTopR, this._canvasBottomL, this._canvasBottomR],
+        headerScrollers: [this._headerScrollerR],
+        headerRowScrollers: [this._headerRowScrollerR],
+        footerRows: this._options.createFooterRow ? [this._footerRowR] : [],
+        footerRowScrollers: this._options.createFooterRow ? [this._footerRowScrollerR] : [],
+      });
+
+      if (this._options.createPreHeaderPanel) {
+        this._bindingEventService.bind(this._preHeaderPanelScrollerR, 'contextmenu', this.handlePreHeaderContextMenu.bind(this) as EventListener);
+        this._bindingEventService.bind(this._preHeaderPanelScrollerR, 'click', this.handlePreHeaderClick.bind(this) as EventListener);
+      }
+
+      // sort clicks for the new right header container
+      this.setupColumnSort([this._headerR]);
+
+      // the ancestor-scroll anchor canvas may have changed band
+      this.unbindAncestorScrollEvents();
+      this.bindAncestorScrollEvents();
+    }
+  }
+
   protected finishInitialization() {
     if (!this.initialized) {
       this.initialized = true;
@@ -1693,18 +1910,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.measureCellPaddingAndBorder();
 
       this.disableSelection(this._headers); // disable all text selection in header (including input and textarea)
-
-      if (!this._options.enableTextSelectionOnCells) {
-        // disable text selection in grid cells except in input and textarea elements
-        this._viewport.forEach((view) => {
-          this._bindingEventService.bind(view, 'selectstart', (event) => {
-            if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
-              return;
-            }
-            event.preventDefault();
-          });
-        });
-      }
 
       this.setFrozenOptions();
       this.setPaneFrozenClasses();
@@ -1721,38 +1926,15 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.bindAncestorScrollEvents();
 
       this._bindingEventService.bind(this._container, 'resize', this.resizeCanvas.bind(this));
-      this._viewport.forEach((view) => {
-        this._bindingEventService.bind(view, 'scroll', this.handleScroll.bind(this));
+
+      this.bindPaneEvents({
+        viewports: this._viewport,
+        canvases: this._canvas,
+        headerScrollers: this._headerScroller,
+        headerRowScrollers: this._headerRowScroller,
+        footerRows: this._footerRow,
+        footerRowScrollers: this._footerRowScroller,
       });
-
-      if (this._options.enableMouseWheelScrollHandler) {
-        this._viewport.forEach((view) => {
-          this.slickMouseWheelInstances.push(MouseWheel({
-            element: view,
-            onMouseWheel: this.handleMouseWheel.bind(this)
-          }));
-        });
-      }
-
-      this._headerScroller.forEach((el) => {
-        this._bindingEventService.bind(el, 'contextmenu', this.handleHeaderContextMenu.bind(this) as EventListener);
-        this._bindingEventService.bind(el, 'click', this.handleHeaderClick.bind(this) as EventListener);
-      });
-
-      this._headerRowScroller.forEach((scroller) => {
-        this._bindingEventService.bind(scroller, 'scroll', this.handleHeaderRowScroll.bind(this) as EventListener);
-      });
-
-      if (this._options.createFooterRow) {
-        this._footerRow.forEach((footer) => {
-          this._bindingEventService.bind(footer, 'contextmenu', this.handleFooterContextMenu.bind(this) as EventListener);
-          this._bindingEventService.bind(footer, 'click', this.handleFooterClick.bind(this) as EventListener);
-        });
-
-        this._footerRowScroller.forEach((scroller) => {
-          this._bindingEventService.bind(scroller, 'scroll', this.handleFooterRowScroll.bind(this) as EventListener);
-        });
-      }
 
       if (this._options.createTopHeaderPanel) {
         this._bindingEventService.bind(this._topHeaderPanelScroller, 'scroll', this.handleTopHeaderPanelScroll.bind(this) as EventListener);
@@ -1768,15 +1950,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       this._bindingEventService.bind(this._focusSink, 'keydown', this.handleKeyDown.bind(this) as EventListener);
       this._bindingEventService.bind(this._focusSink2, 'keydown', this.handleKeyDown.bind(this) as EventListener);
-
-      this._canvas.forEach((element) => {
-        this._bindingEventService.bind(element, 'keydown', this.handleKeyDown.bind(this) as EventListener);
-        this._bindingEventService.bind(element, 'click', this.handleClick.bind(this) as EventListener);
-        this._bindingEventService.bind(element, 'dblclick', this.handleDblClick.bind(this) as EventListener);
-        this._bindingEventService.bind(element, 'contextmenu', this.handleContextMenu.bind(this) as EventListener);
-        this._bindingEventService.bind(element, 'mouseover', this.handleCellMouseOver.bind(this) as EventListener);
-        this._bindingEventService.bind(element, 'mouseout', this.handleCellMouseOut.bind(this) as EventListener);
-      });
 
       if (Draggable) {
         this.slickDraggableInstance = Draggable({
@@ -2421,8 +2594,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    *      --> triggers onBeforeSort
    *      --> and if not cancelled, updates the sort columns and triggers onSort.
    */
-  protected setupColumnSort() {
-    this._headers.forEach((header) => {
+  protected setupColumnSort(headers: HTMLDivElement[] = this._headers) {
+    headers.forEach((header) => {
       this._bindingEventService.bind(header, 'click', (e: any) => {
         if (this.columnResizeDragging) {
           return;
@@ -3175,6 +3348,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       actualFrozenRow: this.actualFrozenRow,
       frozenBottom: !!this._options.frozenBottom,
     });
+
+    // materialize the secondary panes if freezing was just enabled on a lazyPanes grid
+    // (runs before setScroller/setColumns in the internal_setOptions pipeline)
+    if (this._options.frozenColumn! > -1 || this.hasFrozenRows) {
+      this.materializeLazyPanes();
+    }
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -1833,6 +1833,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * to null so that they can be garbage collected.
    */
   protected destroyAllElements() {
+    // drop the ViewportMgr first — it holds references to every pane/viewport/canvas
+    // element and the container, which would otherwise keep the detached DOM alive
+    this._viewportMgr = null as any;
     this._activeCanvasNode = null as any;
     this._activeViewportNode = null as any;
     this._boundAncestors = null as any;

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -146,6 +146,30 @@ interface RowCaching {
   cellRenderQueue: any[];
 }
 
+/** Snapshot of the grid's freeze configuration, pushed into ViewportMgr by setFrozenOptions(). */
+interface ViewportFreezeState {
+  frozenColumnIdx: number;
+  hasFrozenRows: boolean;
+  actualFrozenRow: number;
+  frozenBottom: boolean;
+}
+
+/** Geometry inputs for ViewportMgr.applyCanvasWidths — computed by the grid, distributed by the manager. */
+interface CanvasWidthsGeometry {
+  widthChanged: boolean;
+  canvasWidth: number;
+  canvasWidthL: number;
+  canvasWidthR: number;
+  headersWidthL: number;
+  headersWidthR: number;
+  viewportW: number;
+  viewportHasVScroll: boolean;
+  scrollbarWidth: number;
+  createFooterRow?: boolean;
+  createPreHeaderPanel?: boolean;
+  preHeaderPanelWidth?: number | string;
+}
+
 /** Options consumed by ViewportMgr when constructing the pane/viewport/canvas DOM. */
 interface ViewportMgrBuildOptions {
   createPreHeaderPanel?: boolean;
@@ -370,6 +394,228 @@ class ViewportMgr {
         Utils.hide(scroller);
       });
     }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // Freeze state and pane selection (Phase 2 of the encapsulation refactor)
+  //////////////////////////////////////////////////////////////////////////////////////////////
+
+  protected freeze: ViewportFreezeState = { frozenColumnIdx: -1, hasFrozenRows: false, actualFrozenRow: -1, frozenBottom: false };
+
+  /** Receives the grid's freeze configuration; called by SlickGrid.setFrozenOptions(). */
+  updateFreezeState(f: ViewportFreezeState) {
+    this.freeze = { ...f };
+  }
+
+  /** Returns a boolean indicating whether the grid is configured with frozen columns. */
+  hasFrozenColumns() {
+    return this.freeze.frozenColumnIdx > -1;
+  }
+
+  /**
+   * Index of the pane owning cell (colIdx, rowIdx) in the 4-slot
+   * [TopL, TopR, BottomL, BottomR] element arrays.
+   */
+  paneCellIndex(colIdx: number, rowIdx: number): number {
+    const isBottomSide = this.freeze.hasFrozenRows && rowIdx >= this.freeze.actualFrozenRow + (this.freeze.frozenBottom ? 0 : 1);
+    const isRightSide = this.hasFrozenColumns() && colIdx > this.freeze.frozenColumnIdx;
+    return (isBottomSide ? 2 : 0) + (isRightSide ? 1 : 0);
+  }
+
+  /** add/remove frozen class to left headers/footer when defined */
+  applyPaneFrozenClasses(): void {
+    const classAction = this.hasFrozenColumns() ? 'add' : 'remove';
+    for (const elm of [this.paneHeaderL, this.paneTopL, this.paneBottomL]) {
+      elm.classList[classAction]('frozen');
+    }
+  }
+
+  /** Shows/hides the right and bottom panes according to the freeze configuration. */
+  applyPaneVisibility() {
+    if (this.hasFrozenColumns()) {
+      Utils.show(this.paneHeaderR);
+      Utils.show(this.paneTopR);
+
+      if (this.freeze.hasFrozenRows) {
+        Utils.show(this.paneBottomL);
+        Utils.show(this.paneBottomR);
+      } else {
+        Utils.hide(this.paneBottomR);
+        Utils.hide(this.paneBottomL);
+      }
+    } else {
+      Utils.hide(this.paneHeaderR);
+      Utils.hide(this.paneTopR);
+      Utils.hide(this.paneBottomR);
+
+      if (this.freeze.hasFrozenRows) {
+        Utils.show(this.paneBottomL);
+      } else {
+        Utils.hide(this.paneBottomR);
+        Utils.hide(this.paneBottomL);
+      }
+    }
+  }
+
+  /**
+   * Sets the CSS overflowX and overflowY styles for all four viewport elements
+   * (top–left, top–right, bottom–left, bottom–right) based on the freeze configuration
+   * and options such as alwaysAllowHorizontalScroll and alwaysShowVerticalScroll.
+   * If a viewportClass is specified in options, the class is added to each viewport.
+   */
+  applyOverflow(o: { alwaysAllowHorizontalScroll?: boolean; alwaysShowVerticalScroll?: boolean; viewportClass?: string; }) {
+    const hasFrozenRows = this.freeze.hasFrozenRows;
+    this.viewportTopL.style.overflowX = (this.hasFrozenColumns()) ? (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll') : (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'hidden' : 'auto');
+    this.viewportTopL.style.overflowY = (!this.hasFrozenColumns() && o.alwaysShowVerticalScroll) ? 'scroll' : ((this.hasFrozenColumns()) ? (hasFrozenRows ? 'hidden' : 'hidden') : (hasFrozenRows ? 'scroll' : 'auto'));
+
+    this.viewportTopR.style.overflowX = (this.hasFrozenColumns()) ? (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll') : (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'hidden' : 'auto');
+    this.viewportTopR.style.overflowY = o.alwaysShowVerticalScroll ? 'scroll' : ((this.hasFrozenColumns()) ? (hasFrozenRows ? 'scroll' : 'auto') : (hasFrozenRows ? 'scroll' : 'auto'));
+
+    this.viewportBottomL.style.overflowX = (this.hasFrozenColumns()) ? (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'scroll' : 'auto') : (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'auto' : 'auto');
+    this.viewportBottomL.style.overflowY = (!this.hasFrozenColumns() && o.alwaysShowVerticalScroll) ? 'scroll' : ((this.hasFrozenColumns()) ? (hasFrozenRows ? 'hidden' : 'hidden') : (hasFrozenRows ? 'scroll' : 'auto'));
+
+    this.viewportBottomR.style.overflowX = (this.hasFrozenColumns()) ? (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'scroll' : 'auto') : (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'auto' : 'auto');
+    this.viewportBottomR.style.overflowY = o.alwaysShowVerticalScroll ? 'scroll' : ((this.hasFrozenColumns()) ? (hasFrozenRows ? 'auto' : 'auto') : (hasFrozenRows ? 'auto' : 'auto'));
+
+    if (o.viewportClass) {
+      const viewportClassList = Utils.classNameToList(o.viewportClass);
+      this.viewportTopL.classList.add(...viewportClassList);
+      this.viewportTopR.classList.add(...viewportClassList);
+      this.viewportBottomL.classList.add(...viewportClassList);
+      this.viewportBottomR.classList.add(...viewportClassList);
+    }
+  }
+
+  /**
+   * Picks which viewport owns the X and Y scrollbars and which header/header-row/footer-row
+   * scrollers follow horizontal scrolling, according to the freeze configuration.
+   * The horizontal scrollbar must sit at the physical bottom of the grid, which is why
+   * frozenBottom splits X and Y ownership.
+   */
+  /**
+   * Distributes computed canvas/header widths onto the pane, viewport, canvas, header,
+   * header-row and footer-row elements. Transcribed from the historical middle section
+   * of SlickGrid.updateCanvasWidth(); the width computations stay in the grid.
+   */
+  applyCanvasWidths(g: CanvasWidthsGeometry) {
+    if (g.widthChanged || this.hasFrozenColumns() || this.freeze.hasFrozenRows) {
+      Utils.width(this.canvasTopL, g.canvasWidthL);
+
+      Utils.width(this.headerL, g.headersWidthL);
+      Utils.width(this.headerR, g.headersWidthR);
+
+      if (this.hasFrozenColumns()) {
+        Utils.width(this.canvasTopR, g.canvasWidthR);
+
+        Utils.width(this.paneHeaderL, g.canvasWidthL);
+        Utils.setStyleSize(this.paneHeaderR, 'left', g.canvasWidthL);
+        Utils.setStyleSize(this.paneHeaderR, 'width', g.viewportW - g.canvasWidthL);
+
+        Utils.width(this.paneTopL, g.canvasWidthL);
+        Utils.setStyleSize(this.paneTopR, 'left', g.canvasWidthL);
+        Utils.width(this.paneTopR, g.viewportW - g.canvasWidthL);
+
+        Utils.width(this.headerRowScrollerL, g.canvasWidthL);
+        Utils.width(this.headerRowScrollerR, g.viewportW - g.canvasWidthL);
+
+        Utils.width(this.headerRowL, g.canvasWidthL);
+        Utils.width(this.headerRowR, g.canvasWidthR);
+
+        if (g.createFooterRow) {
+          Utils.width(this.footerRowScrollerL, g.canvasWidthL);
+          Utils.width(this.footerRowScrollerR, g.viewportW - g.canvasWidthL);
+
+          Utils.width(this.footerRowL, g.canvasWidthL);
+          Utils.width(this.footerRowR, g.canvasWidthR);
+        }
+        if (g.createPreHeaderPanel) {
+          Utils.width(this.preHeaderPanel, g.preHeaderPanelWidth ?? g.canvasWidth);
+        }
+        Utils.width(this.viewportTopL, g.canvasWidthL);
+        Utils.width(this.viewportTopR, g.viewportW - g.canvasWidthL);
+
+        if (this.freeze.hasFrozenRows) {
+          Utils.width(this.paneBottomL, g.canvasWidthL);
+          Utils.setStyleSize(this.paneBottomR, 'left', g.canvasWidthL);
+
+          Utils.width(this.viewportBottomL, g.canvasWidthL);
+          Utils.width(this.viewportBottomR, g.viewportW - g.canvasWidthL);
+
+          Utils.width(this.canvasBottomL, g.canvasWidthL);
+          Utils.width(this.canvasBottomR, g.canvasWidthR);
+        }
+      } else {
+        Utils.width(this.paneHeaderL, '100%');
+        Utils.width(this.paneTopL, '100%');
+        Utils.width(this.headerRowScrollerL, '100%');
+        Utils.width(this.headerRowL, g.canvasWidth);
+
+        if (g.createFooterRow) {
+          Utils.width(this.footerRowScrollerL, '100%');
+          Utils.width(this.footerRowL, g.canvasWidth);
+        }
+
+        if (g.createPreHeaderPanel) {
+          Utils.width(this.preHeaderPanel, g.preHeaderPanelWidth ?? g.canvasWidth);
+        }
+        Utils.width(this.viewportTopL, '100%');
+
+        if (this.freeze.hasFrozenRows) {
+          Utils.width(this.viewportBottomL, '100%');
+          Utils.width(this.canvasBottomL, g.canvasWidthL);
+        }
+      }
+    }
+
+    Utils.width(this.headerRowSpacerL, g.canvasWidth + (g.viewportHasVScroll ? g.scrollbarWidth : 0));
+    Utils.width(this.headerRowSpacerR, g.canvasWidth + (g.viewportHasVScroll ? g.scrollbarWidth : 0));
+
+    if (g.createFooterRow) {
+      Utils.width(this.footerRowSpacerL, g.canvasWidth + (g.viewportHasVScroll ? g.scrollbarWidth : 0));
+      Utils.width(this.footerRowSpacerR, g.canvasWidth + (g.viewportHasVScroll ? g.scrollbarWidth : 0));
+    }
+  }
+
+  selectScrollContainers(): { x: HTMLDivElement; y: HTMLDivElement; header: HTMLDivElement; headerRow: HTMLDivElement; footerRow: HTMLDivElement; } {
+    let x: HTMLDivElement;
+    let y: HTMLDivElement;
+    let header: HTMLDivElement;
+    let headerRow: HTMLDivElement;
+    let footerRow: HTMLDivElement;
+
+    if (this.hasFrozenColumns()) {
+      header = this.headerScrollerR;
+      headerRow = this.headerRowScrollerR;
+      footerRow = this.footerRowScrollerR;
+
+      if (this.freeze.hasFrozenRows) {
+        if (this.freeze.frozenBottom) {
+          x = this.viewportBottomR;
+          y = this.viewportTopR;
+        } else {
+          x = y = this.viewportBottomR;
+        }
+      } else {
+        x = y = this.viewportTopR;
+      }
+    } else {
+      header = this.headerScrollerL;
+      headerRow = this.headerRowScrollerL;
+      footerRow = this.footerRowScrollerL;
+
+      if (this.freeze.hasFrozenRows) {
+        if (this.freeze.frozenBottom) {
+          x = this.viewportBottomL;
+          y = this.viewportTopL;
+        } else {
+          x = y = this.viewportBottomL;
+        }
+      } else {
+        x = y = this.viewportTopL;
+      }
+    }
+
+    return { x, y, header, headerRow, footerRow };
   }
 }
 
@@ -1622,10 +1868,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** add/remove frozen class to left headers/footer when defined */
   protected setPaneFrozenClasses(): void {
-    const classAction = this.hasFrozenColumns() ? 'add' : 'remove';
-    for (const elm of [this._paneHeaderL, this._paneTopL, this._paneBottomL]) {
-      elm.classList[classAction]('frozen');
-    }
+    this._viewportMgr.applyPaneFrozenClasses();
   }
 
   //////////////////////////////////////////////////////////////////////
@@ -2556,6 +2799,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     } else {
       this.hasFrozenRows = false;
     }
+
+    // keep the ViewportMgr's freeze snapshot in sync with the grid
+    this._viewportMgr.updateFreezeState({
+      frozenColumnIdx: this._options.frozenColumn!,
+      hasFrozenRows: this.hasFrozenRows,
+      actualFrozenRow: this.actualFrozenRow,
+      frozenBottom: !!this._options.frozenBottom,
+    });
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////
@@ -5029,86 +5280,28 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     const widthChanged = this.canvasWidth !== oldCanvasWidth || this.canvasWidthL !== oldCanvasWidthL || this.canvasWidthR !== oldCanvasWidthR;
 
+    // recompute the header width split only when the pane widths will be redistributed
+    // (preserves the historical conditional side effect on headersWidthL/R)
     if (widthChanged || this.hasFrozenColumns() || this.hasFrozenRows) {
-      Utils.width(this._canvasTopL, this.canvasWidthL);
-
       this.getHeadersWidth();
-
-      Utils.width(this._headerL, this.headersWidthL);
-      Utils.width(this._headerR, this.headersWidthR);
-
-      if (this.hasFrozenColumns()) {
-        Utils.width(this._canvasTopR, this.canvasWidthR);
-
-        Utils.width(this._paneHeaderL, this.canvasWidthL);
-        Utils.setStyleSize(this._paneHeaderR, 'left', this.canvasWidthL);
-        Utils.setStyleSize(this._paneHeaderR, 'width', this.viewportW - this.canvasWidthL);
-
-        Utils.width(this._paneTopL, this.canvasWidthL);
-        Utils.setStyleSize(this._paneTopR, 'left', this.canvasWidthL);
-        Utils.width(this._paneTopR, this.viewportW - this.canvasWidthL);
-
-        Utils.width(this._headerRowScrollerL, this.canvasWidthL);
-        Utils.width(this._headerRowScrollerR, this.viewportW - this.canvasWidthL);
-
-        Utils.width(this._headerRowL, this.canvasWidthL);
-        Utils.width(this._headerRowR, this.canvasWidthR);
-
-        if (this._options.createFooterRow) {
-          Utils.width(this._footerRowScrollerL, this.canvasWidthL);
-          Utils.width(this._footerRowScrollerR, this.viewportW - this.canvasWidthL);
-
-          Utils.width(this._footerRowL, this.canvasWidthL);
-          Utils.width(this._footerRowR, this.canvasWidthR);
-        }
-        if (this._options.createPreHeaderPanel) {
-          Utils.width(this._preHeaderPanel, this._options.preHeaderPanelWidth ?? this.canvasWidth);
-        }
-        Utils.width(this._viewportTopL, this.canvasWidthL);
-        Utils.width(this._viewportTopR, this.viewportW - this.canvasWidthL);
-
-        if (this.hasFrozenRows) {
-          Utils.width(this._paneBottomL, this.canvasWidthL);
-          Utils.setStyleSize(this._paneBottomR, 'left', this.canvasWidthL);
-
-          Utils.width(this._viewportBottomL, this.canvasWidthL);
-          Utils.width(this._viewportBottomR, this.viewportW - this.canvasWidthL);
-
-          Utils.width(this._canvasBottomL, this.canvasWidthL);
-          Utils.width(this._canvasBottomR, this.canvasWidthR);
-        }
-      } else {
-        Utils.width(this._paneHeaderL, '100%');
-        Utils.width(this._paneTopL, '100%');
-        Utils.width(this._headerRowScrollerL, '100%');
-        Utils.width(this._headerRowL, this.canvasWidth);
-
-        if (this._options.createFooterRow) {
-          Utils.width(this._footerRowScrollerL, '100%');
-          Utils.width(this._footerRowL, this.canvasWidth);
-        }
-
-        if (this._options.createPreHeaderPanel) {
-          Utils.width(this._preHeaderPanel, this._options.preHeaderPanelWidth ?? this.canvasWidth);
-        }
-        Utils.width(this._viewportTopL, '100%');
-
-        if (this.hasFrozenRows) {
-          Utils.width(this._viewportBottomL, '100%');
-          Utils.width(this._canvasBottomL, this.canvasWidthL);
-        }
-      }
     }
+
+    this._viewportMgr.applyCanvasWidths({
+      widthChanged,
+      canvasWidth: this.canvasWidth,
+      canvasWidthL: this.canvasWidthL,
+      canvasWidthR: this.canvasWidthR,
+      headersWidthL: this.headersWidthL,
+      headersWidthR: this.headersWidthR,
+      viewportW: this.viewportW,
+      viewportHasVScroll: this.viewportHasVScroll,
+      scrollbarWidth: this.scrollbarDimensions?.width ?? 0,
+      createFooterRow: this._options.createFooterRow,
+      createPreHeaderPanel: this._options.createPreHeaderPanel,
+      preHeaderPanelWidth: this._options.preHeaderPanelWidth,
+    });
 
     this.viewportHasHScroll = (this.canvasWidth >= this.viewportW - (this.scrollbarDimensions?.width ?? 0));
-
-    Utils.width(this._headerRowSpacerL, this.canvasWidth + (this.viewportHasVScroll ? (this.scrollbarDimensions?.width ?? 0) : 0));
-    Utils.width(this._headerRowSpacerR, this.canvasWidth + (this.viewportHasVScroll ? (this.scrollbarDimensions?.width ?? 0) : 0));
-
-    if (this._options.createFooterRow) {
-      Utils.width(this._footerRowSpacerL, this.canvasWidth + (this.viewportHasVScroll ? (this.scrollbarDimensions?.width ?? 0) : 0));
-      Utils.width(this._footerRowSpacerR, this.canvasWidth + (this.viewportHasVScroll ? (this.scrollbarDimensions?.width ?? 0) : 0));
-    }
 
     if (widthChanged || forceColumnWidthsUpdate) {
       this.applyColumnWidths();
@@ -5141,29 +5334,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * otherwise, conditionally shows or hides the bottom panes depending on whether frozen rows exist.
    */
   protected setPaneVisibility() {
-    if (this.hasFrozenColumns()) {
-      Utils.show(this._paneHeaderR);
-      Utils.show(this._paneTopR);
-
-      if (this.hasFrozenRows) {
-        Utils.show(this._paneBottomL);
-        Utils.show(this._paneBottomR);
-      } else {
-        Utils.hide(this._paneBottomR);
-        Utils.hide(this._paneBottomL);
-      }
-    } else {
-      Utils.hide(this._paneHeaderR);
-      Utils.hide(this._paneTopR);
-      Utils.hide(this._paneBottomR);
-
-      if (this.hasFrozenRows) {
-        Utils.show(this._paneBottomL);
-      } else {
-        Utils.hide(this._paneBottomR);
-        Utils.hide(this._paneBottomL);
-      }
-    }
+    this._viewportMgr.applyPaneVisibility();
   }
 
   /**
@@ -5173,25 +5344,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * If a viewportClass is specified in options, the class is added to each viewport.
    */
   protected setOverflow() {
-    this._viewportTopL.style.overflowX = (this.hasFrozenColumns()) ? (this.hasFrozenRows && !this._options.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll') : (this.hasFrozenRows && !this._options.alwaysAllowHorizontalScroll ? 'hidden' : 'auto');
-    this._viewportTopL.style.overflowY = (!this.hasFrozenColumns() && this._options.alwaysShowVerticalScroll) ? 'scroll' : ((this.hasFrozenColumns()) ? (this.hasFrozenRows ? 'hidden' : 'hidden') : (this.hasFrozenRows ? 'scroll' : 'auto'));
-
-    this._viewportTopR.style.overflowX = (this.hasFrozenColumns()) ? (this.hasFrozenRows && !this._options.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll') : (this.hasFrozenRows && !this._options.alwaysAllowHorizontalScroll ? 'hidden' : 'auto');
-    this._viewportTopR.style.overflowY = this._options.alwaysShowVerticalScroll ? 'scroll' : ((this.hasFrozenColumns()) ? (this.hasFrozenRows ? 'scroll' : 'auto') : (this.hasFrozenRows ? 'scroll' : 'auto'));
-
-    this._viewportBottomL.style.overflowX = (this.hasFrozenColumns()) ? (this.hasFrozenRows && !this._options.alwaysAllowHorizontalScroll ? 'scroll' : 'auto') : (this.hasFrozenRows && !this._options.alwaysAllowHorizontalScroll ? 'auto' : 'auto');
-    this._viewportBottomL.style.overflowY = (!this.hasFrozenColumns() && this._options.alwaysShowVerticalScroll) ? 'scroll' : ((this.hasFrozenColumns()) ? (this.hasFrozenRows ? 'hidden' : 'hidden') : (this.hasFrozenRows ? 'scroll' : 'auto'));
-
-    this._viewportBottomR.style.overflowX = (this.hasFrozenColumns()) ? (this.hasFrozenRows && !this._options.alwaysAllowHorizontalScroll ? 'scroll' : 'auto') : (this.hasFrozenRows && !this._options.alwaysAllowHorizontalScroll ? 'auto' : 'auto');
-    this._viewportBottomR.style.overflowY = this._options.alwaysShowVerticalScroll ? 'scroll' : ((this.hasFrozenColumns()) ? (this.hasFrozenRows ? 'auto' : 'auto') : (this.hasFrozenRows ? 'auto' : 'auto'));
-
-    if (this._options.viewportClass) {
-      const viewportClassList = Utils.classNameToList(this._options.viewportClass);
-      this._viewportTopL.classList.add(...viewportClassList);
-      this._viewportTopR.classList.add(...viewportClassList);
-      this._viewportBottomL.classList.add(...viewportClassList);
-      this._viewportBottomR.classList.add(...viewportClassList);
-    }
+    this._viewportMgr.applyOverflow(this._options);
   }
 
   /**
@@ -6768,37 +6921,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * The selection depends on whether the grid has frozen columns and/or frozen rows and whether frozenBottom is set.
    */
   protected setScroller() {
-    if (this.hasFrozenColumns()) {
-      this._headerScrollContainer = this._headerScrollerR;
-      this._headerRowScrollContainer = this._headerRowScrollerR;
-      this._footerRowScrollContainer = this._footerRowScrollerR;
-
-      if (this.hasFrozenRows) {
-        if (this._options.frozenBottom) {
-          this._viewportScrollContainerX = this._viewportBottomR;
-          this._viewportScrollContainerY = this._viewportTopR;
-        } else {
-          this._viewportScrollContainerX = this._viewportScrollContainerY = this._viewportBottomR;
-        }
-      } else {
-        this._viewportScrollContainerX = this._viewportScrollContainerY = this._viewportTopR;
-      }
-    } else {
-      this._headerScrollContainer = this._headerScrollerL;
-      this._headerRowScrollContainer = this._headerRowScrollerL;
-      this._footerRowScrollContainer = this._footerRowScrollerL;
-
-      if (this.hasFrozenRows) {
-        if (this._options.frozenBottom) {
-          this._viewportScrollContainerX = this._viewportBottomL;
-          this._viewportScrollContainerY = this._viewportTopL;
-        } else {
-          this._viewportScrollContainerX = this._viewportScrollContainerY = this._viewportBottomL;
-        }
-      } else {
-        this._viewportScrollContainerX = this._viewportScrollContainerY = this._viewportTopL;
-      }
-    }
+    const containers = this._viewportMgr.selectScrollContainers();
+    this._viewportScrollContainerX = containers.x;
+    this._viewportScrollContainerY = containers.y;
+    this._headerScrollContainer = containers.header;
+    this._headerRowScrollContainer = containers.headerRow;
+    this._footerRowScrollContainer = containers.footerRow;
   }
 
   /**
@@ -7806,10 +7934,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     const idx = (typeof columnIdOrIdx === 'number' ? columnIdOrIdx : this.getColumnIndex(columnIdOrIdx));
 
-    const isBottomSide = this.hasFrozenRows && rowIndex >= this.actualFrozenRow + (this._options.frozenBottom ? 0 : 1);
-    const isRightSide = this.hasFrozenColumns() && idx > this._options.frozenColumn!;
-
-    return targetContainers[(isBottomSide ? 2 : 0) + (isRightSide ? 1 : 0)];
+    return targetContainers[this._viewportMgr.paneCellIndex(idx, rowIndex)];
   }
 
   /**

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -709,6 +709,84 @@ class ViewportMgr {
     return { paneTopH, paneBottomH, viewportTopH, viewportBottomH };
   }
 
+  /** the current scroll-owner/follower set, refreshed by selectScrollContainers() */
+  protected scrollContainers!: { x: HTMLDivElement; y: HTMLDivElement; header: HTMLDivElement; headerRow: HTMLDivElement; footerRow: HTMLDivElement; };
+
+  /**
+   * Attaches one rendered row (left fragment + right fragment when columns are frozen)
+   * to the canvases owned by the row's band, returning the rowNode array for the grid's
+   * rowsCache (or null if the expected fragments are missing).
+   *
+   * NOTE: the band threshold here is `rowIdx >= actualFrozenRow` — deliberately WITHOUT
+   * the `+ (frozenBottom ? 0 : 1)` adjustment used by paneCellIndex(); the historical
+   * render-side and cell-lookup-side splits differ by one row in the non-frozenBottom
+   * case, and that asymmetry is preserved verbatim.
+   */
+  attachRow(rowIdx: number, left: HTMLElement | null, right: HTMLElement | null): HTMLElement[] | null {
+    if ((this.freeze.hasFrozenRows) && (rowIdx >= this.freeze.actualFrozenRow)) {
+      if (this.hasFrozenColumns()) {
+        if (left && right) {
+          this.canvasBottomL.appendChild(left);
+          this.canvasBottomR.appendChild(right);
+          return [left, right];
+        }
+      } else if (left) {
+        this.canvasBottomL.appendChild(left);
+        return [left];
+      }
+    } else if (this.hasFrozenColumns()) {
+      if (left && right) {
+        this.canvasTopL.appendChild(left);
+        this.canvasTopR.appendChild(right);
+        return [left, right];
+      }
+    } else if (left) {
+      this.canvasTopL.appendChild(left);
+      return [left];
+    }
+    return null;
+  }
+
+  /** Applies an X scroll position to the scroll-owner viewport and every horizontal follower. */
+  syncHorizontalScroll(x: number, o: { createFooterRow?: boolean; createPreHeaderPanel?: boolean; }) {
+    this.scrollContainers.x.scrollLeft = x;
+    this.scrollContainers.header.scrollLeft = x;
+    this.topPanelScrollers[0].scrollLeft = x;
+    if (o.createFooterRow) {
+      this.scrollContainers.footerRow.scrollLeft = x;
+    }
+    if (o.createPreHeaderPanel) {
+      if (this.hasFrozenColumns()) {
+        this.preHeaderPanelScrollerR.scrollLeft = x;
+      } else {
+        this.preHeaderPanelScroller.scrollLeft = x;
+      }
+    }
+
+    if (this.hasFrozenColumns()) {
+      if (this.freeze.hasFrozenRows) {
+        this.viewportTopR.scrollLeft = x;
+      }
+      this.headerRowScrollerR.scrollLeft = x; // right header row scrolling with frozen grid
+    } else {
+      if (this.freeze.hasFrozenRows) {
+        this.viewportTopL.scrollLeft = x;
+      }
+      this.headerRowScrollerL.scrollLeft = x; // left header row scrolling with regular grid
+    }
+  }
+
+  /** Mirrors the Y scroll position onto the frozen-left viewport that follows the scroll owner. */
+  syncVerticalFollowers(scrollTop: number) {
+    if (this.hasFrozenColumns()) {
+      if (this.freeze.hasFrozenRows && !this.freeze.frozenBottom) {
+        this.viewportBottomL.scrollTop = scrollTop;
+      } else {
+        this.viewportTopL.scrollTop = scrollTop;
+      }
+    }
+  }
+
   selectScrollContainers(): { x: HTMLDivElement; y: HTMLDivElement; header: HTMLDivElement; headerRow: HTMLDivElement; footerRow: HTMLDivElement; } {
     let x: HTMLDivElement;
     let y: HTMLDivElement;
@@ -748,7 +826,8 @@ class ViewportMgr {
       }
     }
 
-    return { x, y, header, headerRow, footerRow };
+    this.scrollContainers = { x, y, header, headerRow, footerRow };
+    return this.scrollContainers;
   }
 }
 
@@ -6786,29 +6865,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       divArrayR.forEach(elm => xRight.appendChild(elm as HTMLElement));
 
       for (let i = 0, ii = rows.length; i < ii; i++) {
-        if ((this.hasFrozenRows) && (rows[i] >= this.actualFrozenRow)) {
-          if (this.hasFrozenColumns()) {
-            if (this.rowsCache?.hasOwnProperty(rows[i]) && x.firstChild && xRight.firstChild) {
-              this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement, xRight.firstChild as HTMLElement];
-              this._canvasBottomL.appendChild(x.firstChild as ChildNode);
-              this._canvasBottomR.appendChild(xRight.firstChild as ChildNode);
-            }
-          } else {
-            if (this.rowsCache?.hasOwnProperty(rows[i]) && x.firstChild) {
-              this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement];
-              this._canvasBottomL.appendChild(x.firstChild as ChildNode);
-            }
-          }
-        } else if (this.hasFrozenColumns()) {
-          if (this.rowsCache?.hasOwnProperty(rows[i]) && x.firstChild && xRight.firstChild) {
-            this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement, xRight.firstChild as HTMLElement];
-            this._canvasTopL.appendChild(x.firstChild as ChildNode);
-            this._canvasTopR.appendChild(xRight.firstChild as ChildNode);
-          }
-        } else {
-          if (this.rowsCache?.hasOwnProperty(rows[i]) && x.firstChild) {
-            this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement];
-            this._canvasTopL.appendChild(x.firstChild as ChildNode);
+        if (this.rowsCache?.hasOwnProperty(rows[i])) {
+          const attached = this._viewportMgr.attachRow(rows[i], x.firstChild as HTMLElement | null, xRight.firstChild as HTMLElement | null);
+          if (attached) {
+            this.rowsCache[rows[i]].rowNode = attached;
           }
         }
       }
@@ -7142,13 +7202,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         this._viewportScrollContainerY.scrollTop = this.scrollTop;
       }
 
-      if (this.hasFrozenColumns()) {
-        if (this.hasFrozenRows && !this._options.frozenBottom) {
-          this._viewportBottomL.scrollTop = this.scrollTop;
-        } else {
-          this._viewportTopL.scrollTop = this.scrollTop;
-        }
-      }
+      this._viewportMgr.syncVerticalFollowers(this.scrollTop);
 
       // switch virtual pages if needed
       if (vScrollDist < this.viewportH) {
@@ -8149,33 +8203,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number} x
    */
   scrollToX(x: number): void {
-    this._viewportScrollContainerX.scrollLeft = x;
-    this._headerScrollContainer.scrollLeft = x;
-    this._topPanelScrollers[0].scrollLeft = x;
-    if (this._options.createFooterRow) {
-      this._footerRowScrollContainer.scrollLeft = x;
-    }
-    if (this._options.createPreHeaderPanel) {
-      if (this.hasFrozenColumns()) {
-        this._preHeaderPanelScrollerR.scrollLeft = x;
-      } else {
-        this._preHeaderPanelScroller.scrollLeft = x;
-      }
-    }
+    this._viewportMgr.syncHorizontalScroll(x, this._options);
+
     if (this._options.createTopHeaderPanel) {
       this._topHeaderPanelScroller.scrollLeft = x;
-    }
-
-    if (this.hasFrozenColumns()) {
-      if (this.hasFrozenRows) {
-        this._viewportTopR.scrollLeft = x;
-      }
-      this._headerRowScrollerR.scrollLeft = x; // right header row scrolling with frozen grid
-    } else {
-      if (this.hasFrozenRows) {
-        this._viewportTopL.scrollLeft = x;
-      }
-      this._headerRowScrollerL.scrollLeft = x; // left header row scrolling with regular grid
     }
   }
 

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -542,37 +542,47 @@ class ViewportMgr {
     return this.isColumnRightOfFreeze(colIdx) ? right : left;
   }
 
+  /** Utils.show that tolerates panes not built under lazyPanes. */
+  protected showIf(el?: HTMLElement) {
+    if (el) { Utils.show(el); }
+  }
+
+  /** Utils.hide that tolerates panes not built under lazyPanes. */
+  protected hideIf(el?: HTMLElement) {
+    if (el) { Utils.hide(el); }
+  }
+
   /** add/remove frozen class to left headers/footer when defined */
   applyPaneFrozenClasses(): void {
     const classAction = this.hasFrozenColumns() ? 'add' : 'remove';
     for (const elm of [this.paneHeaderL, this.paneTopL, this.paneBottomL]) {
-      elm.classList[classAction]('frozen');
+      elm?.classList[classAction]('frozen');
     }
   }
 
   /** Shows/hides the right and bottom panes according to the freeze configuration. */
   applyPaneVisibility() {
     if (this.hasFrozenColumns()) {
-      Utils.show(this.paneHeaderR);
-      Utils.show(this.paneTopR);
+      this.showIf(this.paneHeaderR);
+      this.showIf(this.paneTopR);
 
       if (this.freeze.hasFrozenRows) {
-        Utils.show(this.paneBottomL);
-        Utils.show(this.paneBottomR);
+        this.showIf(this.paneBottomL);
+        this.showIf(this.paneBottomR);
       } else {
-        Utils.hide(this.paneBottomR);
-        Utils.hide(this.paneBottomL);
+        this.hideIf(this.paneBottomR);
+        this.hideIf(this.paneBottomL);
       }
     } else {
-      Utils.hide(this.paneHeaderR);
-      Utils.hide(this.paneTopR);
-      Utils.hide(this.paneBottomR);
+      this.hideIf(this.paneHeaderR);
+      this.hideIf(this.paneTopR);
+      this.hideIf(this.paneBottomR);
 
       if (this.freeze.hasFrozenRows) {
-        Utils.show(this.paneBottomL);
+        this.showIf(this.paneBottomL);
       } else {
-        Utils.hide(this.paneBottomR);
-        Utils.hide(this.paneBottomL);
+        this.hideIf(this.paneBottomR);
+        this.hideIf(this.paneBottomL);
       }
     }
   }
@@ -588,21 +598,27 @@ class ViewportMgr {
     this.viewportTopL.style.overflowX = (this.hasFrozenColumns()) ? (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll') : (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'hidden' : 'auto');
     this.viewportTopL.style.overflowY = (!this.hasFrozenColumns() && o.alwaysShowVerticalScroll) ? 'scroll' : ((this.hasFrozenColumns()) ? (hasFrozenRows ? 'hidden' : 'hidden') : (hasFrozenRows ? 'scroll' : 'auto'));
 
-    this.viewportTopR.style.overflowX = (this.hasFrozenColumns()) ? (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll') : (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'hidden' : 'auto');
-    this.viewportTopR.style.overflowY = o.alwaysShowVerticalScroll ? 'scroll' : ((this.hasFrozenColumns()) ? (hasFrozenRows ? 'scroll' : 'auto') : (hasFrozenRows ? 'scroll' : 'auto'));
+    if (this.viewportTopR) {
+      this.viewportTopR.style.overflowX = (this.hasFrozenColumns()) ? (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll') : (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'hidden' : 'auto');
+      this.viewportTopR.style.overflowY = o.alwaysShowVerticalScroll ? 'scroll' : ((this.hasFrozenColumns()) ? (hasFrozenRows ? 'scroll' : 'auto') : (hasFrozenRows ? 'scroll' : 'auto'));
+    }
 
-    this.viewportBottomL.style.overflowX = (this.hasFrozenColumns()) ? (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'scroll' : 'auto') : (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'auto' : 'auto');
-    this.viewportBottomL.style.overflowY = (!this.hasFrozenColumns() && o.alwaysShowVerticalScroll) ? 'scroll' : ((this.hasFrozenColumns()) ? (hasFrozenRows ? 'hidden' : 'hidden') : (hasFrozenRows ? 'scroll' : 'auto'));
+    if (this.viewportBottomL) {
+      this.viewportBottomL.style.overflowX = (this.hasFrozenColumns()) ? (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'scroll' : 'auto') : (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'auto' : 'auto');
+      this.viewportBottomL.style.overflowY = (!this.hasFrozenColumns() && o.alwaysShowVerticalScroll) ? 'scroll' : ((this.hasFrozenColumns()) ? (hasFrozenRows ? 'hidden' : 'hidden') : (hasFrozenRows ? 'scroll' : 'auto'));
+    }
 
-    this.viewportBottomR.style.overflowX = (this.hasFrozenColumns()) ? (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'scroll' : 'auto') : (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'auto' : 'auto');
-    this.viewportBottomR.style.overflowY = o.alwaysShowVerticalScroll ? 'scroll' : ((this.hasFrozenColumns()) ? (hasFrozenRows ? 'auto' : 'auto') : (hasFrozenRows ? 'auto' : 'auto'));
+    if (this.viewportBottomR) {
+      this.viewportBottomR.style.overflowX = (this.hasFrozenColumns()) ? (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'scroll' : 'auto') : (hasFrozenRows && !o.alwaysAllowHorizontalScroll ? 'auto' : 'auto');
+      this.viewportBottomR.style.overflowY = o.alwaysShowVerticalScroll ? 'scroll' : ((this.hasFrozenColumns()) ? (hasFrozenRows ? 'auto' : 'auto') : (hasFrozenRows ? 'auto' : 'auto'));
+    }
 
     if (o.viewportClass) {
       const viewportClassList = Utils.classNameToList(o.viewportClass);
-      this.viewportTopL.classList.add(...viewportClassList);
-      this.viewportTopR.classList.add(...viewportClassList);
-      this.viewportBottomL.classList.add(...viewportClassList);
-      this.viewportBottomR.classList.add(...viewportClassList);
+      // this.viewport only ever contains the elements that were actually built
+      this.viewport.forEach((view) => {
+        view.classList.add(...viewportClassList);
+      });
     }
   }
 
@@ -622,7 +638,9 @@ class ViewportMgr {
       Utils.width(this.canvasTopL, g.canvasWidthL);
 
       Utils.width(this.headerL, g.headersWidthL);
-      Utils.width(this.headerR, g.headersWidthR);
+      if (this.headerR) {
+        Utils.width(this.headerR, g.headersWidthR);
+      }
 
       if (this.hasFrozenColumns()) {
         Utils.width(this.canvasTopR, g.canvasWidthR);
@@ -688,11 +706,15 @@ class ViewportMgr {
     }
 
     Utils.width(this.headerRowSpacerL, g.canvasWidth + (g.viewportHasVScroll ? g.scrollbarWidth : 0));
-    Utils.width(this.headerRowSpacerR, g.canvasWidth + (g.viewportHasVScroll ? g.scrollbarWidth : 0));
+    if (this.headerRowSpacerR) {
+      Utils.width(this.headerRowSpacerR, g.canvasWidth + (g.viewportHasVScroll ? g.scrollbarWidth : 0));
+    }
 
     if (g.createFooterRow) {
       Utils.width(this.footerRowSpacerL, g.canvasWidth + (g.viewportHasVScroll ? g.scrollbarWidth : 0));
-      Utils.width(this.footerRowSpacerR, g.canvasWidth + (g.viewportHasVScroll ? g.scrollbarWidth : 0));
+      if (this.footerRowSpacerR) {
+        Utils.width(this.footerRowSpacerR, g.canvasWidth + (g.viewportHasVScroll ? g.scrollbarWidth : 0));
+      }
     }
   }
 
@@ -799,7 +821,9 @@ class ViewportMgr {
         }
       }
     } else {
-      Utils.height(this.viewportTopR, viewportTopH);
+      if (this.viewportTopR) {
+        Utils.height(this.viewportTopR, viewportTopH);
+      }
     }
 
     return { paneTopH, paneBottomH, viewportTopH, viewportBottomH };
@@ -1071,6 +1095,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     frozenColumn: -1,
     frozenRow: -1,
     frozenRightViewportMinWidth: 100,
+    lazyPanes: false,
     throwWhenFrozenNotAllViewable: false,
     fullWidthRows: false,
     multiColumnSort: false,
@@ -1573,7 +1598,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     });
 
     Utils.width(this._headerRowSpacerL, canvasWithScrollbarWidth);
-    Utils.width(this._headerRowSpacerR, canvasWithScrollbarWidth);
+    if (this._headerRowSpacerR) {
+      Utils.width(this._headerRowSpacerR, canvasWithScrollbarWidth);
+    }
 
     // footer Row
     if (this._options.createFooterRow) {
@@ -2465,7 +2492,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     });
 
     Utils.emptyElement(this._headerL);
-    Utils.emptyElement(this._headerR);
+    if (this._headerR) {
+      Utils.emptyElement(this._headerR);
+    }
 
     this.getHeadersWidth();
 
@@ -2487,7 +2516,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     });
 
     Utils.emptyElement(this._headerRowL);
-    Utils.emptyElement(this._headerRowR);
+    if (this._headerRowR) {
+      Utils.emptyElement(this._headerRowR);
+    }
 
     if (this._options.createFooterRow) {
       const footerRowLColumnElements = this._footerRowL.querySelectorAll('.slick-footerrow-column');
@@ -6566,7 +6597,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         }
       } else {
         Utils.height(this._canvasTopL, this.h);
-        Utils.height(this._canvasTopR, this.h);
+        if (this._canvasTopR) {
+          Utils.height(this._canvasTopR, this.h);
+        }
       }
 
       this.scrollTop = this._viewportScrollContainerY.scrollTop;


### PR DESCRIPTION
## Summary

Encapsulates all frozen rows/columns pane management behind an internal `ViewportMgr` class in `slick.grid.ts`, and adds an opt-in `lazyPanes` grid option. Stacked on #1229 (whose characterization spec is the first commit here and the safety net for the whole series).

**Phase 1 — construction.** `ViewportMgr` owns the building of the 6 panes / 4 viewports / 4 canvases and all per-pane chrome; the grid keeps aliases to every element. DOM byte-identical (proven by the dom-shape characterization spec). The class lives inside `slick.grid.ts` because the iife build emits one file per source — a new required file would break script-tag consumers.

**Phase 2 — behaviour absorption (8 milestones).** Pane selection (`paneCellIndex`), scroll-owner selection (ex `setScroller`), pane visibility/frozen classes/overflow, canvas-width distribution (ex `updateCanvasWidth`), pane-height distribution (ex `resizeCanvas`), row-to-canvas routing (ex `renderRows`), scroll synchronization (ex `scrollToX`/`_handleScroll`), frozen-row offset and band predicates, and column-side helpers (`isColumnRightOfFreeze`, `sideLocalColumnIdx`, `sideForColumn`). Grid-side frozen-flag branching went from 95 sites to 0 outside `setFrozenOptions` (the state owner). Historical asymmetries are preserved verbatim and documented at their new homes (e.g. the render-side band threshold differs by one row from the cell-lookup-side in the non-frozenBottom case; the `cleanUpCells` skip predicate's second disjunct is not guarded by `!frozenBottom`).

**Phase 3 — lazyPanes (opt-in, default off).** With `lazyPanes: true` and nothing frozen, the grid builds only the top-left pane set (2 panes / 1 viewport / 1 canvas). Enabling freezing later materializes the missing panes on the fly at their canonical sibling positions, wires their events, and re-anchors ancestor-scroll bindings. Un-freezing keeps the panes (hidden), matching historical behaviour. Default-mode DOM is unchanged.

Also fixed along the way: `destroy()` now clears the manager so the detached pane DOM is GC-eligible, and `getHeaderChildren()` no longer assumes two header containers.

## Testing

- New specs: `dom-shape-characterization.cy.ts` (16 tests pinning the historical DOM shape across all four freeze states), `dom-shape-lazy-panes.cy.ts` (7 tests, single-pane build), `viewportmgr-lazy-materialization.cy.ts` (6 tests, runtime freeze/unfreeze/refreeze from lazy state).
- Every commit in the series was landed only after the full Cypress suite passed locally, matching the pre-refactor baseline exactly.
- An adversarial line-by-line audit compared every `ViewportMgr` method against the pre-refactor original; the one real finding (destroy retention) is fixed in the series.
- Flake note: local full-suite runs on the development machine (Windows) showed a ~1-in-4 ambient flake in timing-sensitive tests — reproduced on pristine `master` (`example-0032-row-span-many-columns` failed there; the `example-excel-compatible-spreadsheet` native-clipboard paste race on this branch). Pre-existing, machine-level, unrelated to these changes; CI here is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
