### PR TITLE
refactor: give the frozen right header band its own width slack

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -4748,7 +4748,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (this.hasFrozenColumns()) {
       this.headersWidthL = this.headersWidthL + HEADER_WIDTH_SLACK;
 
-      this.headersWidthR = Math.max(this.headersWidthR, this.viewportW) + this.headersWidthL;
+      this.headersWidthR = Math.max(this.headersWidthR, this.viewportW) + HEADER_WIDTH_SLACK;
     } else {
       this.headersWidthL = Math.max(this.headersWidthL, this.viewportW) + HEADER_WIDTH_SLACK;
     }


### PR DESCRIPTION
> [!WARNING]
> **Stacked on #1274** (this PR's base branch is `refactor/headers-width-slack`) — it uses the `HEADER_WIDTH_SLACK` constant and the scroll-sync pin spec introduced there. Please merge #1274 first; GitHub will retarget this PR to `master` when that branch is deleted.

Resolves Q15 from the quirks triage (discussion #1247): under a left freeze, the right header band's width was **cumulative** — `headersWidthR = max(sumR, viewportW) + headersWidthL` — sizing the right band to include the entire left band's width for no stated reason.

### Why it survived until now (the load-bearing part)

Every header band is built with `left: -1000px` on the columns container plus an injected `.slick-header-column { left: 1000px; }` rule, so each band's **width must include 1000px of shift compensation** or its columns overflow it. In the frozen path, the right band's compensation was **delivered through `headersWidthL`** (= `sumL` + slack) — which is why the triage classified Q15 as unknown-business-path and why a naive "drop the `+ headersWidthL`" would genuinely break the right band (clipped header columns, scroll clamping short at full right scroll — the pin spec fails exactly there on the naive version).

The borrowed `sumL` on top of that compensation was the phantom part.

### The change

One line: the right band now carries its **own** compensation —

```ts
this.headersWidthR = Math.max(this.headersWidthR, this.viewportW) + HEADER_WIDTH_SLACK;
```

The right header container gets `sumL` narrower (inert — it is clipped), and its post-offset extent becomes `max(sumR + gutter, viewportW)`: **exactly the regime the unfrozen band has always run in** (its `+1000` was likewise consumed by the `-1000px` offset all along). The frozen right band now matches that long-standing contract instead of exceeding it by an arbitrary, frozen-band-width-dependent margin.

This supersedes the triage's "defer normalization to the branch rework" position — the deferral existed because there was no safety net, and #1274's pin spec is that net.

### Validation

- `headers-width-scroll-sync.cy.ts` (from #1274) passes **unchanged** — its frozen-grid checks (header scroll range covers body range, header reaches the body `scrollLeft` at full right scroll with no clamping, last-column header/cell alignment) exercise exactly this contract.
- `example-frozen-columns-and-rows.cy.ts` green (8/8).
- Full cypress suite: all specs passed — 652 tests, 650 passing, 2 pre-existing skips (3m46s).

(With this and #1274, every actionable width-arithmetic item from discussion #1247 is resolved; Q14's shift-compensation slack is now named and documented, and the Q15 entry in the tracking notes moves from keep-as-is to normalized.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
