### PR TITLE
fix(slickgrid): prevent native wheel drift with frozen columns

### DIFF
--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -4119,7 +4119,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   /**
    * Processes a mouse wheel event by adjusting the vertical scroll (scrollTop) based on deltaY (scaled by rowHeight)
    * and horizontal scroll (scrollLeft) based on deltaX. It then calls the internal scroll handler with the “mousewheel”
-   * type and, if any scrolling occurred, prevents the default action.
+   * type and, if any scrolling occurred, stops propagation. For frozen columns it also prevents the
+   * browser's default scrolling so the scrolling pane does not move ahead of the mirrored frozen pane.
    *
    * @param {MouseEvent} e - The mouse event.
    * @param {number} _delta - Unused delta value.
@@ -4137,6 +4138,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const handled = this._handleScroll('mousewheel');
     if (handled) {
       e.stopPropagation();
+      // Frozen columns use a second viewport whose vertical position is mirrored
+      // from the scrolling pane. Letting the browser also process this wheel event
+      // advances the source pane a second time, briefly putting it ahead of the
+      // frozen viewport until its subsequent scroll event is handled.
+      if (this.hasFrozenColumns()) {
+        e.preventDefault();
+      }
     }
   }
 


### PR DESCRIPTION
_replicate Slickgrid-Universal [PR 2737](https://github.com/ghiscoding/slickgrid-universal/pull/2737) into SlickGrid. You can see the included ChatGPT summary below._


## Summary

Fix wheel-scroll drift when using frozen columns.

When SlickGrid handles a wheel event, it updates the scrolling viewport and mirrors the vertical position to the frozen-column pane. The browser could then apply its native wheel scroll as well, briefly advancing the main viewport ahead of the frozen pane.

## Changes

- Prevent the native wheel default only after SlickGrid has handled the event and frozen columns are enabled.
- Keep existing event propagation behavior.
- Leave regular, non-frozen grid scrolling unchanged.

## Test Coverage

- Updated the frozen columns/rows mousewheel regression test to verify that the handled wheel event calls `preventDefault()`.
- `slickGrid.spec.ts`: 428 tests passing.

## Scope

This fixes wheel and touchpad scrolling handled by SlickGrid. Native scrollbar-thumb dragging remains unchanged.

### LLM model attribution
This PR was assisted by Codex GPT-5.6-Terra.

#### bug demo

[Screencast_20260817_193846.webm](https://github.com/user-attachments/assets/575e9ef1-811a-423c-8db3-b06624353c48)


#### with fix

[Screencast_20260817_193728.webm](https://github.com/user-attachments/assets/3fec9a9a-309a-423c-86de-fb94ab2ddad7)
