### PR TITLE
fix: treat frozenRow: 0 as no freeze (input clamp)

### DIFF
--- a/cypress/e2e/quirk-frozen-row-zero.cy.ts
+++ b/cypress/e2e/quirk-frozen-row-zero.cy.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression test for the frozenRow: 0 degenerate configuration.
+ *
+ * frozenRow is a COUNT, but setFrozenOptions gated on `frozenRow > -1`, so
+ * frozenRow: 0 activated the full frozen-row machinery around an EMPTY band:
+ * hasFrozenRows true, split panes shown (a visible empty band strip), and — since
+ * actualFrozenRow computed to 0 — every row routed to the BOTTOM canvas in top
+ * mode. With frozenBottom: true, actualFrozenRow = dataLength and the whole body
+ * rendered in the top canvas while bottom-mode offset math measured it.
+ *
+ * The fix clamps at the source: `frozenRow > 0`. Zero frozen rows IS no freeze.
+ *
+ * The spec is SELF-HOSTING: the two-grid harness (frozenRow: 0 top variant +
+ * frozenRow: 0 with frozenBottom) is served from this file via cy.intercept (no
+ * page is added to examples/). It asserts both grids behave exactly like unfrozen
+ * grids: all rows in the top canvas, no bottom pane visible. Verified to FAIL
+ * pre-fix (grid A renders every row in the bottom canvas; both show the bottom
+ * pane) and PASS with the fix.
+ */
+
+const harnessHtml = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Harness: frozenRow zero clamp</title>
+  <link rel="stylesheet" href="/dist/styles/css/slick-alpine-theme.css"/>
+  <style> .g { width: 700px; height: 220px; } </style>
+</head>
+<body>
+<div id="gridA" class="g"></div>
+<div id="gridB" class="g"></div>
+<div id="checkResults" style="white-space:pre; font-family:monospace;"></div>
+<script src="/dist/browser/slick.core.js"></script>
+<script src="/dist/browser/slick.interactions.js"></script>
+<script src="/dist/browser/slick.grid.js"></script>
+<script>
+  var columns = [
+    { id: 'id', name: '#', field: 'id', width: 80 },
+    { id: 'a', name: 'A', field: 'a', width: 200 },
+    { id: 'b', name: 'B', field: 'b', width: 200 }
+  ];
+  function makeData() {
+    var d = [];
+    for (var i = 0; i < 12; i++) { d.push({ id: i, a: 'a' + i, b: 'b' + i }); }
+    return d;
+  }
+  var base = { enableCellNavigation: true, enableColumnReorder: false, rowHeight: 25 };
+  function cols() { return columns.map(function (c) { return Object.assign({}, c); }); }
+
+  // Grid A: frozenRow: 0 (top variant) — must behave exactly like an unfrozen grid
+  var gridA = new Slick.Grid('#gridA', makeData(), cols(), Object.assign({ frozenRow: 0 }, base));
+  // Grid B: frozenRow: 0 + frozenBottom: true — same
+  var gridB = new Slick.Grid('#gridB', makeData(), cols(), Object.assign({ frozenRow: 0, frozenBottom: true }, base));
+  window.gridA = gridA; window.gridB = gridB;
+
+  function isVisible(el) {
+    return !!el && el.offsetParent !== null && el.offsetHeight > 0;
+  }
+  function stateOf(container) {
+    var topRows = document.querySelectorAll(container + ' .grid-canvas-top .slick-row').length;
+    var bottomRows = document.querySelectorAll(container + ' .grid-canvas-bottom .slick-row').length;
+    var bottomPane = document.querySelector(container + ' .slick-pane-bottom');
+    return { topRows: topRows, bottomRows: bottomRows, bottomPaneVisible: isVisible(bottomPane) };
+  }
+
+  window.runChecks = function runChecks() {
+    var out = [], pass = true;
+    function check(label, ok, detail) {
+      out.push((ok ? 'PASS ' : 'FAIL ') + label + (detail ? '  [' + detail + ']' : ''));
+      if (!ok) { pass = false; }
+    }
+
+    var a = stateOf('#gridA');
+    check('A (frozenRow: 0): rows render in the top canvas, none in the bottom',
+      a.topRows > 0 && a.bottomRows === 0, 'top=' + a.topRows + ' bottom=' + a.bottomRows);
+    check('A (frozenRow: 0): no bottom pane is shown', !a.bottomPaneVisible, 'visible=' + a.bottomPaneVisible);
+
+    var b = stateOf('#gridB');
+    check('B (frozenRow: 0 + frozenBottom): rows render in the top canvas, none in the bottom',
+      b.topRows > 0 && b.bottomRows === 0, 'top=' + b.topRows + ' bottom=' + b.bottomRows);
+    check('B (frozenRow: 0 + frozenBottom): no bottom pane is shown', !b.bottomPaneVisible, 'visible=' + b.bottomPaneVisible);
+
+    out.push(pass ? '\\nALL CHECKS PASSED' : '\\nCHECKS FAILED');
+    document.getElementById('checkResults').textContent = out.join('\\n');
+    return pass;
+  };
+</script>
+</body>
+</html>`;
+
+describe('Quirk - frozenRow: 0 must mean no freeze', { retries: 1 }, () => {
+  it('should behave exactly like an unfrozen grid in both frozenRow: 0 variants', () => {
+    cy.intercept('GET', '/quirk-frozen-row-zero-harness.html', {
+      headers: { 'content-type': 'text/html' },
+      body: harnessHtml,
+    });
+    cy.visit(`${Cypress.config('baseUrl')}/quirk-frozen-row-zero-harness.html`);
+    cy.window().its('gridA').should('exist');
+    cy.window().its('gridB').should('exist');
+
+    cy.window().then((win: any) => {
+      const ok = win.runChecks();
+      const detail = win.document.getElementById('checkResults').textContent;
+      expect(ok, `in-page frozenRow: 0 self-checks:\n${detail}`).to.eq(true);
+    });
+    cy.get('#checkResults').should('contain', 'ALL CHECKS PASSED');
+  });
+});

--- a/examples/example-quirk-frozen-row-zero.html
+++ b/examples/example-quirk-frozen-row-zero.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<!--
+  TEMPORARY repro page for the frozenRow: 0 degenerate configuration.
+  DO NOT MERGE — this page is for human review only and is deleted before merge.
+  The permanent regression test is cypress/e2e/quirk-frozen-row-zero.cy.ts, which
+  is fully self-hosting and does NOT depend on this page.
+
+  Bug (pre-fix): frozenRow is a COUNT, but setFrozenOptions gated on > -1, so
+  frozenRow: 0 activated the full frozen-row machinery around an EMPTY band.
+  On a pre-fix build this page shows: grid A rendering every row in the BOTTOM
+  canvas below a visible empty band strip, and grid B (frozenBottom variant)
+  showing an empty bottom pane strip below the body. On a fixed build both grids
+  are indistinguishable from the unfrozen control grid C.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>SlickGrid quirk repro: frozenRow 0 (temporary, do not merge)</title>
+  <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css"/>
+  <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css"/>
+  <style> .g { width: 700px; height: 200px; } h3 { margin: 12px 0 4px 0; } </style>
+</head>
+<body>
+<h2>frozenRow: 0 — degenerate empty frozen band (TEMPORARY repro, do not merge)</h2>
+<div style="width:700px;">
+  <h3>Grid A — <code>frozenRow: 0</code></h3>
+  <div id="gridA" class="g"></div>
+  <h3>Grid B — <code>frozenRow: 0, frozenBottom: true</code></h3>
+  <div id="gridB" class="g"></div>
+  <h3>Grid C — control (no freeze options)</h3>
+  <div id="gridC" class="g"></div>
+  <button onclick="report()">Report row placement</button>
+  <div id="readout" style="white-space:pre; font-family:monospace; font-size:12px; margin-top:8px;"></div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
+<script src="sortable-cdn-fallback.js"></script>
+
+<script src="../dist/browser/slick.core.js"></script>
+<script src="../dist/browser/slick.interactions.js"></script>
+<script src="../dist/browser/slick.grid.js"></script>
+<script>
+  var columns = [
+    { id: 'id', name: '#', field: 'id', width: 80 },
+    { id: 'a', name: 'A', field: 'a', width: 200 },
+    { id: 'b', name: 'B', field: 'b', width: 200 }
+  ];
+  function makeData() {
+    var d = [];
+    for (var i = 0; i < 12; i++) { d.push({ id: i, a: 'a' + i, b: 'b' + i }); }
+    return d;
+  }
+  var base = { enableCellNavigation: true, enableColumnReorder: false, rowHeight: 25 };
+  function cols() { return columns.map(function (c) { return Object.assign({}, c); }); }
+
+  var gridA = new Slick.Grid('#gridA', makeData(), cols(), Object.assign({ frozenRow: 0 }, base));
+  var gridB = new Slick.Grid('#gridB', makeData(), cols(), Object.assign({ frozenRow: 0, frozenBottom: true }, base));
+  var gridC = new Slick.Grid('#gridC', makeData(), cols(), Object.assign({}, base));
+
+  function report() {
+    function line(name, sel) {
+      var top = document.querySelectorAll(sel + ' .grid-canvas-top .slick-row').length;
+      var bottom = document.querySelectorAll(sel + ' .grid-canvas-bottom .slick-row').length;
+      var pane = document.querySelector(sel + ' .slick-pane-bottom');
+      var paneVisible = !!pane && pane.offsetParent !== null && pane.offsetHeight > 0;
+      return name + ': rows in top canvas=' + top + ', bottom canvas=' + bottom + ', bottom pane visible=' + paneVisible;
+    }
+    document.getElementById('readout').textContent = [
+      line('A (frozenRow 0)        ', '#gridA'),
+      line('B (frozenRow 0, bottom)', '#gridB'),
+      line('C (control)            ', '#gridC'),
+      '',
+      'Fixed build: A and B match C. Pre-fix build: A has all rows in the bottom canvas;',
+      'A and B show a visible bottom pane.'
+    ].join('\n');
+  }
+</script>
+</body>
+</html>

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -2350,7 +2350,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       ? parseInt(this._options.frozenColumn as unknown as string, 10)
       : -1;
 
-    if (this._options.frozenRow! > -1) {
+    // frozenRow is a COUNT: zero frozen rows means no freeze. (Previously the
+    // > -1 gate let frozenRow: 0 activate the full split-pane machinery around an
+    // empty frozen band — visible empty pane strip, all rows routed to the bottom
+    // canvas in top mode, and with frozenBottom the body measured by bottom-mode
+    // offset math. Nothing meaningful is lost: zero pinned rows IS no freeze.)
+    if (this._options.frozenRow! > 0) {
       this.hasFrozenRows = true;
       const dataLength = this.getDataLength();
       this.actualFrozenRow = (this._options.frozenBottom)

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -2350,11 +2350,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       ? parseInt(this._options.frozenColumn as unknown as string, 10)
       : -1;
 
-    // frozenRow is a COUNT: zero frozen rows means no freeze. (Previously the
-    // > -1 gate let frozenRow: 0 activate the full split-pane machinery around an
-    // empty frozen band — visible empty pane strip, all rows routed to the bottom
-    // canvas in top mode, and with frozenBottom the body measured by bottom-mode
-    // offset math. Nothing meaningful is lost: zero pinned rows IS no freeze.)
     if (this._options.frozenRow! > 0) {
       this.hasFrozenRows = true;
       const dataLength = this.getDataLength();


### PR DESCRIPTION
## The bug (Q23/Q24 in discussion #1247)

`frozenRow` is a **count**, but `setFrozenOptions` gated on `frozenRow > -1`, so `frozenRow: 0` activated the full frozen-row machinery around an **empty band**:

- `hasFrozenRows = true`, split panes shown — a visible empty band strip;
- `actualFrozenRow` computed to `0`, so **every row rendered in the bottom canvas** in top mode;
- with `frozenBottom: true`, `actualFrozenRow = dataLength` — the whole body rendered in the top canvas while bottom-mode offset math measured it (the degenerate case behind several downstream contortions).

## The fix

One-line clamp: the gate is now `frozenRow > 0`. Zero pinned rows **is** no freeze. A repo-wide grep (examples/, cypress/, src/) confirms nothing passes `frozenRow: 0` today, so no exercised behavior changes.

## Repro

`new Slick.Grid('#c', data, cols, { frozenRow: 0 })` → pre-fix: all rows live in `.grid-canvas-bottom` under a visible empty band; post-fix: identical to an unfrozen grid.

## Test

`cypress/e2e/quirk-frozen-row-zero.cy.ts` — **self-hosting** (the two-variant harness is served from within the spec via `cy.intercept`; the spec does not depend on any example page). Asserts both `frozenRow: 0` variants are observably identical to an unfrozen grid (all rows in the top canvas, no bottom pane visible). Verified to **fail pre-fix** (`top=0 bottom=12`, phantom panes visible) **and pass with the fix**; frozen suites ran green as a regression gate.

## ⚠️ Temporary example page

`examples/example-quirk-frozen-row-zero.html` is a human-review repro (three grids: both variants + an unfrozen control) **intended to be deleted before merge**. The cypress test is fully independent of it.

(Part of the quirks-triage series — remaining-items wave: see discussion #1247.)