### PR TITLE
fix: route off-viewport alwaysRenderColumn cells to their own column band

### DIFF
--- a/cypress/e2e/quirk-always-render-column-routing.cy.ts
+++ b/cypress/e2e/quirk-always-render-column-routing.cy.ts
@@ -1,0 +1,124 @@
+/**
+ * Regression test for off-viewport alwaysRenderColumn band routing.
+ *
+ * appendRowHtml has two cell-routing branches. The in-viewport branch routes by
+ * column band (left fragment vs right fragment under a left freeze). The
+ * OFF-VIEWPORT branch — taken when a column has scrolled out past the LEFT edge —
+ * appended alwaysRenderColumn cells to the left fragment unconditionally. So an
+ * alwaysRenderColumn column sitting RIGHT of the freeze rendered its off-viewport
+ * cells into the clipped LEFT canvas: mispositioned/invisible, and its
+ * cellNodesByColumnIdx entry mapped to a node in the wrong pane (editors, plugins
+ * and getCellNode all consume that mapping).
+ *
+ * The spec is SELF-HOSTING: the harness is served from this file via cy.intercept
+ * (no page is added to examples/). It freezes column 0, marks a middle scrollable
+ * column alwaysRenderColumn, scrolls it off the left edge via the grid API, and
+ * asserts the cell node lives in the RIGHT canvas. Verified to FAIL pre-fix
+ * (node parented in .grid-canvas-left) and PASS with the fix.
+ */
+
+const ARC_COL = 5; // the alwaysRenderColumn column index (right of the freeze)
+
+const harnessHtml = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Harness: alwaysRenderColumn band routing</title>
+  <link rel="stylesheet" href="/dist/styles/css/slick-alpine-theme.css"/>
+  <style> #myGrid { width: 700px; height: 300px; } </style>
+</head>
+<body>
+<div id="myGrid"></div>
+<div id="checkResults" style="white-space:pre; font-family:monospace;"></div>
+<script src="/dist/browser/slick.core.js"></script>
+<script src="/dist/browser/slick.interactions.js"></script>
+<script src="/dist/browser/slick.grid.js"></script>
+<script>
+  var COLS = 30, ROWS = 100, ARC = ${ARC_COL};
+  var columns = [];
+  for (var c = 0; c < COLS; c++) {
+    columns.push({ id: 'c' + c, name: 'Col ' + c, field: 'c' + c, width: 100, alwaysRenderColumn: c === ARC });
+  }
+  var data = [];
+  for (var r = 0; r < ROWS; r++) {
+    var row = {};
+    for (var k = 0; k < COLS; k++) { row['c' + k] = 'r' + r + 'c' + k; }
+    data.push(row);
+  }
+  var grid = new Slick.Grid('#myGrid', data, columns, {
+    enableCellNavigation: true,
+    enableColumnReorder: false,
+    frozenColumn: 0,          // column 0 frozen-left; ARC (index ${ARC_COL}) is in the RIGHT band
+    rowHeight: 25
+  });
+  window.grid = grid;
+
+  window.runChecks = function runChecks() {
+    var out = [], pass = true;
+    function check(label, ok, detail) {
+      out.push((ok ? 'PASS ' : 'FAIL ') + label + (detail ? '  [' + detail + ']' : ''));
+      if (!ok) { pass = false; }
+    }
+
+    // the CALLER scrolls and lets the async scroll handler settle before invoking
+    // this (the grid's cached scrollLeft updates in the scroll handler, not
+    // synchronously in scrollCellIntoView) — here we only assert
+    var node = grid.getCellNode(80, ARC);
+    check('alwaysRenderColumn cell renders on a freshly-scrolled-in row', !!node, node ? 'present' : 'missing');
+    if (node) {
+      var canvas = node.closest('.grid-canvas');
+      var inRight = !!canvas && canvas.classList.contains('grid-canvas-right');
+      check('off-viewport alwaysRenderColumn cell lives in the RIGHT canvas (its own band)',
+        inRight, 'canvas=' + (canvas ? canvas.className : 'none'));
+    }
+
+    // control: the frozen-left column (index 0) of the same fresh row stays LEFT
+    var frozenNode = grid.getCellNode(80, 0);
+    var frozenCanvas = frozenNode && frozenNode.closest('.grid-canvas');
+    check('control: frozen-left column cell stays in the LEFT canvas',
+      !!frozenCanvas && frozenCanvas.classList.contains('grid-canvas-left'),
+      'canvas=' + (frozenCanvas ? frozenCanvas.className : 'none'));
+
+    out.push(pass ? '\\nALL CHECKS PASSED' : '\\nCHECKS FAILED');
+    document.getElementById('checkResults').textContent = out.join('\\n');
+    return pass;
+  };
+</script>
+</body>
+</html>`;
+
+describe('Quirk - off-viewport alwaysRenderColumn cells must render in their own column band', { retries: 1 }, () => {
+  it('should keep the always-rendered right-band cell in the right canvas when scrolled off-left', () => {
+    cy.intercept('GET', '/quirk-always-render-column-harness.html', {
+      headers: { 'content-type': 'text/html' },
+      body: harnessHtml,
+    });
+    cy.visit(`${Cypress.config('baseUrl')}/quirk-always-render-column-harness.html`);
+    cy.window().its('grid').should('exist');
+
+    // TWO-STEP scroll, settling between steps. Step 1 scrolls far RIGHT on an
+    // already-rendered row (the async scroll handler then updates the cached
+    // horizontal range). Step 2 scrolls DOWN to row 80 — never rendered at load —
+    // so it renders FRESH while column ARC sits off past the LEFT edge: exactly
+    // the off-viewport append branch under test. (A single combined
+    // scrollCellIntoView(80, 29) does NOT repro: it scrolls vertically first and
+    // renders the fresh row synchronously while scrollLeft is still 0, routing
+    // the cell in-viewport; cleanUpCells then deliberately never removes
+    // alwaysRenderColumn cells, so that correct node persists.)
+    cy.window().then((win: any) => {
+      win.grid.scrollCellIntoView(0, 29);   // horizontal first, on a rendered row
+    });
+    cy.wait(200);                            // let the scroll handler re-render
+    cy.window().then((win: any) => {
+      win.grid.scrollCellIntoView(80, 29);  // now the fresh vertical render happens far-right
+    });
+    cy.wait(200);
+    cy.window().then((win: any) => {
+      win.grid.render();
+      const ok = win.runChecks();
+      const detail = win.document.getElementById('checkResults').textContent;
+      expect(ok, `in-page band-routing self-checks:\n${detail}`).to.eq(true);
+    });
+    cy.get('#checkResults').should('contain', 'ALL CHECKS PASSED');
+  });
+});

--- a/examples/example-quirk-always-render-column-routing.html
+++ b/examples/example-quirk-always-render-column-routing.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<!--
+  TEMPORARY repro page for the off-viewport alwaysRenderColumn band-routing bug.
+  DO NOT MERGE — this page is for human review only and is deleted before merge.
+  The permanent regression test is
+  cypress/e2e/quirk-always-render-column-routing.cy.ts, which is fully
+  self-hosting and does NOT depend on this page.
+
+  Bug (pre-fix): appendRowHtml's off-viewport branch appended alwaysRenderColumn
+  cells to the LEFT row fragment unconditionally. With frozen columns, an
+  alwaysRenderColumn column RIGHT of the freeze that scrolls off the left edge
+  therefore rendered into the clipped LEFT canvas — mispositioned/invisible, and
+  its cell-node mapping pointed at the wrong pane.
+
+  On this page: column 0 is frozen; "Sticky" (column 5, highlighted) is
+  alwaysRenderColumn in the scrollable band. Click "Scroll far right" then
+  "Report" — a pre-fix build reports the Sticky cell inside .grid-canvas-left;
+  a fixed build reports .grid-canvas-right.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>SlickGrid quirk repro: alwaysRenderColumn routing (temporary, do not merge)</title>
+  <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css"/>
+  <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css"/>
+  <style>
+    #myGrid { width: 700px; height: 300px; }
+    .sticky-col { background: #fff3c4; }
+  </style>
+</head>
+<body>
+<h2>Off-viewport <code>alwaysRenderColumn</code> band routing (TEMPORARY repro, do not merge)</h2>
+<div style="width:700px;">
+  <div id="myGrid"></div>
+  <button onclick="stepOne()">1. Scroll far right (settles range)</button>
+  <button onclick="stepTwo()">2. Then scroll down to fresh row 80</button>
+  <button onclick="report()">3. Report Sticky cell canvas</button>
+  <div id="readout" style="white-space:pre; font-family:monospace; font-size:12px; margin-top:8px;"></div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
+<script src="sortable-cdn-fallback.js"></script>
+
+<script src="../dist/browser/slick.core.js"></script>
+<script src="../dist/browser/slick.interactions.js"></script>
+<script src="../dist/browser/slick.grid.js"></script>
+<script>
+  var COLS = 30, ROWS = 100, ARC = 5;
+  var columns = [];
+  for (var c = 0; c < COLS; c++) {
+    columns.push({
+      id: 'c' + c,
+      name: c === ARC ? 'Sticky' : 'Col ' + c,
+      field: 'c' + c,
+      width: 100,
+      alwaysRenderColumn: c === ARC,
+      cssClass: c === ARC ? 'sticky-col' : undefined
+    });
+  }
+  var data = [];
+  for (var r = 0; r < ROWS; r++) {
+    var row = {};
+    for (var k = 0; k < COLS; k++) { row['c' + k] = 'r' + r + 'c' + k; }
+    data.push(row);
+  }
+  var grid = new Slick.Grid('#myGrid', data, columns, {
+    enableCellNavigation: true,
+    enableColumnReorder: false,
+    frozenColumn: 0,
+    rowHeight: 25
+  });
+
+  // the repro needs TWO steps: horizontal scroll must SETTLE (async handler)
+  // before a fresh row renders, else the row renders while scrollLeft is 0 and
+  // the cell routes in-viewport (and cleanUpCells never removes ARC cells)
+  function stepOne() { grid.scrollCellIntoView(0, 29); }
+  function stepTwo() { grid.scrollCellIntoView(80, 29); grid.render(); }
+
+  function report() {
+    var node = grid.getCellNode(80, ARC);
+    var canvas = node && node.closest('.grid-canvas');
+    document.getElementById('readout').textContent = !node
+      ? 'Sticky cell (row 80) is NOT rendered'
+      : 'Sticky cell (row 80) lives in: ' + (canvas ? canvas.className : '(no canvas)') + '\n'
+        + 'Fixed build: grid-canvas-right (its own band). Pre-fix build after scrolling right: grid-canvas-left (wrong, clipped).';
+  }
+</script>
+</body>
+</html>

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -5427,10 +5427,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           this.appendCellHtml(targetedRowDiv, row, i, ncolspan, rowspan, columnData, d);
         }
       } else if (m.alwaysRenderColumn || (this.hasFrozenColumns() && i <= this._options.frozenColumn!)) {
-        // route by column band like the in-viewport branch above: an off-viewport
-        // alwaysRenderColumn cell RIGHT of the freeze must render into the right
-        // fragment — appending it to rowDiv put it in the clipped left canvas and
-        // mapped its cellNodesByColumnIdx entry to the wrong pane
         const targetedRowDiv = (this.hasFrozenColumns() && (i > this._options.frozenColumn!) ? rowDivR! : rowDiv);
         this.appendCellHtml(targetedRowDiv, row, i, ncolspan, rowspan, columnData, d);
       }

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -5427,7 +5427,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           this.appendCellHtml(targetedRowDiv, row, i, ncolspan, rowspan, columnData, d);
         }
       } else if (m.alwaysRenderColumn || (this.hasFrozenColumns() && i <= this._options.frozenColumn!)) {
-        this.appendCellHtml(rowDiv, row, i, ncolspan, rowspan, columnData, d);
+        // route by column band like the in-viewport branch above: an off-viewport
+        // alwaysRenderColumn cell RIGHT of the freeze must render into the right
+        // fragment — appending it to rowDiv put it in the clipped left canvas and
+        // mapped its cellNodesByColumnIdx entry to the wrong pane
+        const targetedRowDiv = (this.hasFrozenColumns() && (i > this._options.frozenColumn!) ? rowDivR! : rowDiv);
+        this.appendCellHtml(targetedRowDiv, row, i, ncolspan, rowspan, columnData, d);
       }
 
       if (ncolspan > 1) {


### PR DESCRIPTION
## The bug (Q4 in discussion #1247)

`appendRowHtml` has two cell-routing branches. The in-viewport branch routes by column band. The **off-viewport** branch — taken when a column has scrolled out past the left edge — appended `alwaysRenderColumn` cells to the left fragment unconditionally:

```ts
} else if (m.alwaysRenderColumn || (this.hasFrozenColumns() && i <= this._options.frozenColumn!)) {
  this.appendCellHtml(rowDiv, row, i, …);   // LEFT fragment — wrong for a right-band column
}
```

So an `alwaysRenderColumn` column **right of the freeze** (e.g. an action/checkbox column at the right edge of a frozen grid) rendered its off-viewport cells into the clipped **left** canvas: mispositioned/invisible, and — worse — its `cellNodesByColumnIdx` entry mapped to a node in the wrong pane, which `getCellNode`, editors and plugins all consume.

## The fix

The off-viewport branch now uses the same band pick as the in-viewport branch. Left-frozen and plain-grid cells keep landing in the left fragment exactly as before — the change is strictly narrowing.

## Repro subtlety (worth knowing for review)

The misroute only manifests on a row rendered **fresh while the horizontal position is already far-right**: a combined `scrollCellIntoView(row, col)` scrolls vertically first (synchronously, while the cached `scrollLeft` is still stale) so the fresh row routes in-viewport — and `cleanUpCells` deliberately never removes `alwaysRenderColumn` cells, so already-rendered rows never repro. Discovered while validating the spec; the test therefore scrolls horizontally, lets the async scroll handler settle, then scrolls a never-rendered row in.

## Test

`cypress/e2e/quirk-always-render-column-routing.cy.ts` — **self-hosting** (harness served from within the spec via `cy.intercept`; no dependency on any example page), with a frozen-left control cell. Verified to **fail pre-fix** (`canvas=grid-canvas-left`) **and pass with the fix**; frozen + rowspan + checkbox suites ran 75/75 as a regression gate.

## ⚠️ Temporary example page

`examples/example-quirk-always-render-column-routing.html` is a human-review repro (highlighted "Sticky" column, three-step buttons mirroring the settle-then-fresh-render recipe) **intended to be deleted before merge**. The cypress test is fully independent of it.

(Part of the quirks-triage series — remaining-items wave: see discussion #1247; sibling PR #1266.)