### PR TITLE
fix: align frozen-band cell-cleanup ranges with the (inclusive) render ranges

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -6638,12 +6638,15 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (this.hasFrozenRows) {
         const renderedFrozenRows = Utils.extend(true, {}, rendered);
 
+        // same INCLUSIVE bounds as the frozen renderRows ranges below — the previous
+        // dataLength / frozenRow bounds overshot by one, double-processing the first
+        // scrollable row (top mode) in both the frozen and the main pass
         if (this._options.frozenBottom) {
           renderedFrozenRows.top = this.actualFrozenRow;
-          renderedFrozenRows.bottom = this.getDataLength();
+          renderedFrozenRows.bottom = this.getDataLength() - 1;
         } else {
           renderedFrozenRows.top = 0;
-          renderedFrozenRows.bottom = this._options.frozenRow;
+          renderedFrozenRows.bottom = this._options.frozenRow! - 1;
         }
         this.cleanUpAndRenderCells(renderedFrozenRows);
       }

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -6638,9 +6638,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (this.hasFrozenRows) {
         const renderedFrozenRows = Utils.extend(true, {}, rendered);
 
-        // same INCLUSIVE bounds as the frozen renderRows ranges below — the previous
-        // dataLength / frozenRow bounds overshot by one, double-processing the first
-        // scrollable row (top mode) in both the frozen and the main pass
         if (this._options.frozenBottom) {
           renderedFrozenRows.top = this.actualFrozenRow;
           renderedFrozenRows.bottom = this.getDataLength() - 1;


### PR DESCRIPTION
## The bug

`render()`'s frozen-band `cleanUpAndRenderCells` ranges used `bottom = getDataLength()` (frozenBottom) / `frozenRow` (top mode), while the frozen `renderRows` ranges directly below use `getDataLength() - 1` / `frozenRow - 1`. Both are consumed as **inclusive** row ranges, so the cleanup pass overshot by one row: in top mode the first *scrollable* row (index `frozenRow`) was processed by both the frozen pass and the main pass of the same `render()` call. (In bottom mode the overshoot index equals `getDataLength()`, which is never cached, so it was skipped.)

## The fix

Two-token change aligning the cleanup bounds with the render bounds, so the invariant *cleanup range == render range* actually holds.

## Why no new test

There is **no user-observable effect to pin**: the double-processed boundary row's cleanup and render are idempotent within a single `render()` call, so pre-fix and post-fix DOM are identical — this removes redundant work and a latent correctness hazard, not a visible symptom. A 'repro' test would pass on both sides and be worthless. Non-regression is covered by the existing frozen-row suites (ran frozen-rows / frozen-columns-and-rows / frozen spreadsheet locally, 22/22 green).

(Part of the quirks-triage series: #1255, #1256, #1257, #1258.)