### PR TITLE
fix(selection): allow drag handle to shrink cell selection

### DIFF
--- a/src/plugins/slick.cellrangeselector.ts
+++ b/src/plugins/slick.cellrangeselector.ts
@@ -153,7 +153,7 @@ export class SlickCellRangeSelector implements SlickPlugin {
     }
 
       this._dragReplaceHandleActive = (dd.matchClassTag === 'dragReplaceHandle');
-      if (this._dragReplaceHandleActive) { 
+      if (this._dragReplaceHandleActive) {
         this._dragReplaceHandleCell = this._grid.getCellFromEvent(e);
       } else {
         this._previousSelectedRange = null;
@@ -389,7 +389,7 @@ export class SlickCellRangeSelector implements SlickPlugin {
 
       this._decorator.show(range, this._dragReplaceHandleActive);
       this.onCellRangeSelecting.notify({
-        range, selectionMode: '', 
+        range, selectionMode: '',
         allowAutoEdit: false
       });
     }
@@ -432,7 +432,11 @@ export class SlickCellRangeSelector implements SlickPlugin {
       );
 
     this.onCellRangeSelected.notify({ range: r, selectionMode: this._selectionMode, allowAutoEdit: (this._selectionMode === "SEL" && r.isSingleCell()) });
-    this._previousSelectedRange = SelectionUtils.normaliseDragRange(dd.range);
+    // keep the resulting range (not the raw drag range) so that a next drag-extend anchors on the real selection
+    this._previousSelectedRange = SelectionUtils.normaliseDragRange({
+      start: { row: r.fromRow, cell: r.fromCell },
+      end: { row: r.toRow, cell: r.toCell },
+    });
   }
 
   getCurrentRange() {
@@ -441,7 +445,7 @@ export class SlickCellRangeSelector implements SlickPlugin {
 
   getPreviousRange() {
     return this._previousSelectedRange;
-  } 
+  }
 }
 
 // extend Slick namespace on window object when building as iife

--- a/src/slick.core.ts
+++ b/src/slick.core.ts
@@ -1222,16 +1222,23 @@ export class SelectionUtils {
       ;
   }
 
-  public static normalRangeOppositeCellFromCopy(normalisedDragRange: DragRange, targetCell: { row: number, cell: number }): { row: number, cell: number } {
-    const row = targetCell.row < (normalisedDragRange.end.row || 0)
-      ? (normalisedDragRange.end.row || 0)
-      : (normalisedDragRange.start.row || 0)
-      ;
-    const cell = targetCell.cell < (normalisedDragRange.end.cell || 0)
-      ? (normalisedDragRange.end.cell || 0)
-      : (normalisedDragRange.start.cell || 0)
-      ;
-    return { row, cell };
+  /**
+   * Returns the anchor (opposite) cell to use while dragging the drag-extend handle.
+   * Anchoring on the range start lets the drag shrink the range (Excel behavior), while dragging
+   * past the start anchors on the range end so that it expands in the opposite direction instead.
+   */
+  public static normalRangeOppositeCellFromCopy(
+    normalisedDragRange: DragRange,
+    targetCell: { row: number; cell: number }
+  ): { row: number; cell: number } {
+    return {
+      row: targetCell.row < (normalisedDragRange.start.row || 0)
+        ? normalisedDragRange.end.row || 0
+        : normalisedDragRange.start.row || 0,
+      cell: targetCell.cell < (normalisedDragRange.start.cell || 0)
+        ? normalisedDragRange.end.cell || 0
+        : normalisedDragRange.start.cell || 0,
+    };
   }
 
   // copy to range above or below - includes corner space target range


### PR DESCRIPTION
_replicate Slickgrid-Universal PR https://github.com/ghiscoding/slickgrid-universal/pull/2729 to fix the issue described below_

### Problem

With the hybrid/cell selection model, the drag-extend handle (`.slick-drag-replace-handle`)
could only grow a cell range, never shrink it.

Given a selection of `D3:E4`, dragging the handle up by 1 row did nothing — the range
snapped back to `D3:E4`. Only dragging past the top of the range (row 2) had an effect,
expanding to `D2:E4`.

### Cause

`SlickSelectionUtils.normalRangeOppositeCellFromCopy()` picked the drag anchor by comparing
the drag target against the previous range's **end** corner. Any target inside the range
therefore anchored on the end corner, which reproduced the original range instead of
shrinking it.

Additionally, `SlickCellRangeSelector` stored `_previousSelectedRange` from the raw drag range
(active cell → drag target) rather than the range that actually ended up selected, so the
anchor was wrong on the drag following an opposite-direction expand.

### Fix

- `normalRangeOppositeCellFromCopy()` now anchors on the range **start** when the target is at
  or after the start (shrink or grow), and only anchors on the end when the target is dragged
  past the start (expand in the opposite direction).
- `_previousSelectedRange` is now derived from the resulting `SlickRange` instead of the raw
  drag range.

### Behavior (selection `D3:E4`, handle at bottom-right)

| drag handle to | before | after |
| --- | --- | --- |
| row 5 | `D3:E5` | `D3:E5` (unchanged) |
| row 4 | `D3:E4` | `D3:E4` (unchanged) |
| row 3 | `D3:E4` (no-op) | `D3:E3` (shrinks) |
| row 2 | `D2:E4` | `D2:E4` (unchanged) |

Same logic applies horizontally.

Shrinking does not fire `onDragReplaceCells` — `copyRangeIsLarger()` stays `false`, so no cells
are copied; only the selection changes.

### Notes on Excel parity

Excel *clears* the contents of the excluded cells when the fill handle is dragged inward,
whereas this only shrinks the selection. Directional/anchoring behavior otherwise matches.

### Breaking changes

None. Public API unchanged; only the anchor selection rule changed for a case that was
previously a no-op.

### Tests

- Added a shrink case to `normalRangeOppositeCellFromCopy()` in `slickCore.spec.ts`.
- Existing `slickCore.spec.ts` (98) and `slickCellRangeSelector.spec.ts` (18) pass unchanged.

---
_Assisted by GitHub Copilot using Claude Opus 5._

<img width="1914" height="660" alt="EXCEL_Yvo1BmkvLt" src="https://github.com/user-attachments/assets/37a3406e-9b9c-4fa1-a7b1-51434c418872" />
