### PR TITLE
feat: add core RTL support for headers and column resizing

### DIFF
--- a/cypress/e2e/example-rtl.cy.ts
+++ b/cypress/e2e/example-rtl.cy.ts
@@ -1,0 +1,203 @@
+describe('Example - RTL (Right-to-Left) Support', () => {
+    const titles = [
+        'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven',
+        'Priority', 'Status', 'Assignee', 'Department', 'Project', 'Completed'
+    ];
+
+    beforeEach(() => {
+        cy.visit(`${Cypress.config('baseUrl')}/examples/example1-simple-rtl.html`);
+    });
+
+    // Section 1: Basic Rendering
+
+    describe('Basic Rendering', () => {
+        it('should display Example title', () => {
+            cy.get('h2').should('contain', 'Simple Grid (RTL)');
+        });
+
+        it('should have exact Column Titles in the grid', () => {
+            cy.get('#myGrid')
+                .find('.slick-header-columns')
+                .children()
+                .each(($child, index) => expect($child.text()).to.eq(titles[index]));
+        });
+
+        it('should render columns in right-to-left order', () => {
+            cy.get('#myGrid')
+                .find('.slick-header-columns')
+                .children()
+                .each(($child, index) => expect($child.text()).to.eq(titles[index]));
+        });
+    });
+
+    // Section 2: Configuration & Setup
+
+    describe('Configuration', () => {
+        it('should have RTL class applied to grid container', () => {
+            cy.get('#myGrid')
+                .should('have.class', 'slick-rtl');
+        });
+
+        it('should have RTL option enabled in grid options', () => {
+            cy.window().then((win) => {
+                const grid = (win as any).grid;
+                if (grid && grid.getOptions) {
+                    const options = grid.getOptions();
+                    expect(options.rtl).to.be.true;
+                }
+            });
+        });
+
+        it('should have proper RTL cell content alignment', () => {
+            cy.get('#myGrid')
+                .find('.slick-cell:first')
+                .should('have.css', 'direction', 'rtl');
+        });
+    });
+
+    // Section 3: UI Interactions
+
+    describe('UI Interactions', () => {
+        it('should have resize handle on the left side', () => {
+            cy.get('#myGrid')
+                .find('.slick-header-column:first .slick-resizable-handle')
+                .should('exist')
+                .and('have.css', 'left', '0px');
+        });
+
+        it('should maintain RTL behavior after column resize', () => {
+            // Resize first column
+            cy.get('#myGrid')
+                .find('.slick-header-column:first .slick-resizable-handle')
+                .trigger('mousedown', { which: 1 })
+                .trigger('mousemove', { clientX: 30 })
+                .trigger('mouseup');
+
+            // Verify columns still in correct RTL order
+            cy.get('#myGrid')
+                .find('.slick-header-columns')
+                .children()
+                .each(($child, index) => expect($child.text()).to.eq(titles[index]));
+        });
+    });
+
+    // Section 4: Scrolling Behavior
+
+    describe('Scrolling Behavior', () => {
+        it('should have horizontal scroll enabled', () => {
+            cy.get('.slick-viewport')
+                .should('have.prop', 'scrollWidth')
+                .then((scrollWidth) => {
+                    cy.get('.slick-viewport')
+                        .invoke('width')
+                        .should((viewportWidth) => {
+                            // @ts-ignore - scrollWidth and viewportWidth are numbers
+                            expect(scrollWidth).to.be.greaterThan(viewportWidth);
+                        });
+                });
+        });
+
+        it('should scroll horizontally in RTL mode', () => {
+            cy.get('.slick-viewport')
+                .then(($viewport) => {
+                    const viewport = $viewport[0];
+                    viewport.scrollLeft = -200;
+                    cy.wait(100);
+                    expect(viewport.scrollLeft).to.be.lessThan(0);
+                });
+        });
+
+        it('should update visible range when scrolling in RTL', () => {
+            let initialFirstColumn = '';
+            cy.get('.slick-header-column:visible')
+                .first()
+                .invoke('text')
+                .then((text) => {
+                    initialFirstColumn = text;
+                });
+
+            cy.get('.slick-viewport')
+                .then(($viewport) => {
+                    const viewport = $viewport[0];
+                    viewport.scrollLeft = -300;
+                    cy.wait(150);
+                });
+
+            cy.get('.slick-header-column:visible')
+                .first()
+                .invoke('text')
+                .should((newText) => {
+                    expect(newText).not.to.equal(initialFirstColumn);
+                });
+        });
+
+        it('should calculate correct visible range in RTL mode', () => {
+            cy.window().then((win) => {
+                const grid = (win as any).grid;
+                if (grid && grid.getVisibleRange) {
+                    const viewport = grid._viewport;
+                    const originalScrollLeft = viewport.scrollLeft;
+                    viewport.scrollLeft = -200;
+                    const range = grid.getVisibleRange();
+                    expect(range.leftPx).to.be.a('number');
+                    expect(range.rightPx).to.be.a('number');
+                    expect(range.rightPx).to.be.greaterThan(range.leftPx);
+                    viewport.scrollLeft = originalScrollLeft;
+                }
+            });
+        });
+    });
+
+    // Section 5: Edge Cases & Stability
+
+    describe('Edge Cases & Stability', () => {
+        it('should handle max scroll in RTL mode', () => {
+            cy.get('.slick-viewport')
+                .then(($viewport) => {
+                    const viewport = $viewport[0];
+                    const maxScroll = viewport.scrollWidth - viewport.clientWidth;
+                    viewport.scrollLeft = -maxScroll;
+                    cy.wait(150);
+                    cy.get('.slick-header-column:visible')
+                        .last()
+                        .should('exist');
+                });
+        });
+
+        it('should maintain scroll position after column updates', () => {
+            let currentScrollLeft = 0;
+            cy.get('.slick-viewport')
+                .then(($viewport) => {
+                    const viewport = $viewport[0];
+                    viewport.scrollLeft = -300;
+                    currentScrollLeft = viewport.scrollLeft;
+                    cy.wait(100);
+                    cy.window().then((win) => {
+                        const grid = (win as any).grid;
+                        if (grid && grid.render) {
+                            grid.render();
+                        }
+                    });
+                    cy.wait(100);
+                    expect(viewport.scrollLeft).to.equal(currentScrollLeft);
+                });
+        });
+
+        it('should scroll to the end and display last columns', () => {
+            cy.get('.slick-viewport')
+                .then(($viewport) => {
+                    const viewport = $viewport[0];
+                    const maxScroll = viewport.scrollWidth - viewport.clientWidth;
+                    viewport.scrollLeft = -maxScroll;
+                    cy.wait(300);
+                });
+
+            cy.get('.slick-header-column:visible')
+                .first()
+                .invoke('text')
+                .then((text) => {
+                    expect(text).not.to.equal('Title');
+                });
+        });
+    });
+});

--- a/examples/example1-simple-rtl.html
+++ b/examples/example1-simple-rtl.html
@@ -1,0 +1,88 @@
+<!DOCTYPE HTML>
+<html dir="rtl">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
+  <title>SlickGrid example 1: Basic grid (RTL)</title>
+  <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css" />
+  <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css" />
+  <style>
+    .slick-resizable-handle {
+      right: auto !important;
+      left: 0 !important;
+    }
+  </style>
+</head>
+
+<body>
+  <h2 class="title">Example 1 Simple Grid (RTL) - ESM</h2>
+  <table width="100%">
+    <tr>
+      <td valign="top" width="50%">
+        <div id="myGrid" class="slick-container" style="width:600px;height:500px;"></div>
+      </td>
+      <td valign="top">
+        <div>
+          <h2>
+            <a href="/examples/index.html" style="text-decoration: none; font-size: 22px">&#x2302;</a>
+            Demonstrates:
+          </h2>
+        </div>
+        <ul>
+          <li>basic grid with minimal configuration</li>
+          <li>RTL (right-to-left) support with Persian (Farsi) sample data</li>
+        </ul>
+        <h2>View Source:</h2>
+        <ul>
+          <li><a href="https://github.com/6pac/SlickGrid/blob/master/examples/example1-simple-rtl.html"
+              target="_sourcewindow"> View the source for this example on Github</a>
+          </li>
+        </ul>
+      </td>
+    </tr>
+  </table>
+
+
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
+  <script src="sortable-cdn-fallback.js"></script>
+
+  <script src="../dist/browser/slick.core.js"></script>
+  <script src="../dist/browser/slick.interactions.js"></script>
+  <script src="../dist/browser/slick.grid.js"></script>
+
+  <script>
+    var grid;
+    var columns = [
+      { id: "title", name: "عنوان", field: "title" },
+      { id: "duration", name: "مدت زمان", field: "duration" },
+      { id: "%", name: "درصد تکمیل", field: "percentComplete", width: 90 },
+      { id: "start", name: "شروع", field: "start" },
+      { id: "finish", name: "پایان", field: "finish" },
+      { id: "effort-driven", name: "تلاش‌محور", field: "effortDriven", width: 90 }
+    ];
+
+    var options = {
+      enableCellNavigation: true,
+      enableColumnReorder: false,
+      rtl: true
+    };
+
+    var data = [];
+    for (var i = 0; i < 500; i++) {
+      data[i] = {
+        title: "وظیفه " + (i + 1),
+        duration: "۵ روز",
+        percentComplete: Math.round(Math.random() * 100),
+        start: "۱۴۰۵/۰۵/۱۱",
+        finish: "۱۴۰۵/۰۵/۱۶",
+        effortDriven: (i % 5 == 0) ? "بله" : "خیر"
+      };
+    }
+
+    grid = new Slick.Grid("#myGrid", data, columns, options);
+
+  </script>
+</body>
+
+</html>

--- a/examples/example1-simple-rtl.html
+++ b/examples/example1-simple-rtl.html
@@ -2,18 +2,13 @@
 <html dir="rtl">
 
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
   <title>SlickGrid example 1: Basic grid (RTL)</title>
   <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css" />
   <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css" />
-  <style>
-    .slick-resizable-handle {
-      right: auto !important;
-      left: 0 !important;
-    }
-  </style>
-</head>
+  </head>
 
 <body>
   <h2 class="title">Example 1 Simple Grid (RTL) - ESM</h2>
@@ -43,7 +38,6 @@
     </tr>
   </table>
 
-
   <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
   <script src="sortable-cdn-fallback.js"></script>
 
@@ -54,12 +48,18 @@
   <script>
     var grid;
     var columns = [
-      { id: "title", name: "Title", field: "title" },
-      { id: "duration", name: "Duration", field: "duration" },
+      { id: "title", name: "Title", field: "title", width: 90 },
+      { id: "duration", name: "Duration", field: "duration", with: 80 },
       { id: "%", name: "% Complete", field: "percentComplete", width: 90 },
-      { id: "start", name: "Start", field: "start" },
-      { id: "finish", name: "Finish", field: "finish" },
-      { id: "effort-driven", name: "Effort Driven", field: "effortDriven", width: 90 }
+      { id: "start", name: "Start", field: "start", width: 80 },
+      { id: "finish", name: "Finish", field: "finish", width: 80 },
+      { id: "effort-driven", name: "Effort Driven", field: "effortDriven", width: 100 },
+      { id: "priority", name: "Priority", field: "priority", width: 80 },
+      { id: "status", name: "Status", field: "status" },
+      { id: "assignee", name: "Assignee", field: "assignee" },
+      { id: "department", name: "Department", field: "department", width: 100 },
+      { id: "project", name: "Project", field: "project" },
+      { id: "completed", name: "Completed", field: "completed" }
     ];
 
     var options = {
@@ -69,18 +69,34 @@
     };
 
     var data = [];
+    var statuses = ['Not Started', 'In Progress', 'Review', 'Completed', 'On Hold'];
+    var priorities = ['Low', 'Medium', 'High', 'Critical'];
+    var assignees = ['Alice', 'Bob', 'Carol', 'Dave', 'Eve', 'Frank', 'Grace'];
+    var departments = ['Engineering', 'Marketing', 'Sales', 'Design', 'Support', 'Finance'];
+    var projects = ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta'];
+
     for (var i = 0; i < 500; i++) {
+      var startDate = new Date(2025, Math.floor(Math.random() * 12), Math.floor(Math.random() * 28) + 1);
+      var finishDate = new Date(startDate);
+      finishDate.setDate(finishDate.getDate() + Math.floor(Math.random() * 14) + 3);
+
       data[i] = {
-        title: "Task " + i,
-        duration: "5 days",
+        title: "Task " + (i + 1),
+        duration: (Math.floor(Math.random() * 10) + 2) + " days",
         percentComplete: Math.round(Math.random() * 100),
-        start: "01/01/2009",
-        finish: "01/05/2009",
-        effortDriven: (i % 5 == 0)
+        start: startDate.toLocaleDateString('en-US'),
+        finish: finishDate.toLocaleDateString('en-US'),
+        effortDriven: (i % 5 == 0),
+        priority: priorities[Math.floor(Math.random() * priorities.length)],
+        status: statuses[Math.floor(Math.random() * statuses.length)],
+        assignee: assignees[Math.floor(Math.random() * assignees.length)],
+        department: departments[Math.floor(Math.random() * departments.length)],
+        project: projects[Math.floor(Math.random() * projects.length)],
+        completed: (i % 3 == 0) ? 'Yes' : 'No'
       };
     }
-    grid = new Slick.Grid("#myGrid", data, columns, options);
 
+    grid = new Slick.Grid("#myGrid", data, columns, options);
   </script>
 </body>
 

--- a/examples/example1-simple-rtl.html
+++ b/examples/example1-simple-rtl.html
@@ -31,7 +31,7 @@
         </div>
         <ul>
           <li>basic grid with minimal configuration</li>
-          <li>RTL (right-to-left) support with Persian (Farsi) sample data</li>
+          <li>RTL (right-to-left) support enabled</li>
         </ul>
         <h2>View Source:</h2>
         <ul>
@@ -54,12 +54,12 @@
   <script>
     var grid;
     var columns = [
-      { id: "title", name: "عنوان", field: "title" },
-      { id: "duration", name: "مدت زمان", field: "duration" },
-      { id: "%", name: "درصد تکمیل", field: "percentComplete", width: 90 },
-      { id: "start", name: "شروع", field: "start" },
-      { id: "finish", name: "پایان", field: "finish" },
-      { id: "effort-driven", name: "تلاش‌محور", field: "effortDriven", width: 90 }
+      { id: "title", name: "Title", field: "title" },
+      { id: "duration", name: "Duration", field: "duration" },
+      { id: "%", name: "% Complete", field: "percentComplete", width: 90 },
+      { id: "start", name: "Start", field: "start" },
+      { id: "finish", name: "Finish", field: "finish" },
+      { id: "effort-driven", name: "Effort Driven", field: "effortDriven", width: 90 }
     ];
 
     var options = {
@@ -71,15 +71,14 @@
     var data = [];
     for (var i = 0; i < 500; i++) {
       data[i] = {
-        title: "وظیفه " + (i + 1),
-        duration: "۵ روز",
+        title: "Task " + i,
+        duration: "5 days",
         percentComplete: Math.round(Math.random() * 100),
-        start: "۱۴۰۵/۰۵/۱۱",
-        finish: "۱۴۰۵/۰۵/۱۶",
-        effortDriven: (i % 5 == 0) ? "بله" : "خیر"
+        start: "01/01/2009",
+        finish: "01/05/2009",
+        effortDriven: (i % 5 == 0)
       };
     }
-
     grid = new Slick.Grid("#myGrid", data, columns, options);
 
   </script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -65,6 +65,7 @@
       <li><a href="./example7-events.html">Handling events and context menu</a></li>
       <li><a href="./example14-highlighting.html">Highlighting and flashing cells</a></li>
       <li><a href="./example2-formatters-event.html">Adding some formatting</a></li>
+      <li><a href="./example1-simple-rtl.html">Basic use with RTL support</a></li>
     </ul>
   </div>
   <h2>Editing</h2>

--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -350,6 +350,9 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   /** Defaults to 400, duration to show the row highlight (e.g. after CRUD executions) */
   rowHighlightDuration?: number;
 
+  /** Defaults to false, sets the grid direction to RTL (Right-to-Left) for proper rendering of RTL languages */
+  rtl?: boolean;
+
   /**
    * Defaults to "top", what CSS style to we want to use to render each row top offset (we can use "top" or "transform").
    * For example, with a default `rowHeight: 22`, the 2nd row will have a `top` offset of 44px and by default have a CSS style of `top: 44px`.

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -868,6 +868,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (!this._options.explicitInitialization) {
       this.finishInitialization();
     }
+
+    this.applyRTL(this._options.rtl ?? false);
   }
 
   /**
@@ -6263,11 +6265,22 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     viewportTop ??= this.scrollTop;
     viewportLeft ??= this.scrollLeft;
 
+    let leftPx = viewportLeft;
+    let rightPx = viewportLeft + this.viewportW;
+
+    if (this._options.rtl) {
+      // In RTL, scrollLeft represents the offset from the RIGHT edge.
+      // The viewport's left edge is: maxScroll (far left) - scrollLeft (offset from right)
+      const maxScroll = this.canvasWidth - this.viewportW;
+      leftPx = maxScroll - viewportLeft - this.viewportW;
+      rightPx = maxScroll - viewportLeft;
+    }
+
     return {
       top: this.getRowFromPosition(viewportTop),
       bottom: this.getRowFromPosition(viewportTop + this.viewportH) + 1,
-      leftPx: viewportLeft,
-      rightPx: viewportLeft + this.viewportW
+      leftPx,
+      rightPx
     };
   }
 
@@ -8347,6 +8360,27 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    */
   protected get dirSide() {
     return this._options.rtl ? 'right' : 'left';
+  }
+
+  /**
+   * Applies or removes RTL (Right-to-Left) support on the grid container.
+   * 
+   * When enabled, this method:
+   * - Adds the `slick-rtl` CSS class for styling
+   * - Sets the `dir="rtl"` attribute for proper text direction
+   * When disabled, it removes both the class and attribute.
+   * This makes the grid self-contained, allowing RTL to work regardless of the page's direction setting.
+   * 
+   * @param enabled - Whether RTL should be enabled
+   */
+  private applyRTL(enabled: boolean): void {
+    if (enabled) {
+      this._container.classList.add('slick-rtl');
+      this._container.setAttribute('dir', 'rtl');
+    } else {
+      this._container.classList.remove('slick-rtl');
+      this._container.removeAttribute('dir');
+    }
   }
 
   ///////////////////////////////////////////////////////////////

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -759,8 +759,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this._headerScroller.push(this._headerScrollerR);
 
     // Append the columnn containers to the headers
-    this._headerL = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-left', role: 'row', style: { [this.hideSide]: '-1000px' } }, this._headerScrollerL);
-    this._headerR = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-right', role: 'row', style: { [this.hideSide]: '-1000px' } }, this._headerScrollerR);
+    this._headerL = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-left', role: 'row', style: { [this.dirSide]: '-1000px' } }, this._headerScrollerL);
+    this._headerR = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-right', role: 'row', style: { [this.dirSide]: '-1000px' } }, this._headerScrollerR);
 
     // Cache the header columns
     this._headers = [this._headerL, this._headerR];
@@ -5092,8 +5092,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     const rowHeight = (this._options.rowHeight! - this.cellHeightDiff);
     const rules = [
-      `.${this.uid} .slick-group-header-column { ${this.hideSide}: 1000px; }`,
-      `.${this.uid} .slick-header-column { ${this.hideSide}: 1000px; }`,
+      `.${this.uid} .slick-group-header-column { ${this.dirSide}: 1000px; }`,
+      `.${this.uid} .slick-header-column { ${this.dirSide}: 1000px; }`,
       `.${this.uid} .slick-top-panel { height: ${this._options.topPanelHeight}px; }`,
       `.${this.uid} .slick-preheader-panel { height: ${this._options.preHeaderPanelHeight}px; }`,
       `.${this.uid} .slick-topheader-panel { height: ${this._options.topHeaderPanelHeight}px; }`,
@@ -8345,7 +8345,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * 
    * @returns 'right' when RTL is enabled, otherwise 'left'
    */
-  protected get hideSide() {
+  protected get dirSide() {
     return this._options.rtl ? 'right' : 'left';
   }
 

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -334,7 +334,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     logSanitizedHtml: false, // log to console when sanitised - recommend true for testing of dev and production
     mixinDefaults: true,
     shadowRoot: undefined,
-    colAutosizeTreatAsLockedBelowWidth: 100
+    colAutosizeTreatAsLockedBelowWidth: 100,
+    rtl: false
   };
 
   protected _columnDefaults = {
@@ -758,8 +759,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this._headerScroller.push(this._headerScrollerR);
 
     // Append the columnn containers to the headers
-    this._headerL = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-left', role: 'row', style: { left: '-1000px' } }, this._headerScrollerL);
-    this._headerR = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-right', role: 'row', style: { left: '-1000px' } }, this._headerScrollerR);
+    this._headerL = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-left', role: 'row', style: { [this.hideSide]: '-1000px' } }, this._headerScrollerL);
+    this._headerR = Utils.createDomElement('div', { className: 'slick-header-columns slick-header-columns-right', role: 'row', style: { [this.hideSide]: '-1000px' } }, this._headerScrollerR);
 
     // Cache the header columns
     this._headers = [this._headerL, this._headerR];
@@ -2173,14 +2174,25 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
             if (stretchLeewayOnLeft === null) {
               stretchLeewayOnLeft = 100000;
             }
-            maxPageX = pageX + Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft);
-            minPageX = pageX - Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight);
+
+            if (this._options.rtl) {
+              maxPageX = pageX + Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight);
+              minPageX = pageX - Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft);
+            } else {
+              maxPageX = pageX + Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft);
+              minPageX = pageX - Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight);
+            }
           },
           onResize: (e, resizeElms) => {
             const targetEvent = (e as TouchEvent).touches ? (e as TouchEvent).changedTouches[0] : e;
             this.columnResizeDragging = true;
             let actualMinWidth;
-            const d = Math.min(maxPageX, Math.max(minPageX, (targetEvent as MouseEvent).pageX)) - pageX;
+            let d = Math.min(maxPageX, Math.max(minPageX, (targetEvent as MouseEvent).pageX)) - pageX;
+
+            if (this._options.rtl) {
+              d = -d;
+            }
+
             let x;
             let newCanvasWidthL = 0;
             let newCanvasWidthR = 0;
@@ -3164,8 +3176,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         w = this.columns[i].width || 0;
 
         rule = this.getColumnCssRules(i);
-        rule.left.style.left = `${x}px`;
-        rule.right.style.right = (((this._options.frozenColumn !== -1 && i > this._options.frozenColumn!) ? this.canvasWidthR : this.canvasWidthL) - x - w) + 'px';
+
+        if (this._options.rtl) {
+          rule.left.style.right = `${x}px`;
+          rule.right.style.left = (((this._options.frozenColumn !== -1 && i > this._options.frozenColumn!) ? this.canvasWidthR : this.canvasWidthL) - x - w) + 'px';
+        } else {
+          rule.left.style.left = `${x}px`;
+          rule.right.style.right = (((this._options.frozenColumn !== -1 && i > this._options.frozenColumn!) ? this.canvasWidthR : this.canvasWidthL) - x - w) + 'px';
+        }
 
         // If this column is frozen, reset the css left value since the
         // column starts in a new viewport.
@@ -5074,8 +5092,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     const rowHeight = (this._options.rowHeight! - this.cellHeightDiff);
     const rules = [
-      `.${this.uid} .slick-group-header-column { left: 1000px; }`,
-      `.${this.uid} .slick-header-column { left: 1000px; }`,
+      `.${this.uid} .slick-group-header-column { ${this.hideSide}: 1000px; }`,
+      `.${this.uid} .slick-header-column { ${this.hideSide}: 1000px; }`,
       `.${this.uid} .slick-top-panel { height: ${this._options.topPanelHeight}px; }`,
       `.${this.uid} .slick-preheader-panel { height: ${this._options.preHeaderPanelHeight}px; }`,
       `.${this.uid} .slick-topheader-panel { height: ${this._options.topHeaderPanelHeight}px; }`,
@@ -8317,6 +8335,18 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.logMessageCount++;
     }
     return cleanHtml;
+  }
+
+  /**
+   * Returns the CSS property used to hide header columns off-screen by applying a large offset (e.g., `1000px`).
+   *
+   * In LTR mode (`rtl: false`), columns are positioned with a negative `left` value to hide them off-screen. 
+   * In RTL mode (`rtl: true`), the same effect is achieved by using a positive `right` value, since the scroll direction is mirrored.
+   * 
+   * @returns 'right' when RTL is enabled, otherwise 'left'
+   */
+  protected get hideSide() {
+    return this._options.rtl ? 'right' : 'left';
   }
 
   ///////////////////////////////////////////////////////////////

--- a/src/styles/slick-alpine-theme.scss
+++ b/src/styles/slick-alpine-theme.scss
@@ -866,3 +866,9 @@ button.slick-btn {
   bottom: 0;
   right: 0;
 }
+
+/* RTL (Right-to-Left) Support  */
+.slick-rtl .slick-resizable-handle {
+  right: auto;
+  left: 0;
+}

--- a/src/styles/slick.grid.scss
+++ b/src/styles/slick.grid.scss
@@ -273,3 +273,9 @@ classes should alter those!
   outline: 0;
   width: 100%;
 }
+
+/* RTL (Right-to-Left) Support  */
+.slick-rtl .slick-resizable-handle {
+  right: auto;
+  left: -5px;
+}


### PR DESCRIPTION
fixes #446 

This PR adds foundational RTL (Right-to-Left) support to SlickGrid, focusing on:
- RTL header alignment
- Column resizing in RTL mode  
- CSS property swapping for RTL

## Changes
- Added `dirSide` getter for dynamic CSS property selection
- Updated header container positioning to use `[dirSide]`
- Modified `applyColumnWidths` to swap `left`/`right` for RTL
- Updated column resize logic for RTL
- Added `example1-simple-rtl.html`

## Testing
Manual testing confirmed:
- Headers display in correct RTL order
- Resize handles appear on the left side
- Column resizing works correctly
- No regression in LTR mode

## Breaking Changes
None. `rtl` option defaults to `false`.

**Cypress Test Result:** https://github.com/user-attachments/files/30840967/test-results-chrome.txt
**Demo:** https://github.com/user-attachments/assets/903c56a2-8472-43ed-8615-e567146685a2