### PR TITLE
fix: canonicalize the frozen-row boundary across all comparison sites

### DIFF
--- a/cypress/e2e/quirk-frozen-row-boundary.cy.ts
+++ b/cypress/e2e/quirk-frozen-row-boundary.cy.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression test for frozen-row boundary canonicalization.
+ *
+ * The row-band boundary was compared differently at six sites, and they
+ * contradicted each other and the render split (rows >= actualFrozenRow go to the
+ * bottom canvas):
+ * - appendRowHtml classed rows 'frozen' via `row <= frozenRow` (a COUNT compare):
+ *   wrong rows classed in bottom mode, off-by-one in top mode;
+ * - cleanupRows/cleanUpCells exempted `<= actualFrozenRow`, sparing the first
+ *   SCROLLABLE row from eviction/cleanup in top mode;
+ * - getCanvasNode/getViewportNode classified with `>= actualFrozenRow + 1` in top
+ *   mode, returning the TOP pane for a row whose DOM lives in the BOTTOM canvas;
+ * - scrollRowIntoView used `actualFrozenRow - 1` boundaries, refusing to scroll
+ *   the LAST scrollable row in bottom mode.
+ *
+ * All sites now route through two predicates that match the render split:
+ * isBottomBandRow (>= actualFrozenRow) and isFrozenRowIdx (frozenBottom ?
+ * >= actualFrozenRow : < actualFrozenRow).
+ *
+ * The spec is SELF-HOSTING (harness served via cy.intercept; no example page).
+ * Each check pins one drifted site. Verified to FAIL pre-fix on every drifted
+ * site and PASS with the fix.
+ */
+
+const harnessHtml = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Harness: frozen-row boundary</title>
+  <link rel="stylesheet" href="/dist/styles/css/slick-alpine-theme.css"/>
+  <style> .g { width: 700px; height: 300px; } </style>
+</head>
+<body>
+<div id="gridA" class="g"></div>
+<div id="gridB" class="g"></div>
+<div id="checkResults" style="white-space:pre; font-family:monospace;"></div>
+<script src="/dist/browser/slick.core.js"></script>
+<script src="/dist/browser/slick.interactions.js"></script>
+<script src="/dist/browser/slick.grid.js"></script>
+<script>
+  var ROWS = 1000, FR = 3;
+  var columns = [
+    { id: 'id', name: '#', field: 'id', width: 80 },
+    { id: 'a', name: 'A', field: 'a', width: 200 },
+    { id: 'b', name: 'B', field: 'b', width: 200 }
+  ];
+  function makeData() {
+    var d = [];
+    for (var i = 0; i < ROWS; i++) { d.push({ id: i, a: 'a' + i, b: 'b' + i }); }
+    return d;
+  }
+  var base = { enableCellNavigation: true, enableColumnReorder: false, rowHeight: 25 };
+  function cols() { return columns.map(function (c) { return Object.assign({}, c); }); }
+
+  // Grid A: 3 frozen TOP rows -> actualFrozenRow = 3; first scrollable row = 3
+  var gridA = new Slick.Grid('#gridA', makeData(), cols(), Object.assign({ frozenRow: FR }, base));
+  // Grid B: 3 frozen BOTTOM rows -> actualFrozenRow = 997; last scrollable row = 996
+  var gridB = new Slick.Grid('#gridB', makeData(), cols(), Object.assign({ frozenRow: FR, frozenBottom: true }, base));
+  window.gridA = gridA; window.gridB = gridB;
+
+  function frozenClassedRows(container) {
+    var out = [];
+    document.querySelectorAll(container + ' .slick-row.frozen').forEach(function (r) { out.push(parseInt(r.dataset.row, 10)); });
+    out.sort(function (a, b) { return a - b; });
+    return out;
+  }
+
+  window.runChecks = function runChecks() {
+    var out = [], pass = true;
+    function check(label, ok, detail) {
+      out.push((ok ? 'PASS ' : 'FAIL ') + label + (detail ? '  [' + detail + ']' : ''));
+      if (!ok) { pass = false; }
+    }
+    function eq(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
+
+    // 1. 'frozen' css class = exactly the configured pinned rows, both modes
+    var aClassed = frozenClassedRows('#gridA');
+    check('A(top): frozen class on exactly rows 0..' + (FR - 1), eq(aClassed, [0, 1, 2]), 'classed=' + JSON.stringify(aClassed));
+    var bClassed = frozenClassedRows('#gridB');
+    check('B(bottom): frozen class on exactly rows 997..999', eq(bClassed, [997, 998, 999]), 'classed=' + JSON.stringify(bClassed));
+
+    // 2. getCanvasNode pane agreement: the canvas returned for the first
+    //    scrollable row must be the canvas that CONTAINS that row's DOM
+    var apiCanvas = gridA.getCanvasNode(0, FR);
+    var domRow = document.querySelector('#gridA .slick-row[data-row="' + FR + '"]');
+    var domCanvas = domRow && domRow.closest('.grid-canvas');
+    check('A(top): getCanvasNode(0, ' + FR + ') returns the canvas containing row ' + FR,
+      !!apiCanvas && !!domCanvas && apiCanvas === domCanvas,
+      'api=' + (apiCanvas && apiCanvas.className) + ' dom=' + (domCanvas && domCanvas.className));
+
+    // 3. B(bottom): scrollRowIntoView must scroll the LAST scrollable row (996)
+    gridB.scrollRowIntoView(996);
+    var vpTop = gridB.getViewport().top;
+    check('B(bottom): scrollRowIntoView(996) scrolls (viewport.top > 0)', vpTop > 0, 'viewport.top=' + vpTop);
+
+    // 4. A(top): the first scrollable row must be EVICTABLE - scroll far away and
+    //    confirm row FR leaves the row cache (frozen rows 0..2 stay)
+    gridA.scrollRowIntoView(600);
+    gridA.render();
+    var cache = gridA.getRowCache();
+    check('A(top): first scrollable row ' + FR + ' evicted after far scroll', !cache[FR], 'cached=' + !!cache[FR]);
+    check('A(top): frozen row 0 stays cached after far scroll', !!cache[0], 'cached=' + !!cache[0]);
+
+    out.push(pass ? '\\nALL CHECKS PASSED' : '\\nCHECKS FAILED');
+    document.getElementById('checkResults').textContent = out.join('\\n');
+    return pass;
+  };
+</script>
+</body>
+</html>`;
+
+describe('Quirk - frozen-row boundary must be consistent across all comparison sites', { retries: 1 }, () => {
+  it('should agree on the boundary across css classing, pane lookup, scrolling and cache eviction', () => {
+    cy.intercept('GET', '/quirk-frozen-row-boundary-harness.html', {
+      headers: { 'content-type': 'text/html' },
+      body: harnessHtml,
+    });
+    cy.visit(`${Cypress.config('baseUrl')}/quirk-frozen-row-boundary-harness.html`);
+    cy.window().its('gridA').should('exist');
+    cy.window().its('gridB').should('exist');
+
+    cy.window().then((win: any) => {
+      const ok = win.runChecks();
+      const detail = win.document.getElementById('checkResults').textContent;
+      expect(ok, `in-page boundary self-checks:\n${detail}`).to.eq(true);
+    });
+    cy.get('#checkResults').should('contain', 'ALL CHECKS PASSED');
+  });
+});

--- a/cypress/support/drag.ts
+++ b/cypress/support/drag.ts
@@ -107,8 +107,8 @@ Cypress.Commands.overwrite('drag', (_originalFn: any, subject: any, target: any,
 // @ts-ignore
 Cypress.Commands.add('dragStart', { prevSubject: true }, (subject, { cellWidth = 80, cellHeight = 25 } = {}) => {
   return cy.wrap(subject).click({ force: true })
-    .trigger('mousedown', { which: 1 })
-    .trigger('mousemove', cellWidth / 3, cellHeight / 3);
+    .trigger('mousedown', { which: 1, force: true })
+    .trigger('mousemove', cellWidth / 3, cellHeight / 3, { force: true });
 });
 
 // use a different command name than "drag" so that it doesn't conflict with the "@4tw/cypress-drag-drop" lib
@@ -143,6 +143,7 @@ Cypress.Commands.add('dragOutside', (viewport = 'topLeft', ms = 0, px = 0, { par
 });
 
 Cypress.Commands.add('dragEnd', { prevSubject: 'optional' }, (subject, gridSelector = 'div[class^="slickgrid_"]') => {
+  cy.get('body').trigger('mouseup', { force: true });
   cy.get(gridSelector).trigger('mouseup', { force: true });
   return;
 });

--- a/examples/example-quirk-frozen-row-boundary.html
+++ b/examples/example-quirk-frozen-row-boundary.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<!--
+  TEMPORARY repro page for the frozen-row boundary drift.
+  DO NOT MERGE — human review only; deleted before merge. The permanent
+  regression test is cypress/e2e/quirk-frozen-row-boundary.cy.ts, which is fully
+  self-hosting and does NOT depend on this page.
+
+  Pre-fix, the boundary was compared differently at six sites. Visible here:
+  - Grid A (3 frozen TOP rows): row 3 (first SCROLLABLE row) carries the
+    .frozen class, and "Check pane lookup" reports getCanvasNode disagreeing
+    with where row 3's DOM actually lives.
+  - Grid B (3 frozen BOTTOM rows): the pinned rows 997-999 carry NO .frozen
+    class (rows 0-3 do instead), and "Scroll to last scrollable row" refuses
+    to scroll.
+  On a fixed build every readout reports agreement.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>SlickGrid quirk repro: frozen-row boundary (temporary, do not merge)</title>
+  <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css"/>
+  <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css"/>
+  <style>
+    .g { width: 700px; height: 260px; } h3 { margin: 12px 0 4px 0; }
+    .slick-row.frozen { background: #fde2e2; }
+  </style>
+</head>
+<body>
+<h2>Frozen-row boundary drift (TEMPORARY repro, do not merge)</h2>
+<p style="max-width:700px;">Rows carrying the <code>.frozen</code> class are tinted red.
+Fixed build: exactly the pinned rows are tinted in both grids.</p>
+<div style="width:700px;">
+  <h3>Grid A — 3 frozen TOP rows</h3>
+  <div id="gridA" class="g"></div>
+  <h3>Grid B — 3 frozen BOTTOM rows (1000 rows)</h3>
+  <div id="gridB" class="g"></div>
+  <button onclick="checkPane()">Check pane lookup for first scrollable row (A)</button>
+  <button onclick="scrollLast()">Scroll to last scrollable row (B)</button>
+  <div id="readout" style="white-space:pre; font-family:monospace; font-size:12px; margin-top:8px;"></div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
+<script src="sortable-cdn-fallback.js"></script>
+
+<script src="../dist/browser/slick.core.js"></script>
+<script src="../dist/browser/slick.interactions.js"></script>
+<script src="../dist/browser/slick.grid.js"></script>
+<script>
+  var ROWS = 1000, FR = 3;
+  var columns = [
+    { id: 'id', name: '#', field: 'id', width: 80 },
+    { id: 'a', name: 'A', field: 'a', width: 200 },
+    { id: 'b', name: 'B', field: 'b', width: 200 }
+  ];
+  function makeData() {
+    var d = [];
+    for (var i = 0; i < ROWS; i++) { d.push({ id: i, a: 'a' + i, b: 'b' + i }); }
+    return d;
+  }
+  var base = { enableCellNavigation: true, enableColumnReorder: false, rowHeight: 25 };
+  function cols() { return columns.map(function (c) { return Object.assign({}, c); }); }
+
+  var gridA = new Slick.Grid('#gridA', makeData(), cols(), Object.assign({ frozenRow: FR }, base));
+  var gridB = new Slick.Grid('#gridB', makeData(), cols(), Object.assign({ frozenRow: FR, frozenBottom: true }, base));
+
+  function checkPane() {
+    var api = gridA.getCanvasNode(0, FR);
+    var dom = document.querySelector('#gridA .slick-row[data-row="' + FR + '"]');
+    var domCanvas = dom && dom.closest('.grid-canvas');
+    document.getElementById('readout').textContent =
+      'getCanvasNode(0, ' + FR + ') -> ' + (api ? api.className : 'null') + '\n' +
+      'row ' + FR + ' DOM lives in -> ' + (domCanvas ? domCanvas.className : 'not rendered') + '\n' +
+      (api === domCanvas ? 'AGREE (fixed)' : 'DISAGREE (pre-fix bug: overlays/menus target the wrong pane)');
+  }
+  function scrollLast() {
+    gridB.scrollRowIntoView(996);
+    var t = gridB.getViewport().top;
+    document.getElementById('readout').textContent =
+      'scrollRowIntoView(996) -> viewport.top = ' + t + '\n' +
+      (t > 0 ? 'SCROLLED (fixed)' : 'DID NOT SCROLL (pre-fix bug: last scrollable row unreachable)');
+  }
+</script>
+</body>
+</html>

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -1487,6 +1487,16 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return this._options.frozenColumn! > -1;
   }
 
+  /** Whether the row renders in the bottom canvas (the render split: rows >= actualFrozenRow). */
+  protected isBottomBandRow(row: number) {
+    return this.hasFrozenRows && row >= this.actualFrozenRow;
+  }
+
+  /** Whether the row index is one of the frozen (pinned) rows. */
+  protected isFrozenRowIdx(row: number) {
+    return this.hasFrozenRows && (this._options.frozenBottom ? row >= this.actualFrozenRow : row < this.actualFrozenRow);
+  }
+
   /**
    * Updates an existing column definition and a corresponding header DOM element with the new title and tooltip.
    * @param {Number|String} columnId Column id.
@@ -5333,7 +5343,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const d = this.getDataItem(row);
     const dataLoading = row < dataLength && !d;
     let rowCss = 'slick-row' +
-      (this.hasFrozenRows && row <= this._options.frozenRow! ? ' frozen' : '') +
+      (this.isFrozenRowIdx(row) ? ' frozen' : '') +
       (dataLoading ? ' loading' : '') +
       (row === this.activeRow && this._options.showCellSelection ? ' active' : '') +
       (row % 2 === 1 ? ' odd' : ' even');
@@ -5569,11 +5579,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         let i = +rowId;
         let removeFrozenRow = true;
 
-        if (this.hasFrozenRows
-          && ((this._options.frozenBottom && (i as unknown as number) >= this.actualFrozenRow) // Frozen bottom rows
-            || (!this._options.frozenBottom && (i as unknown as number) <= this.actualFrozenRow) // Frozen top rows
-          )
-        ) {
+        if (this.isFrozenRowIdx(i)) {
           removeFrozenRow = false;
         }
 
@@ -6282,14 +6288,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {number} row - The row index to clean up.
    */
   protected cleanUpCells(range: CellViewportRange, row: number) {
-    // Ignore frozen rows (mirror the guard used by cleanupRows: the top-band
-    // disjunct must be qualified with !frozenBottom, otherwise in frozenBottom
-    // mode the two disjuncts cover every row and NO row is ever cell-cleaned)
-    if (this.hasFrozenRows
-      && ((this._options.frozenBottom && row >= this.actualFrozenRow) // Frozen bottom rows
-        || (!this._options.frozenBottom && row <= this.actualFrozenRow) // Frozen top rows
-      )
-    ) {
+    if (this.isFrozenRowIdx(row)) {
       return;
     }
 
@@ -6521,7 +6520,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       divArrayR.forEach(elm => xRight.appendChild(elm as HTMLElement));
 
       for (let i = 0, ii = rows.length; i < ii; i++) {
-        if ((this.hasFrozenRows) && (rows[i] >= this.actualFrozenRow)) {
+        if (this.isBottomBandRow(rows[i])) {
           if (this.hasFrozenColumns()) {
             if (this.rowsCache?.hasOwnProperty(rows[i]) && x.firstChild && xRight.firstChild) {
               this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement, xRight.firstChild as HTMLElement];
@@ -7179,9 +7178,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Boolean} doPaging - scroll when pagination is enabled
    */
   scrollRowIntoView(row: number, doPaging?: boolean) {
-    if (!this.hasFrozenRows ||
-      (!this._options.frozenBottom && row > this.actualFrozenRow - 1) ||
-      (this._options.frozenBottom && row < this.actualFrozenRow - 1)) {
+    if (!this.isFrozenRowIdx(row)) {
 
       const viewportScrollH = Utils.height(this._viewportScrollContainerY) as number;
 
@@ -7757,7 +7754,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     const idx = (typeof columnIdOrIdx === 'number' ? columnIdOrIdx : this.getColumnIndex(columnIdOrIdx));
 
-    const isBottomSide = this.hasFrozenRows && rowIndex >= this.actualFrozenRow + (this._options.frozenBottom ? 0 : 1);
+    const isBottomSide = this.isBottomBandRow(rowIndex);
     const isRightSide = this.hasFrozenColumns() && idx > this._options.frozenColumn!;
 
     return targetContainers[(isBottomSide ? 2 : 0) + (isRightSide ? 1 : 0)];
@@ -8813,9 +8810,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       const isAddNewRow = (pos.row === this.getDataLength());
 
-      if ((!this._options.frozenBottom && pos.row >= this.actualFrozenRow)
-        || (this._options.frozenBottom && pos.row < this.actualFrozenRow)
-      ) {
+      if (!this.isFrozenRowIdx(pos.row)) {
         this.scrollCellIntoView(pos.row, pos.cell, !isAddNewRow && this._options.emulatePagingWhenScrolling);
       }
       this.setActiveCellInternal(this.getCellNode(pos.row, pos.cell));


### PR DESCRIPTION
> ⚠️ **Merge order:** this PR assumes **#1266** and **#1267** are merged first. It has no textual conflicts with either, but it was authored and validated against a master that includes them — please land those two before this one.

## The bug (Q3 in discussion #1247)

The frozen-row boundary was compared differently at **six sites**, contradicting each other and the render split (`rows >= actualFrozenRow` render in the bottom canvas):

| Site | Drift | Observable |
|------|-------|-----------|
| `appendRowHtml` frozen class | `row <= frozenRow` (a **count** compare) | bottom mode: the first rows classed `.frozen`, the actually-pinned rows never; top mode: off-by-one |
| `cleanupRows` / `cleanUpCells` | `<= actualFrozenRow` | first **scrollable** row never evicted/cleaned in top mode |
| `_getContainerElement` (`getCanvasNode`/`getViewportNode`) | `>= actualFrozenRow + 1` in top mode | returns the TOP pane for a row whose DOM lives in the BOTTOM canvas — overlays/menus positioned via the public API mis-target exactly the boundary row |
| `scrollRowIntoView` | `actualFrozenRow - 1` boundaries | bottom mode: refuses to scroll the LAST scrollable row (`navigateToPos`, one screen away, already compares correctly) |

## The fix

Two predicates matching the render split — `isBottomBandRow` (`row >= actualFrozenRow`) and `isFrozenRowIdx` (`frozenBottom ? row >= actualFrozenRow : row < actualFrozenRow`) — with every site routed through them. Net **−5 lines**.

## Downstream check (executed)

slickgrid-universal maintains its **own fork** of this grid (verified by clone + grep — it does not consume this file at runtime), so this cannot break it. Its fork carries the same `isBottomSide` off-by-one and may want to port the fix.

## Test

`cypress/e2e/quirk-frozen-row-boundary.cy.ts` — **self-hosting** (harness via `cy.intercept`; no example-page dependency), one check per drifted site plus a frozen-row-stays-cached control. Pre-fix it fails on **every** drifted site with the predicted signatures (frozen class `[0,1,2,3]` in *both* modes; `getCanvasNode` returning the top canvas while the row's DOM is in the bottom; `scrollRowIntoView(996)` leaving `viewport.top=0`; boundary row never evicted); post-fix all pass. Frozen-family suites including the merged #1255/#1258 quirk specs ran 27/27.

## ⚠️ Temporary example page

`examples/example-quirk-frozen-row-boundary.html` (tinted `.frozen` rows + pane-lookup/scroll readouts) is **intended to be deleted before merge** — the cypress test is fully independent of it.

(Quirks-triage remaining-items wave: see discussion #1247; siblings #1266, #1267.)