### PR TITLE
fix(examples): deterministic seeded data in checkbox-header-row example (fix flaky CI)

### DIFF
--- a/examples/example-checkbox-header-row.html
+++ b/examples/example-checkbox-header-row.html
@@ -236,12 +236,26 @@
     });
   }
 
+  // deterministic pseudo-random generator (mulberry32) so the grid data is identical on every
+  // load. The E2E tests assert exact column-filter and pagination outcomes (e.g. filtering "5"
+  // shows a single page); with Math.random() the match count varied run-to-run and those
+  // assertions flaked. A fixed seed keeps the data realistic-looking but reproducible.
+  function makeSeededRandom(seed) {
+    return function () {
+      seed |= 0; seed = (seed + 0x6D2B79F5) | 0;
+      var t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+
   document.addEventListener("DOMContentLoaded", function() {
+    var seededRandom = makeSeededRandom(12345);
     for (var i = 0; i < 150; i++) {
       var d = (data[i] = {});
       d["id"] = i + idOffset;
       for (var j = 0; j < columns.length; j++) {
-        d[j] = Math.round(Math.random() * 10);
+        d[j] = Math.round(seededRandom() * 10);
       }
     }
 


### PR DESCRIPTION
## Problem

`example-checkbox-header-row.cy.ts` flakes intermittently in CI with three failures that share one root cause:

- `filter data with text "5"… Select All` → times out waiting for pager `Showing page 1 of 1`
- `remove filter… same selected Ids` → `expected 0 to not equal 0`
- `revert back to the same filter…` → same pager timeout

With `testIsolation: false` the tests share state, so the middle failure is just the previous test aborting before it could select any rows. The real failure is the two tests that type `5` into a column filter and hard-assert the grid collapses to a single page.

## Root cause

The example builds its grid with `Math.round(Math.random() * 10)` on every load, and the spec asserts **exact** filter/pagination outcomes against that data. Filtering column A by `5` matches a random number of rows each run (mean ~15, observed range 2–32), so "shows a single page (≤ 25 rows)" is true most of the time but not always — a flake baked into the data. (An earlier test in the same file does the identical filter but asserts the page state *conditionally*, i.e. it was already written to tolerate this randomness; the two failing tests were not.)

## Fix

Generate the example data with a small fixed-seed PRNG (mulberry32) instead of `Math.random()`. The data still looks varied but is identical on every load; filtering `5` now matches exactly **11** rows → always one page. This removes the flake at its source and makes assertions on this example reproducible.

```diff
- for (var j = 0; j < columns.length; j++) {
-   d[j] = Math.round(Math.random() * 10);
- }
+ for (var j = 0; j < columns.length; j++) {
+   d[j] = Math.round(seededRandom() * 10);   // seededRandom = mulberry32(12345)
+ }
```

## Verification

- Deterministic match count confirmed (11 rows match `5` on the filtered column).
- Ran `example-checkbox-header-row.cy.ts` in Chrome **12 consecutive times — all green** (previously ~10–25% flaky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
