### PR TITLE
refactor: single scrollbar add and named slack in getHeadersWidth

### DIFF
--- a/cypress/e2e/headers-width-scroll-sync.cy.ts
+++ b/cypress/e2e/headers-width-scroll-sync.cy.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression pin for getHeadersWidth() — the invariants that make header/body
+ * horizontal scrolling work:
+ *
+ *   1. the header band's scroll range covers the body viewport's scroll range
+ *      (header width acts as the scroll-range floor), and
+ *   2. after scrolling the body fully right, the header scroller lands on the
+ *      same scrollLeft (no clamping), and
+ *   3. the last column's header stays pixel-aligned with its body cells there.
+ *
+ * Pinned across the three width regimes: plain grid, frozen columns (the right
+ * band scrolls), and autoHeight (no vertical scrollbar, so no gutter term).
+ * This spec is expected to pass BEFORE and AFTER any getHeadersWidth change —
+ * it exists so refactors of the width formula (e.g. the removal of the
+ * historical duplicate scrollbar addition) cannot silently break scroll sync.
+ *
+ * SELF-HOSTING: harness served via cy.intercept; no example page involved.
+ */
+
+const harnessHtml = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Harness: headers width scroll sync</title>
+  <link rel="stylesheet" href="/dist/styles/css/slick-alpine-theme.css"/>
+  <style>
+    #gridPlain, #gridFrozen { width: 600px; height: 300px; }
+    #gridAuto { width: 600px; }
+  </style>
+</head>
+<body>
+<div id="gridPlain"></div>
+<div id="gridFrozen"></div>
+<div id="gridAuto"></div>
+<div id="checkResults" style="white-space:pre; font-family:monospace;"></div>
+<script src="/dist/browser/slick.core.js"></script>
+<script src="/dist/browser/slick.interactions.js"></script>
+<script src="/dist/browser/slick.grid.js"></script>
+<script>
+  var columns = [];
+  for (var c = 0; c < 15; c++) {
+    columns.push({ id: 'c' + c, name: 'C' + c, field: 'c' + c, width: 100 });
+  }
+  function makeData(count) {
+    var d = [];
+    for (var i = 0; i < count; i++) {
+      var row = { id: i };
+      for (var c = 0; c < 15; c++) { row['c' + c] = 'r' + i + 'c' + c; }
+      d.push(row);
+    }
+    return d;
+  }
+  var baseOptions = { enableCellNavigation: true, enableColumnReorder: false, rowHeight: 25 };
+
+  var gridPlain = new Slick.Grid('#gridPlain', makeData(30), columns, baseOptions);
+  var gridFrozen = new Slick.Grid('#gridFrozen', makeData(30), columns,
+    Object.assign({}, baseOptions, { frozenColumn: 1 }));
+  var gridAuto = new Slick.Grid('#gridAuto', makeData(8), columns,
+    Object.assign({}, baseOptions, { autoHeight: true }));
+  window.grid = gridPlain;
+
+  function settle() {
+    return new Promise(function (resolve) {
+      requestAnimationFrame(function () {
+        requestAnimationFrame(function () { setTimeout(resolve, 60); });
+      });
+    });
+  }
+
+  window.runChecks = function runChecks() {
+    var out = [], pass = true;
+    function check(label, ok, detail) {
+      out.push((ok ? 'PASS ' : 'FAIL ') + label + (detail ? '  [' + detail + ']' : ''));
+      if (!ok) { pass = false; }
+    }
+
+    function checkGrid(name, containerSel, headerScrollerSel, viewportSel) {
+      var container = document.querySelector(containerSel);
+      var headerScroller = container.querySelector(headerScrollerSel);
+      var headersDiv = headerScroller.querySelector('.slick-header-columns');
+      var viewport = container.querySelector(viewportSel);
+
+      var headerRange = headersDiv.getBoundingClientRect().width - headerScroller.clientWidth;
+      var bodyRange = viewport.scrollWidth - viewport.clientWidth;
+      check(name + ': header scroll range covers body scroll range',
+        headerRange >= bodyRange,
+        'headerRange=' + Math.round(headerRange) + ' bodyRange=' + Math.round(bodyRange));
+
+      viewport.scrollLeft = 1000000;
+      return settle().then(function () {
+        check(name + ': header scroller reaches the body scrollLeft at full right scroll',
+          headerScroller.scrollLeft === viewport.scrollLeft,
+          'header=' + headerScroller.scrollLeft + ' body=' + viewport.scrollLeft);
+
+        var lastHeader = headerScroller.querySelectorAll('.slick-header-column');
+        lastHeader = lastHeader[lastHeader.length - 1];
+        var lastCell = viewport.querySelector('.slick-row .slick-cell.l14.r14');
+        var dh = lastHeader.getBoundingClientRect().left;
+        var dc = lastCell.getBoundingClientRect().left;
+        check(name + ': last column header aligns with its body cells at full right scroll',
+          Math.abs(dh - dc) <= 1,
+          'headerLeft=' + dh.toFixed(1) + ' cellLeft=' + dc.toFixed(1));
+      });
+    }
+
+    return checkGrid('plain', '#gridPlain', '.slick-header-left', '.slick-viewport-top.slick-viewport-left')
+      .then(function () {
+        return checkGrid('frozen', '#gridFrozen', '.slick-header-right', '.slick-viewport-top.slick-viewport-right');
+      })
+      .then(function () {
+        return checkGrid('autoHeight', '#gridAuto', '.slick-header-left', '.slick-viewport-top.slick-viewport-left');
+      })
+      .then(function () {
+        out.push(pass ? '\\nALL CHECKS PASSED' : '\\nCHECKS FAILED');
+        document.getElementById('checkResults').textContent = out.join('\\n');
+        return pass;
+      });
+  };
+</script>
+</body>
+</html>`;
+
+describe('getHeadersWidth - header/body horizontal scroll sync pin', { retries: 1 }, () => {
+  it('should keep header scroll range, sync and alignment across plain, frozen and autoHeight grids', () => {
+    cy.intercept('GET', '/headers-width-scroll-sync-harness.html', {
+      headers: { 'content-type': 'text/html' },
+      body: harnessHtml,
+    });
+    cy.visit(`${Cypress.config('baseUrl')}/headers-width-scroll-sync-harness.html`);
+    cy.window().its('grid').should('exist');
+
+    cy.window().then((win: any) => win.runChecks()).then((ok) => {
+      cy.get('#checkResults').invoke('text').then((detail) => {
+        expect(ok, `in-page headers-width self-checks:\n${detail}`).to.eq(true);
+      });
+    });
+    cy.get('#checkResults').should('contain', 'ALL CHECKS PASSED');
+  });
+});

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -114,6 +114,11 @@ const ValueFilterMode = IIFE_ONLY ? Slick.ValueFilterMode : ValueFilterMode_;
 const Utils = IIFE_ONLY ? Slick.Utils : Utils_;
 const SelectionUtils = IIFE_ONLY ? Slick.SelectionUtils : SelectionUtils_;
 const WidthEvalMode = IIFE_ONLY ? Slick.WidthEvalMode : WidthEvalMode_;
+
+// slack added beyond the summed column widths so the header band always exceeds the
+// body scroll range (header width is the header/body scroll-sync floor) and column
+// drag-reorder has room past the last column
+const HEADER_WIDTH_SLACK = 1000;
 const Draggable = IIFE_ONLY ? Slick.Draggable : Draggable_;
 const MouseWheel = IIFE_ONLY ? Slick.MouseWheel : MouseWheel_;
 const Resizable = IIFE_ONLY ? Slick.Resizable : Resizable_;
@@ -4732,17 +4737,15 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     if (this.hasFrozenColumns()) {
-      this.headersWidthL = this.headersWidthL + 1000;
+      this.headersWidthL = this.headersWidthL + HEADER_WIDTH_SLACK;
 
       this.headersWidthR = Math.max(this.headersWidthR, this.viewportW) + this.headersWidthL;
-      this.headersWidthR += this.scrollbarDimensions?.width ?? 0;
     } else {
-      this.headersWidthL += this.scrollbarDimensions?.width ?? 0;
-      this.headersWidthL = Math.max(this.headersWidthL, this.viewportW) + 1000;
+      this.headersWidthL = Math.max(this.headersWidthL, this.viewportW) + HEADER_WIDTH_SLACK;
     }
 
     this.headersWidth = this.headersWidthL + this.headersWidthR;
-    return Math.max(this.headersWidth, this.viewportW) + 1000;
+    return Math.max(this.headersWidth, this.viewportW) + HEADER_WIDTH_SLACK;
   }
 
   /** Get the grid canvas width


### PR DESCRIPTION
Resolves the Q16 investigation item from the quirks triage (discussion #1247): `getHeadersWidth()` added the vertical-scrollbar width to the active band **twice** — once in the conditional gutter-attribution block (from #1260, gated on `!autoHeight`), and once more, unconditionally, in the band-finalization block. Two generations of code expressing the same intent.

### Why the duplicate add contributes nothing

The band widths already carry the classic **`+1000` fixed slack** (applied to the left band and again to the return value), which is what actually guarantees the two invariants the header width serves:

1. the header band's scroll range covers the body viewport's scroll range (header width is the header/body scroll-sync floor), and
2. column drag-reorder has room past the last column.

A second ≤17px scrollbar term riding on a 1000px slack cannot be load-bearing. It was also wrong-shaped: the conditional add correctly skips `autoHeight` grids (which have no vertical scrollbar), while the unconditional one gave them a gutter for a scrollbar that doesn't exist.

### The change

- Exactly **one** scrollbar add remains — the documented, conditional gutter attribution.
- The two unconditional duplicate adds are deleted.
- The `1000` literals are promoted to a named module constant, **`HEADER_WIDTH_SLACK`**, with a comment stating what the slack is for — the intent is now explicit rather than folklore.

Net effect on computed widths: the header container gets ≤17px narrower (and autoHeight grids lose the phantom gutter). The container is clipped, and both scroll-range floors retain the full 1000px slack, so nothing is user-visible.

This also simplifies the #1238 rework: the ViewportMgr's `computeHeaderWidths` currently mirrors the double-add bit-for-bit; after this lands it mirrors one sane formula.

### Test

`cypress/e2e/headers-width-scroll-sync.cy.ts` — a **regression pin**, not a bug repro (there is no fail-on-unfixed leg, and per that, no temporary example page). Self-hosting harness with three grids — plain, `frozenColumn: 1` (right band scrolls), and `autoHeight` — asserting for each: header scroll range ≥ body scroll range, header scroller reaches the body's `scrollLeft` at full right scroll (no clamping), and the last column's header stays pixel-aligned with its body cells there. Verified to pass on the **pre-change** build (baseline) and on the refactored build, so any future width-formula change that breaks scroll sync fails this spec.

Full cypress suite: all specs passed — 652 tests, 650 passing, 2 pre-existing skips (4m51s).

(Quirks-triage follow-up: with this, every actionable item from discussion #1247 is resolved on master — remaining entries are the documented keep-as-is decisions and the Q32 product call.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
