### PR TITLE
chore: exclude dist from tsconfig so build:types works against an existing dist

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,6 @@
       "./node_modules/@types"
     ]
   },
-  "exclude": ["cypress", "node_modules", "**/*.spec.ts"],
+  "exclude": ["cypress", "dist", "node_modules", "**/*.spec.ts"],
   "include": ["**/*.ts", "index.d.ts", "**/*.d.ts"]
 }


### PR DESCRIPTION
One-word change to `exclude`, so that `npm run build:types` works against an existing `dist`.

### The problem

```json
"exclude": ["cypress", "node_modules", "**/*.spec.ts"],
"include": ["**/*.ts", "index.d.ts", "**/*.d.ts"]
```

There is no `dist` exclusion, so previously emitted `dist/types/*.d.ts` files are read back as **inputs**. Running the types build against a populated `dist` fails with 114 errors:

```
error TS5055: Cannot write file '.../dist/types/slick.grid.d.ts' because it would overwrite input file.
```

This is invisible in CI because `prebuild:prod` runs `remove dist` first, so `npm run build:prod` always starts from an empty `dist`. But `npm run build:types` on its own — the normal case when rebuilding locally — fails every time unless you manually delete `dist/types` and `dist/tsconfig.tsbuildinfo` first.

### The change

```diff
-  "exclude": ["cypress", "node_modules", "**/*.spec.ts"],
+  "exclude": ["cypress", "dist", "node_modules", "**/*.spec.ts"],
```

This scopes compilation to `src`, which is all that was ever intended. There are **no `.ts` or `.d.ts` files anywhere outside `src`, `dist`, `cypress` and `node_modules`**, so the `"**/*.d.ts"` entry in `include` was only ever matching `dist` — excluding it removes exactly the unwanted inputs and nothing else. (For the same reason the `"index.d.ts"` entry matches nothing; I left it alone rather than widen this PR.)

### Verification

- `npm run build:types` now succeeds **twice in a row** against a fully populated `dist` — no manual cleanup step.
- `tsc --noEmit` and `eslint` stay clean.
- `dist/types` emits the same **228** files, none missing.
- **The esbuild bundles are byte-identical with and without the change.** I confirmed this rather than assuming it: reverted the tsconfig, rebuilt, and compared hashes of `dist/browser/slick.grid.js`, `dist/cjs/index.js` and `dist/esm/index.mjs` — all three match. esbuild reads only `compilerOptions`.
- Full Cypress suite: **645 tests, 641 passing, 2 pending**. The 2 failures were `example-optimizing-updates` (its wall-clock assertion, `expected 1459 to be below 874`) and an `example-plugin-contextmenu` 4s element timeout — both load-sensitive, and both pass on a clean re-run (42/42).
- `cypress/tsconfig.json` is standalone and does not extend this config, so it is unaffected.

### Out of scope, but related

`node ./scripts/builds.mjs --prod` currently dies at its last step, `copySassFiles()`, with `TypeError: paths.pop is not a function` whenever the installed `native-copyfiles` is v1 while `package.json` declares `^2.0.3` (v2 changed the signature to take an array). That crash sits one line above the `npm run build:types` call in `runProdBuildWithTypes()`, so **the types step never runs** and `dist/types` is silently never produced. That one needs a dependency refresh rather than a config change, so I have not touched it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
