### PR TITLE
chore(ci): bump cypress-io/github-action to v7 for Node 24 runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
         run: npm run serve:demo &
 
       - name: Run Cypress E2E tests
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           # wait-on: 'http://localhost:8080'
           browser: chrome


### PR DESCRIPTION
v6 still targets the Node 20 action runtime, which GitHub deprecated ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)) and now forces onto Node 24 with a warning annotation on every CI run. v7 (currently v7.4.1) is Node 24-native. This was the last action in the workflow still on the Node 20 runtime - checkout/cache/setup-node/upload-artifact are already on Node 24 majors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
