### PR TITLE
fix: autosize never measured autoSize.colValueArray (#934)

### DIFF
--- a/cypress/e2e/quirk-autosize-colvaluearray.cy.ts
+++ b/cypress/e2e/quirk-autosize-colvaluearray.cy.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression test for issue #934: autosize ignored `autoSize.colValueArray`.
+ *
+ * `getColContentSize()` handed the bare `colValueArray` to `getColWidth()` cast as `any`, but
+ * `getColWidth()` measures by walking `rowInfo.startIndex`..`rowInfo.endIndex`. On a bare array
+ * both bounds are `undefined`, `undefined <= undefined` is false, so the measuring loop never ran
+ * and the column was sized to an empty cell (~8px).
+ *
+ * This is not only a user-supplied path: under the default `ColAutosizeMode.ContentIntelligent`,
+ * the grid sets `colValueArray` itself for boolean, date and moment columns, so autosize silently
+ * failed to measure content for all three types.
+ *
+ * The spec is SELF-HOSTING: the harness page is served from this file via cy.intercept (nothing is
+ * added to examples/). It asserts on `column.autoSize.contentSizePx`, which is the value
+ * `getColContentSize()` returns - the measurement itself, isolated from the width-distribution that
+ * happens afterwards. FAILS on the unfixed code (date column measures ~8px) and PASSES with the fix
+ * (~427px).
+ */
+
+const harnessHtml = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Harness: autosize colValueArray</title>
+  <link rel="stylesheet" href="/dist/styles/css/slick-alpine-theme.css"/>
+  <style> #myGrid { width: 800px; height: 300px; } </style>
+</head>
+<body>
+<div id="myGrid"></div>
+<script src="/dist/browser/slick.core.js"></script>
+<script src="/dist/browser/slick.interactions.js"></script>
+<script src="/dist/browser/slick.grid.js"></script>
+<script>
+  var data = [];
+  for (var i = 0; i < 20; i++) {
+    data.push({
+      id: i,
+      text: 'Task ' + i,
+      when: new Date(2009, 8, 30, 12, 20, 20),  // typeof 'object' + instanceof Date -> colValueArray
+      flag: (i % 2 === 0)                       // typeof 'boolean'                  -> colValueArray
+    });
+  }
+
+  // deliberately SHORT header names: getColContentSize() returns max(headerWidthPx, measured), so a
+  // wide header would mask a failed measurement.
+  var columns = [
+    { id: 'text', name: 'T', field: 'text', width: 80 },
+    { id: 'when', name: 'W', field: 'when', width: 80 },
+    { id: 'flag', name: 'F', field: 'flag', width: 80 }
+  ];
+
+  window.grid = new Slick.Grid('#myGrid', data, columns, {
+    enableCellNavigation: true,
+    enableColumnReorder: false,       // keep the harness free of the SortableJS dependency
+    autosizeColsMode: Slick.GridAutosizeColsMode.IgnoreViewport
+  });
+
+  window.measureColumns = function () {
+    var cols = window.grid.getColumns();
+    cols.forEach(function (c) {
+      c.width = 80;
+      c.autoSize = { autosizeMode: Slick.ColAutosizeMode.ContentIntelligent };
+    });
+    window.grid.setColumns(cols);
+    window.grid.autosizeColumns();
+
+    var result = {};
+    window.grid.getColumns().forEach(function (c) {
+      result[c.id] = {
+        contentSizePx: Math.round(c.autoSize.contentSizePx),
+        headerWidthPx: Math.round(c.autoSize.headerWidthPx),
+        usedValueArray: !!c.autoSize.colValueArray
+      };
+    });
+    return result;
+  };
+</script>
+</body>
+</html>`;
+
+describe('Quirk - autosize must measure autoSize.colValueArray', { retries: 1 }, () => {
+  it('should measure date and boolean columns instead of sizing them to an empty cell', () => {
+    cy.intercept('GET', '/quirk-autosize-colvaluearray-harness.html', {
+      headers: { 'content-type': 'text/html' },
+      body: harnessHtml,
+    });
+    cy.visit(`${Cypress.config('baseUrl')}/quirk-autosize-colvaluearray-harness.html`);
+    cy.window().its('grid').should('exist');
+
+    cy.window().then((win: any) => {
+      const measured = win.measureColumns();
+
+      // preconditions: the two columns really do go through the colValueArray path, and their
+      // headers are small enough that a failed measurement cannot hide behind headerWidthPx
+      expect(measured.when.usedValueArray, 'date column uses colValueArray').to.eq(true);
+      expect(measured.flag.usedValueArray, 'boolean column uses colValueArray').to.eq(true);
+      expect(measured.when.headerWidthPx, 'date header is narrow').to.be.lessThan(60);
+
+      // control: a plain string column does not use colValueArray and must keep measuring correctly
+      expect(measured.text.usedValueArray, 'string column does not use colValueArray').to.eq(false);
+      expect(measured.text.contentSizePx, 'string column still measured').to.be.greaterThan(30);
+
+      // The bug measured ~8px (an empty cell) for both, so `max(headerWidthPx, measured)` collapsed
+      // to exactly headerWidthPx. Beating one's own header width is therefore the precise signal
+      // that the content was measured at all.
+      expect(measured.when.contentSizePx, 'date content beats its header width').to.be.greaterThan(measured.when.headerWidthPx);
+      expect(measured.flag.contentSizePx, 'boolean content beats its header width').to.be.greaterThan(measured.flag.headerWidthPx);
+
+      // ...and a stringified Date is long, so this also holds in absolute terms with a wide margin
+      expect(measured.when.contentSizePx, 'date column content measured').to.be.greaterThan(200);
+    });
+  });
+});

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -2753,8 +2753,17 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     if (autoSize.colValueArray) {
-      // if an array of values are specified, just pass them in instead of data
-      maxColWidth = this.getColWidth(columnDef, gridCanvas, autoSize.colValueArray as any);
+      // if an array of values are specified, measure them instead of the data. `getColWidth()` walks
+      // `startIndex`..`endIndex`, so the values have to be wrapped in a RowInfo - handing it the bare
+      // array leaves those bounds undefined and the measuring loop never runs.
+      const valueArrRowInfo = {
+        colIndex,
+        rowCount: autoSize.colValueArray.length,
+        startIndex: 0,
+        endIndex: autoSize.colValueArray.length - 1,
+        valueArr: autoSize.colValueArray,
+      } as RowInfo;
+      maxColWidth = this.getColWidth(columnDef, gridCanvas, valueArrRowInfo);
       return Math.max(autoSize.headerWidthPx, maxColWidth);
     }
 


### PR DESCRIPTION
Fixes #934, reported by @doornik in Nov 2023 with the correct diagnosis and a working fix.

### The bug

`getColContentSize()` handed the bare `colValueArray` to `getColWidth()` cast as `any`:

```ts
maxColWidth = this.getColWidth(columnDef, gridCanvas, autoSize.colValueArray as any);
```

`getColWidth()` measures by walking `rowInfo.startIndex`..`rowInfo.endIndex`. On a bare array both bounds are `undefined`, `undefined <= undefined` is **false**, so the measuring loop never ran and the column was sized to an empty cell. It didn't throw only because the loop never executed — `rowInfo.getRowVal` is undefined too and would have thrown on the first iteration.

### It is wider than the original report

The issue was raised as affecting the reporter's own use of `colValueArray`. But under the default `ColAutosizeMode.ContentIntelligent`, **the grid sets `colValueArray` itself** for three data types:

```ts
if (colDataTypeOf === 'boolean') { autoSize.colValueArray = [true, false]; }
if (colDataTypeOf === 'date')    { autoSize.colValueArray = [new Date(...)]; }
if (colDataTypeOf === 'moment')  { autoSize.colValueArray = [moment(...)]; }
```

So autosize silently failed to measure content for every boolean, date and moment column, falling back to header width.

### Measured effect

Instrumenting `getColWidth`, with `ContentIntelligent` + `IgnoreViewport`:

| column | rowInfo received | before | after |
|:--|:--|--:|--:|
| Date | bare `Array`, bounds `undefined` | **8px** | **427px** |
| boolean | bare `Array`, bounds `undefined` | **8px** | **34px** |
| string (control) | proper `RowInfo` | 50px | 50px |

8px is the width of an empty cell.

### The change

The values are wrapped in a proper `RowInfo`. Two details beyond the reported fix:

- **`colIndex` is included** — `getColWidth()` passes it to the formatter as the cell index, so without it formatters receive `undefined`.
- **`as any` becomes `as RowInfo`** — that cast was the root cause. It silenced exactly the shape mismatch that would otherwise have been a compile error, which is how this survived two years.

### Test

`cypress/e2e/quirk-autosize-colvaluearray.cy.ts`, self-hosting via `cy.intercept` (nothing added to `examples/`), following the existing `quirk-*` specs.

It asserts on `autoSize.contentSizePx` — the measurement itself — rather than the final column width, because the width distribution that runs afterwards does **not** discriminate between the two behaviours (I checked: the date column ends up at the same final width either way). Header names are deliberately one character, since `getColContentSize()` returns `max(headerWidthPx, measured)` and a wide header would mask a failed measurement.

The precise signal: the bug collapses that `max()` to *exactly* `headerWidthPx`, so "content beats its own header width" is what separates the two. The spec also checks its own preconditions (both columns really do take the `colValueArray` path) and keeps a plain string column as a control so the main measuring path is not broken.

### Verification

- **Fails on the unfixed build** (fix stashed and rebuilt), both retry attempts: `expected 21 to be above 21` — the date column collapsed to its 21px header. **Passes with the fix.**
- `tsc --noEmit`, `eslint` and the prod build all clean, exit 0.
- Full Cypress suite: **652 tests, 650 passing, 2 pending, 0 failing**.

### Note for whoever picks this up

The issue is currently labelled `enhancement` + `PR welcome`; it is a bug. Also worth a follow-up: this survived two years because an `any` cast hid a shape mismatch at a call boundary, and the autosize code is the least test-covered area of `slick.grid.ts` — a targeted sweep for similar casts there would be worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
