### PR TITLE
feat: add autoHeaderHeight option for multi-line column headers

### DIFF
--- a/cypress/e2e/example-auto-header-height-autosize.cy.ts
+++ b/cypress/e2e/example-auto-header-height-autosize.cy.ts
@@ -1,0 +1,262 @@
+describe('SlickGrid Auto Header Height - Autosize', () => {
+
+  beforeEach(() => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-auto-header-height-autosize.html`);
+    cy.get('#myGrid .slick-viewport', { timeout: 1000 }).should('be.visible');
+  });
+
+  describe('Header Content', () => {
+
+    it('should render plain text headers', () => {
+      cy.get('.slick-header-column').eq(1).find('.slick-column-name')
+        .should('contain.text', 'Customer');
+    });
+
+    it('should render HTML string headers without clipping', () => {
+      cy.get('.slick-header-column').eq(1).should(($header) => {
+        const element = $header[0] as HTMLElement;
+
+        expect(element.scrollHeight).to.be.lte(element.clientHeight + 1);
+      });
+
+      cy.get('.slick-header-column').eq(1).find('.slick-column-name strong')
+        .should('contain.text', 'Information');
+    });
+
+    it('should render DOM element headers without clipping', () => {
+      cy.get('.slick-header-column').eq(3).should(($header) => {
+        const element = $header[0] as HTMLElement;
+
+        expect(element.scrollHeight).to.be.lte(element.clientHeight + 1);
+      });
+
+      cy.get('.slick-header-column').eq(3).find('.slick-column-name strong')
+        .should('contain.text', 'Information');
+    });
+
+    it('should not clip any rendered header content', () => {
+      cy.get('.slick-header-column').each(($header) => {
+        const element = $header[0] as HTMLElement;
+        expect(element.scrollHeight).to.be.lte(element.clientHeight + 1);
+      });
+    });
+
+  });
+
+  describe('Auto Header Height', () => {
+
+    it('should expand the header when autoHeaderHeight is enabled', () => {
+      cy.get('#autoHeaderHeight').should('be.checked');
+
+      cy.get('.slick-header-columns').should(($header) => {
+        expect($header[0].offsetHeight).to.be.greaterThan(35);
+      });
+    });
+
+    it('should return to the normal header height when disabled', () => {
+      let expandedHeight = 0;
+
+      cy.get('.slick-header-columns').then(($header) => {
+        expandedHeight = $header[0].offsetHeight;
+      });
+
+      cy.get('#autoHeaderHeight').uncheck();
+      cy.get('#applyOptions').click();
+
+      cy.get('.slick-header-columns').should(($header) => {
+        expect($header[0].offsetHeight).to.be.lessThan(expandedHeight);
+      });
+    });
+
+    it('should restore the expanded header when re-enabled', () => {
+      cy.get('#autoHeaderHeight').uncheck();
+      cy.get('#applyOptions').click();
+
+      let normalHeight = 0;
+
+      cy.get('.slick-header-columns').then(($header) => {
+        normalHeight = $header[0].offsetHeight;
+      });
+
+      cy.get('#autoHeaderHeight').check();
+      cy.get('#applyOptions').click();
+
+      cy.get('.slick-header-columns').should(($header) => {
+        expect($header[0].offsetHeight).to.be.greaterThan(normalHeight);
+      });
+    });
+
+    it('should not clip headers after toggling autoHeaderHeight repeatedly', () => {
+      for (let i = 0; i < 3; i++) {
+        cy.get('#autoHeaderHeight').uncheck();
+        cy.get('#applyOptions').click();
+
+        cy.get('#autoHeaderHeight').check();
+        cy.get('#applyOptions').click();
+      }
+
+      cy.get('.slick-header-column').each(($header) => {
+        const element = $header[0] as HTMLElement;
+        expect(element.scrollHeight).to.be.lte(element.clientHeight + 1);
+      });
+    });
+
+  });
+
+  describe('IgnoreViewport Autosizing', () => {
+
+    it('should apply IgnoreViewport autosizing', () => {
+      cy.get('#autosizeMode').select('IgnoreViewport');
+      cy.get('#applyOptions').click();
+
+      cy.get('.slick-header-column').should('have.length', 5);
+
+      cy.get('.slick-header-column').each(($header) => {
+        expect($header.outerWidth()).to.be.greaterThan(0);
+      });
+    });
+
+    it('should recalculate header height after IgnoreViewport autosizes columns', () => {
+      cy.get('#autosizeMode').select('IgnoreViewport');
+      cy.get('#applyOptions').click();
+
+      // The important requirement is that header content remains fully visible
+      // after autosizing changes the column widths and triggers header measurement.
+      cy.get('.slick-header-column').each(($header) => {
+        const element = $header[0] as HTMLElement;
+        expect(element.scrollHeight).to.be.lte(element.clientHeight + 1);
+      });
+
+      cy.get('.slick-header-columns').should(($header) => {
+        expect($header[0].offsetHeight).to.be.greaterThan(0);
+      });
+    });
+
+  });
+
+  describe('ignoreHeaderText', () => {
+
+    it('should initially ignore header text during autosizing', () => {
+      cy.get('#ignoreHeaderText').should('be.checked');
+    });
+
+    it('should remain valid when header text is ignored during autosizing', () => {
+      cy.get('#ignoreHeaderText').check();
+      cy.get('#autosizeMode').select('IgnoreViewport');
+      cy.get('#applyOptions').click();
+
+      cy.get('.slick-header-column').eq(4).should(($header) => {
+        const element = $header[0] as HTMLElement;
+
+        expect(element.offsetWidth).to.be.greaterThan(0);
+        expect(element.scrollHeight).to.be.lte(element.clientHeight + 1);
+      });
+    });
+
+    it('should maintain valid header measurement when ignoreHeaderText is enabled', () => {
+      cy.get('#autosizeMode').select('IgnoreViewport');
+      cy.get('#ignoreHeaderText').check();
+      cy.get('#applyOptions').click();
+
+      cy.get('.slick-header-columns').should(($header) => {
+        expect($header[0].offsetHeight).to.be.greaterThan(0);
+      });
+
+      cy.get('.slick-header-column').each(($header) => {
+        const element = $header[0] as HTMLElement;
+        expect(element.scrollHeight).to.be.lte(element.clientHeight + 1);
+      });
+    });
+
+  });
+
+  describe('Column Autosizing', () => {
+
+    it('should maintain valid header height after autosizing columns', () => {
+      cy.get('#autosizeMode').select('IgnoreViewport');
+      cy.get('#applyOptions').click();
+
+      cy.get('.slick-header-columns').should(($header) => {
+        expect($header[0].offsetHeight).to.be.greaterThan(0);
+      });
+
+      cy.get('.slick-header-column').each(($header) => {
+        const element = $header[0] as HTMLElement;
+        expect(element.scrollHeight).to.be.lte(element.clientHeight + 1);
+      });
+    });
+
+    it('should remain functional after autosizing', () => {
+      cy.get('#autosizeMode').select('IgnoreViewport');
+      cy.get('#applyOptions').click();
+
+      cy.get('.slick-row:first-child .slick-cell:first-child').first().click()
+        .should('have.class', 'active');
+
+      cy.get('.slick-viewport').first().scrollTo('bottom');
+
+      cy.get('.slick-viewport').first().should(($viewport) => {
+        expect($viewport[0].scrollTop).to.be.greaterThan(0);
+      });
+    });
+
+  });
+
+  describe('LegacyForceFit', () => {
+
+    it('should not cause recursive rendering with autoHeaderHeight enabled', () => {
+      cy.get('#autosizeMode').select('LegacyForceFit');
+      cy.get('#applyOptions').click();
+
+      cy.get('#myGrid').should('be.visible');
+
+      cy.get('.slick-header-columns').should(($header) => {
+        expect($header[0].offsetHeight).to.be.greaterThan(0);
+      });
+      cy.get('.slick-row').should('exist');
+    });
+
+    it('should respond to container resize in LegacyForceFit without clipping or recursion', () => {
+      cy.get('#autosizeMode').select('LegacyForceFit');
+      cy.get('#applyOptions').click();
+
+      cy.get('#gridWidth').invoke('val', 800).trigger('input');
+
+      cy.get('.slick-header-column').each(($header) => {
+        const element = $header[0] as HTMLElement;
+
+        expect(element.scrollHeight).to.be.lte(element.clientHeight + 1);
+      });
+
+      cy.get('.slick-header-columns').should(($header) => {
+        expect($header[0].offsetHeight).to.be.greaterThan(0);
+      });
+      cy.get('.slick-row').should('exist');
+    });
+  });
+
+  describe('Combined Header Content and Autosizing', () => {
+
+    it('should support HTML and DOM headers with IgnoreViewport', () => {
+      cy.get('#autosizeMode').select('IgnoreViewport');
+      cy.get('#ignoreHeaderText').check();
+      cy.get('#applyOptions').click();
+
+      // HTML header.
+      cy.get('.slick-header-column').eq(1).find('.slick-column-name strong')
+        .should('contain.text', 'Information');
+
+      // DOM header.
+      cy.get('.slick-header-column').eq(3).find('.slick-column-name strong')
+        .should('contain.text', 'Information');
+
+      // Every header must still fit its content.
+      cy.get('.slick-header-column').each(($header) => {
+        const element = $header[0] as HTMLElement;
+        expect(element.scrollHeight).to.be.lte(element.clientHeight + 1);
+      });
+    });
+
+  });
+
+});

--- a/cypress/e2e/example-auto-header-height.cy.ts
+++ b/cypress/e2e/example-auto-header-height.cy.ts
@@ -1,0 +1,193 @@
+describe('SlickGrid Auto Header Height', () => {
+    beforeEach(() => {
+        cy.visit(`${Cypress.config('baseUrl')}/examples/example-auto-header-height.html`);
+        cy.get('#myGrid .slick-viewport', { timeout: 1000 }).should('be.visible');
+    });
+
+    describe('Basic Functionality', () => {
+        it('should auto-size the header when autoHeaderHeight is enabled by default', () => {
+            cy.get('#myGrid .slick-header-columns')
+                .should(($el) => {
+                    expect($el[0].offsetHeight).to.be.greaterThan(35);
+                });
+        });
+
+        it('should shrink header height when autoHeaderHeight is disabled', () => {
+            cy.get('#autoHeaderHeight').uncheck();
+            cy.get('#setAutoHeaderHeight').click();
+
+            cy.get('.slick-header-columns').should(($el) => {
+                const height = $el[0].offsetHeight;
+                expect(height).to.be.within(28, 34);
+            });
+        });
+
+        it('should not clip multi-line header content when autoHeaderHeight is enabled', () => {
+            cy.get('.slick-header-column .slick-column-name').first().should(($el) => {
+                // Check that content is not clipped (scrollHeight <= clientHeight)
+                const element = $el[0];
+                const scrollHeight = element.scrollHeight;
+                const clientHeight = element.clientHeight;
+                expect(scrollHeight).to.be.lte(clientHeight);
+            });
+        });
+
+        it('should revert to expanded height when autoHeaderHeight is re-enabled', () => {
+            cy.get('#autoHeaderHeight').uncheck();
+            cy.get('#setAutoHeaderHeight').click();
+
+            cy.get('.slick-header-columns').should(($el) => {
+                expect($el[0].offsetHeight).to.be.within(28, 34);
+            });
+
+            cy.get('#autoHeaderHeight').check();
+            cy.get('#setAutoHeaderHeight').click();
+
+            // Verify header expanded again
+            cy.get('.slick-header-columns').should(($el) => {
+                const height = $el[0].offsetHeight;
+                expect(height).to.be.greaterThan(35);
+            });
+        });
+    });
+
+    describe('Frozen Columns Support', () => {
+        it('should equalize left and right header pane heights when frozen columns exist', () => {
+            // Set frozen column to 3
+            cy.get('#frozenColumn').clear().type('3');
+            cy.get('#setFrozenColumn').click();
+
+            cy.get('.slick-header-left .slick-header-columns').then(($left) => {
+                cy.get('.slick-header-right .slick-header-columns').should(($right) => {
+                    const leftHeight = $left[0].offsetHeight;
+                    const rightHeight = $right[0].offsetHeight;
+
+                    // Heights should be equal (within 1px tolerance)
+                    expect(Math.abs(leftHeight - rightHeight)).to.be.lessThan(2);
+                });
+            });
+        });
+
+        it('should not overflow container when frozen columns are active', () => {
+            cy.get('#frozenColumn').clear().type('3');
+            cy.get('#setFrozenColumn').click();
+
+            cy.get('#myGrid').should(($grid) => {
+                const containerHeight = $grid[0].clientHeight;
+                const gridScrollHeight = $grid[0].scrollHeight;
+
+                expect(gridScrollHeight).to.be.lte(containerHeight + 1);
+            });
+        });
+
+        it('should maintain equal header heights after column resize with frozen columns', () => {
+            cy.get('#frozenColumn').clear().type('3');
+            cy.get('#setFrozenColumn').click();
+
+            cy.get('.slick-header-right .slick-header-columns')
+                .should('exist');
+
+            cy.get('.slick-resizable-handle').first().trigger('mousedown', { which: 1 });
+            cy.get('.slick-resizable-handle').first().trigger('mousemove', { clientX: 150, clientY: 0 });
+            cy.get('.slick-resizable-handle').first().trigger('mouseup', { force: true });
+
+            // Check that heights are still equal
+            cy.get('.slick-header-left .slick-header-columns').then(($left) => {
+                cy.get('.slick-header-right .slick-header-columns').should(($right) => {
+                    const leftHeight = $left[0].offsetHeight;
+                    const rightHeight = $right[0].offsetHeight;
+                    expect(Math.abs(leftHeight - rightHeight)).to.be.lessThan(2);
+                });
+            });
+        });
+    });
+
+    describe('Re-measure Triggers', () => {
+        it('should recalculate header height on column resize end', () => {
+            let initialHeight = 0;
+            cy.get('.slick-header-columns').should(($el) => {
+                initialHeight = $el[0].offsetHeight;
+            }).then(() => {
+                // "Duration Days" column is at index 2, its handle is at index 1 (since column 0 has no handle)
+                cy.get('.slick-resizable-handle:nth(1)').then(($handle) => {
+                    const rect = $handle[0].getBoundingClientRect();
+                    const pageX = rect.left + window.scrollX;
+                    const pageY = rect.top + window.scrollY;
+
+                    cy.get('.slick-resizable-handle:nth(1)')
+                        .trigger('mousedown', { which: 1, force: true, pageX, pageY })
+                        .trigger('mousemove', { which: 1, force: true, pageX: pageX - 30, pageY })
+                        .trigger('mouseup', { force: true });
+                });
+
+                cy.get('.slick-header-columns').should(($el) => {
+                    const newHeight = $el[0].offsetHeight;
+                    // The "Duration Days" column only has 2 words, so shrinking it doesn't force a 3rd line
+                    // The height should remain the same as the initial 2-line layout
+                    expect(newHeight).to.equal(initialHeight);
+                });
+            });
+        });
+
+        it('should recalculate header height when expanding a multi-line column to single line', () => {
+            let initialHeight = 0;
+            cy.get('.slick-header-columns').should(($el) => {
+                initialHeight = $el[0].offsetHeight;
+            }).then(() => {
+                // "Duration Days" column is at index 2, its handle is at index 1 (since column 0 has no handle)
+                cy.get('.slick-resizable-handle:nth(1)').then(($handle) => {
+                    const rect = $handle[0].getBoundingClientRect();
+                    const pageX = rect.left + window.scrollX;
+                    const pageY = rect.top + window.scrollY;
+
+                    cy.get('.slick-resizable-handle:nth(1)')
+                        .trigger('mousedown', { which: 1, force: true, pageX, pageY })
+                        .trigger('mousemove', { which: 1, force: true, pageX: pageX + 100, pageY })
+                        .trigger('mouseup', { force: true });
+                });
+
+                cy.get('.slick-header-columns').should(($el) => {
+                    const newHeight = $el[0].offsetHeight;
+                    // Expanding the column should reduce from 2 lines to 1 line
+                    expect(newHeight).to.be.lessThan(initialHeight);
+                });
+            });
+        });
+    });
+
+    describe('Edge Cases and Validation', () => {
+        it('should not clip multi-line headers after multiple toggles', () => {
+            // Toggle multiple times
+            for (let i = 0; i < 3; i++) {
+                cy.get('#autoHeaderHeight').uncheck();
+                cy.get('#setAutoHeaderHeight').click();
+
+                cy.get('#autoHeaderHeight').check();
+                cy.get('#setAutoHeaderHeight').click();
+            }
+
+            // Verify no clipping
+            cy.get('.slick-header-column .slick-column-name').first().should(($el) => {
+                const element = $el[0];
+                const scrollHeight = element.scrollHeight;
+                const clientHeight = element.clientHeight;
+                expect(scrollHeight).to.be.lte(clientHeight + 2);
+            });
+        });
+
+        it('should maintain grid functionality with autoHeaderHeight enabled', () => {
+            // Click on a cell should work
+            cy.get('.slick-row:first-child .slick-cell:first-child').click();
+
+            // Cell should be selected (has 'active' class)
+            cy.get('.slick-row:first-child .slick-cell:first-child').should('have.class', 'active');
+
+            // Scroll should still work
+            cy.get('.slick-viewport').first().scrollTo('bottom');
+            cy.get('.slick-viewport').should(($el) => {
+                const scrollTop = $el[0].scrollTop;
+                expect(scrollTop).to.be.greaterThan(0);
+            });
+        });
+    });
+});

--- a/cypress/e2e/example-auto-header-height.cy.ts
+++ b/cypress/e2e/example-auto-header-height.cy.ts
@@ -51,11 +51,13 @@ describe('SlickGrid Auto Header Height', () => {
         });
     });
 
-    describe('Frozen Columns Support', () => {
-        it('should equalize left and right header pane heights when frozen columns exist', () => {
-            // Set frozen column to 3
-            cy.get('#frozenColumn').clear().type('3');
+    describe('Frozen Columns & Rows Support', () => {
+        it('should equalize left and right header pane heights when frozen columns & rows exist', () => {
+            cy.get('#frozenColumn').clear().type('2');
             cy.get('#setFrozenColumn').click();
+
+            cy.get('#frozenRow').clear().type('5');
+            cy.get('#setFrozenRow').click();
 
             cy.get('.slick-header-left .slick-header-columns').then(($left) => {
                 cy.get('.slick-header-right .slick-header-columns').should(($right) => {
@@ -68,9 +70,28 @@ describe('SlickGrid Auto Header Height', () => {
             });
         });
 
-        it('should not overflow container when frozen columns are active', () => {
-            cy.get('#frozenColumn').clear().type('3');
+        it('should maintain correct header and container dimensions with frozen rows & columns', () => {
+            cy.get('#frozenColumn').clear().type('2');
             cy.get('#setFrozenColumn').click();
+
+            cy.get('#frozenRow').clear().type('5');
+            cy.get('#setFrozenRow').click();
+
+            cy.get('.slick-header-columns').should(($header) => {
+                expect($header[0].offsetHeight).to.be.greaterThan(0);
+            });
+
+            cy.get('#myGrid').should(($grid) => {
+                expect($grid[0].scrollHeight).to.be.lte($grid[0].clientHeight + 1);
+            });
+        });
+
+        it('should not overflow container when frozen columns & rows are active', () => {
+            cy.get('#frozenColumn').clear().type('2');
+            cy.get('#setFrozenColumn').click();
+
+            cy.get('#frozenRow').clear().type('5');
+            cy.get('#setFrozenRow').click();
 
             cy.get('#myGrid').should(($grid) => {
                 const containerHeight = $grid[0].clientHeight;
@@ -80,9 +101,12 @@ describe('SlickGrid Auto Header Height', () => {
             });
         });
 
-        it('should maintain equal header heights after column resize with frozen columns', () => {
-            cy.get('#frozenColumn').clear().type('3');
+        it('should maintain equal header heights after column resize with frozen columns & rows', () => {
+            cy.get('#frozenColumn').clear().type('2');
             cy.get('#setFrozenColumn').click();
+
+            cy.get('#frozenRow').clear().type('5');
+            cy.get('#setFrozenRow').click();
 
             cy.get('.slick-header-right .slick-header-columns')
                 .should('exist');
@@ -176,17 +200,16 @@ describe('SlickGrid Auto Header Height', () => {
         });
 
         it('should maintain grid functionality with autoHeaderHeight enabled', () => {
-            // Click on a cell should work
-            cy.get('.slick-row:first-child .slick-cell:first-child').click();
+            const cellSelector = '.slick-row:first-child .slick-cell:first-child';
 
-            // Cell should be selected (has 'active' class)
-            cy.get('.slick-row:first-child .slick-cell:first-child').should('have.class', 'active');
+            // Frozen panes can result in multiple matching cells.
+            cy.get(cellSelector).first().click().should('have.class', 'active');
 
-            // Scroll should still work
-            cy.get('.slick-viewport').first().scrollTo('bottom');
-            cy.get('.slick-viewport').should(($el) => {
-                const scrollTop = $el[0].scrollTop;
-                expect(scrollTop).to.be.greaterThan(0);
+            // Scroll should still work.
+            cy.get('.slick-viewport-bottom').eq(1).scrollTo('bottom');
+
+            cy.get('.slick-viewport-bottom').eq(1).should(($el) => {
+                expect($el[0].scrollTop).to.be.greaterThan(0);
             });
         });
     });

--- a/examples/example-auto-header-height-autosize.html
+++ b/examples/example-auto-header-height-autosize.html
@@ -1,0 +1,242 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
+  <title>Auto Header Height - Autosize Modes</title>
+  <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css" />
+  <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css" />
+
+  <style>
+    .controls-panel { width: 280px; padding: 10px 15px; vertical-align: top; }
+    .control-row { margin-bottom: 8px; }
+    .control-row label { display: inline-block; min-width: 140px; }
+    .control-row select { min-width: 110px; }
+  </style>
+</head>
+
+<body>
+  <h2 class="title">Example - Auto Header Height &amp; Column Autosizing</h2>
+  <div style="position:relative">
+    <table width="100%">
+      <tr>
+        <td valign="top">
+          <div id="myGrid" class="slick-container" style="width:700px;height:450px;">
+          </div>
+        </td>
+
+        <td class="options-panel controls-panel" style="left: 900px;">
+          <h2>Options</h2>
+          <hr />
+
+          <div class="control-row">
+            <label for="autoHeaderHeight">
+              Auto Header Height:
+            </label>
+            <input type="checkbox" id="autoHeaderHeight" checked>
+          </div>
+
+          <div class="control-row">
+            <label for="autosizeMode">Autosize Mode:</label>
+            <select id="autosizeMode">
+              <option value="NOA">None</option>
+              <option value="LOF">LegacyOff</option>
+              <option value="LFF">LegacyForceFit</option>
+              <option value="IGV" selected>IgnoreViewport</option>
+              <option value="FCV">FitColsToViewport</option>
+              <option value="FVC">FitViewportToCols</option>
+            </select>
+          </div>
+
+          <div class="control-row">
+            <label for="ignoreHeaderText">Ignore Header Text:</label>
+            <input type="checkbox" id="ignoreHeaderText" checked>
+          </div>
+
+          <div class="control-row">
+            <label for="gridWidth" class="label">Grid Width:</label>
+            <input type="range" id="gridWidth" min="550" max="850" value="700" step="50" style="width: 65px;">
+            <span id="gridWidthValue">700px</span>
+          </div>
+          <p>
+            Change the grid width to test container resizing.
+            <code>LegacyForceFit</code> automatically responds through the existing
+            SlickGrid resize pipeline. Other autosize modes can be recalculated with
+            <strong>Apply</strong>.
+          </p>
+
+          <button id="applyOptions">Apply</button>
+          <button id="resetOptions">Reset</button>
+
+          <h2>Demonstrates</h2>
+          <ul>
+            <li>Header text participating in autosizing</li>
+            <li><code>ignoreHeaderText</code></li>
+            <li>All column autosizing algorithms</li>
+            <li>Header height recalculation after column width changes</li>
+            <li>Automatic header height for multi-line headers</li>
+            <li>HTML and DOM header content</li>
+            <li>Naturally wrapping long headers</li>
+            <li>Header wrapping when the grid width changes</li>
+            <li>Existing container resize behavior with <code>LegacyForceFit</code></li>
+          </ul>
+
+          <h2>View Source</h2>
+          <ul>
+            <li>
+              <a href="https://github.com/6pac/SlickGrid/blob/master/examples/example-auto-header-height-autosize.html"
+                target="_sourcewindow"> View the source on Github </a>
+            </li>
+          </ul>
+        </td>
+      </tr>
+    </table>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
+  <script src="sortable-cdn-fallback.js"></script>
+  <script src="../dist/browser/slick.core.js"></script>
+  <script src="../dist/browser/slick.interactions.js"></script>
+  <script src="../dist/browser/slick.grid.js"></script>
+  <script src="../dist/browser/slick.formatters.js"></script>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+
+      var grid;
+
+      var domHeader = document.createElement('p');
+      domHeader.style.margin = '0';
+      domHeader.innerHTML = 'Project<br><strong style="color:red;">Information</strong>';
+
+      var columns = [
+        { id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 30, cannotTriggerInsert: true, resizable: false, unselectable: true },
+        { id: 'html', name: 'Customer<br><strong style="color:red;">Information</strong>', field: 'customer', minWidth: 85 },
+        { id: 'ignore', name: 'Header Text Should Be Ignored', field: 'value', minWidth: 110, autoSize: { ignoreHeaderText: true } },
+        { id: 'dom', name: domHeader, field: 'project', minWidth: 85 },
+        { id: 'long', name: 'Long Header With Several Words', field: 'description', width: 130, minWidth: 70 },
+      ];
+
+      var initialColumnWidths = columns.map(function (column) { return column.width; });
+      updateIgnoreHeaderTextState();
+
+      var data = [];
+      for (var i = 0; i < 999; i++) {
+        data.push({
+          num: (i + 1),
+          customer: 'Customer ' + (i + 1),
+          value: 'Value with information ' + (i + 1),
+          project: 'Project ' + (i + 1),
+          description: 'Description ' + (i + 1) + ' with useful information'
+        });
+      }
+
+      var initialOptions = {
+        enableCellNavigation: true,
+        enableColumnReorder: false,
+        autoHeaderHeight: true,
+        autosizeColsMode: Slick.GridAutosizeColsMode.IgnoreViewport
+      };
+
+      grid = new Slick.Grid('#myGrid', data, columns, initialOptions);
+      grid.autosizeColumns();
+
+      // Apply
+      document.querySelector('#applyOptions').addEventListener('click', function () {
+
+        var autoHeaderHeight = document.querySelector('#autoHeaderHeight').checked;
+        var autosizeMode = document.querySelector('#autosizeMode').value;
+        var ignoreHeaderText = document.querySelector('#ignoreHeaderText').checked;
+
+
+        columns.forEach(function (column, index) {
+          if (autosizeMode !== Slick.GridAutosizeColsMode.LegacyForceFit) {
+            column.width = initialColumnWidths[index];
+          }
+
+          column.autoSize = { ignoreHeaderText: ignoreHeaderText };
+        });
+
+        grid.setOptions({
+          autoHeaderHeight: autoHeaderHeight,
+          autosizeColsMode: autosizeMode
+        });
+
+        grid.setColumns(columns);
+        grid.autosizeColumns();
+
+        setTimeout(function () {
+          var gridElement = document.querySelector('#myGrid');
+          var newWidth = parseInt(gridElement.style.width) || gridElement.clientWidth;
+
+          document.querySelector('#gridWidthValue').textContent = newWidth + 'px';
+          document.querySelector('#gridWidth').value = newWidth;
+        }, 50);
+
+      });
+
+      // Reset
+      document.querySelector('#resetOptions').addEventListener('click', function () {
+
+        columns.forEach(function (column, index) {
+          column.width = initialColumnWidths[index];
+          column.autoSize = { ignoreHeaderText: true };
+        });
+
+        var defaultWidth = 700;
+        document.querySelector('#gridWidthValue').textContent = defaultWidth + 'px';
+        document.querySelector('#myGrid').style.width = defaultWidth + 'px';
+        document.querySelector('#gridWidth').value = defaultWidth;
+
+        // Set default controls
+        document.querySelector('#autoHeaderHeight').checked = initialOptions.autoHeaderHeight;
+        document.querySelector('#autosizeMode').value = initialOptions.autosizeColsMode;
+        document.querySelector('#ignoreHeaderText').checked = true;
+        updateIgnoreHeaderTextState();
+
+        grid.setOptions({
+          autoHeaderHeight: initialOptions.autoHeaderHeight,
+          autosizeColsMode: initialOptions.autosizeColsMode
+        });
+
+        grid.setColumns(columns);
+        grid.autosizeColumns();
+      });
+
+      document.querySelector('#gridWidth').addEventListener('input', function () {
+        var width = parseInt(this.value);
+
+        document.querySelector('#gridWidthValue').textContent = width + 'px';
+        var gridElement = document.querySelector('#myGrid');
+        gridElement.style.width = width + 'px';
+
+        var autosizeMode = document.querySelector('#autosizeMode').value;
+
+        // LegacyForceFit automatically responds to the container resize through SlickGrid's existing resizeCanvas() pipeline.
+        if (autosizeMode === Slick.GridAutosizeColsMode.LegacyForceFit) {
+          gridElement.dispatchEvent(new Event('resize'));
+        }
+      });
+
+      function updateIgnoreHeaderTextState() {
+        var autosizeMode = document.querySelector('#autosizeMode').value;
+        var ignoreHeaderText = document.querySelector('#ignoreHeaderText');
+
+        var supported =
+          autosizeMode !== Slick.GridAutosizeColsMode.None &&
+          autosizeMode !== Slick.GridAutosizeColsMode.LegacyOff &&
+          autosizeMode !== Slick.GridAutosizeColsMode.LegacyForceFit;
+
+        ignoreHeaderText.disabled = !supported;
+      }
+
+      document.querySelector('#autosizeMode').addEventListener('change', function () {
+        updateIgnoreHeaderTextState();
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/examples/example-auto-header-height.html
+++ b/examples/example-auto-header-height.html
@@ -5,13 +5,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
-  <title>Auto Header Height</title>
+  <title>Auto Header Height - Layout</title>
   <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css" />
   <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css" />
 
   <style>
     .slick-pane.frozen {
-      border-right: 1.5px dotted darkblue !important;
+      border-right: 1.5px dotted darkred !important;
+    }
+
+    .slick-pane-top {
+      border-bottom: 1.5px dotted darkred !important;
     }
 
     .cell-selection {
@@ -30,7 +34,7 @@
 </head>
 
 <body>
-  <h2 class="title">Example - Auto Header Height</h2>
+  <h2 class="title">Example - Auto Header Height (Layout)</h2>
   <div style="position:relative">
     <table width="100%">
       <tr>
@@ -46,28 +50,35 @@
           <hr />
 
           <label for="autoHeaderHeight" style="width:160px;float:left;padding-left:40px;">
-            Enable Auto Header Height:
+            Auto Header Height:
           </label>
-          <input type=checkbox id="autoHeaderHeight" style="width:60px;" checked=checked>
+          <input type="checkbox" id="autoHeaderHeight" style="width:60px;" checked>
           <button id="setAutoHeaderHeight">Set</button>
           <br /><br />
 
           <label for="frozenColumn" style="width:160px;float:left;padding-left:40px;">
             Frozen Column:
           </label>
-          <input type=text id="frozenColumn" style="width:60px;" value="-1">
+          <input type="text" id="frozenColumn" style="width:60px;" value="2">
           <button id="setFrozenColumn">Set</button>
           <br />
 
+          <label for="frozenRow" style="width:160px;float:left;padding-left:40px;">
+            Frozen Row:
+          </label>
+          <input type="text" id="frozenRow" style="width:60px;" value="5">
+          <button id="setFrozenRow">Set</button>
+
           <h2> Demonstrates: </h2>
           <ul>
-            <li>auto-sizing header height to fit multi-line column titles</li>
-            <li>no clipping of header content when titles wrap to multiple lines</li>
-            <li>opt-in feature with <code>autoHeaderHeight</code> grid option (disabled by default)</li>
-            <li>works with both single-line and multi-line headers</li>
-            <li>dynamic recalculation on column resize</li>
-            <li>frozen column support with equalized left/right header heights</li>
-            <li>minimal configuration (just set <code>autoHeaderHeight:true</code>)</li>
+            <li>automatic header height calculation</li>
+            <li>enabling and disabling <code>autoHeaderHeight</code></li>
+            <li>frozen column support</li>
+            <li>frozen row support</li>
+            <li>combined frozen column and frozen row layouts</li>
+            <li>equal left/right header heights</li>
+            <li>header recalculation after column resizing</li>
+            <li>grid remaining within its container</li>
           </ul>
           <h2>View Source:</h2>
           <ul>
@@ -90,10 +101,6 @@
   <script src="../dist/browser/slick.formatters.js"></script>
 
   <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      document.querySelector('#frozenColumn').value = options.frozenColumn;
-    });
-
     var grid;
     var columns = [
       { id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 30, cannotTriggerInsert: true, resizable: false, unselectable: true },
@@ -103,21 +110,19 @@
       { id: "start", name: "Start", field: "start", width: 80 },
       { id: "finish", name: "Finish", field: "finish", width: 80 },
       { id: "effort-driven", name: "Effort Driven", field: "effortDriven", width: 100, minWidth: 60 },
-      { id: "priority", name: "Priority", field: "priority", width: 80 },
-      { id: "status", name: "Status", field: "status" },
-      { id: "completed", name: "Completed", field: "completed" }
+      { id: "status", name: "Status", field: "status" }
     ];
 
     var options = {
       enableCellNavigation: true,
       enableColumnReorder: false,
       autoHeaderHeight: true,
-      frozenColumn: -1
+      frozenColumn: 2,
+      frozenRow: 5
     };
 
     var data = [];
     var statuses = ['Not Started', 'In Progress', 'Review', 'Completed', 'On Hold'];
-    var priorities = ['Low', 'Medium', 'High', 'Critical'];
 
     for (var i = 0; i < 1000; i++) {
       var startDate = new Date(2025, Math.floor(Math.random() * 12), Math.floor(Math.random() * 28) + 1);
@@ -132,9 +137,7 @@
         start: startDate.toLocaleDateString('en-US'),
         finish: finishDate.toLocaleDateString('en-US'),
         effortDriven: (i % 5 == 0),
-        priority: priorities[Math.floor(Math.random() * priorities.length)],
-        status: statuses[Math.floor(Math.random() * statuses.length)],
-        completed: (i % 3 == 0) ? 'Yes' : 'No'
+        status: statuses[Math.floor(Math.random() * statuses.length)]
       };
     }
 
@@ -153,6 +156,16 @@
       }
 
       grid.setOptions({ 'frozenColumn': val });
+    });
+
+    document.querySelector('#setFrozenRow').addEventListener('click', function () {
+      var val = -1;
+
+      if (document.querySelector('#frozenRow').value != '') {
+        val = parseInt(document.querySelector('#frozenRow').value);
+      }
+
+      grid.setOptions({ 'frozenRow': val });
     });
   </script>
 </body>

--- a/examples/example-auto-header-height.html
+++ b/examples/example-auto-header-height.html
@@ -1,0 +1,160 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
+  <title>Auto Header Height</title>
+  <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css" />
+  <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css" />
+
+  <style>
+    .slick-pane.frozen {
+      border-right: 1.5px dotted darkblue !important;
+    }
+
+    .cell-selection {
+      border-right-color: silver;
+      border-right-style: solid;
+      background: #f5f5f5;
+      color: gray;
+      text-align: right;
+      font-size: 10px;
+    }
+
+    .slick-row.selected .cell-selection {
+      background-color: transparent;
+    }
+  </style>
+</head>
+
+<body>
+  <h2 class="title">Example - Auto Header Height</h2>
+  <div style="position:relative">
+    <table width="100%">
+      <tr>
+        <td valign="top" width="50%">
+          <div id="myGrid" class="slick-container" style="width:600px;height:450px;"></div>
+        </td>
+
+        <td class="options-panel" valign="center" style="padding:6px;">
+          <h2>
+            <a href="/examples/index.html" style="text-decoration: none; font-size: 22px">&#x2302;</a>
+            Search:
+          </h2>
+          <hr />
+
+          <label for="autoHeaderHeight" style="width:160px;float:left;padding-left:40px;">
+            Enable Auto Header Height:
+          </label>
+          <input type=checkbox id="autoHeaderHeight" style="width:60px;" checked=checked>
+          <button id="setAutoHeaderHeight">Set</button>
+          <br /><br />
+
+          <label for="frozenColumn" style="width:160px;float:left;padding-left:40px;">
+            Frozen Column:
+          </label>
+          <input type=text id="frozenColumn" style="width:60px;" value="-1">
+          <button id="setFrozenColumn">Set</button>
+          <br />
+
+          <h2> Demonstrates: </h2>
+          <ul>
+            <li>auto-sizing header height to fit multi-line column titles</li>
+            <li>no clipping of header content when titles wrap to multiple lines</li>
+            <li>opt-in feature with <code>autoHeaderHeight</code> grid option (disabled by default)</li>
+            <li>works with both single-line and multi-line headers</li>
+            <li>dynamic recalculation on column resize</li>
+            <li>frozen column support with equalized left/right header heights</li>
+            <li>minimal configuration (just set <code>autoHeaderHeight:true</code>)</li>
+          </ul>
+          <h2>View Source:</h2>
+          <ul>
+            <li>
+              <a href="https://github.com/6pac/SlickGrid/blob/master/examples/example-auto-header-height.html"
+                target="_sourcewindow"> View the source for this example on Github</a>
+            </li>
+          </ul>
+        </td>
+      </tr>
+    </table>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
+  <script src="sortable-cdn-fallback.js"></script>
+
+  <script src="../dist/browser/slick.core.js"></script>
+  <script src="../dist/browser/slick.interactions.js"></script>
+  <script src="../dist/browser/slick.grid.js"></script>
+  <script src="../dist/browser/slick.formatters.js"></script>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      document.querySelector('#frozenColumn').value = options.frozenColumn;
+    });
+
+    var grid;
+    var columns = [
+      { id: "sel", name: "#", field: "num", behavior: "select", cssClass: "cell-selection", width: 30, cannotTriggerInsert: true, resizable: false, unselectable: true },
+      { id: "title", name: "Title", field: "title", width: 70 },
+      { id: "duration", name: "Duration Days", field: "duration", width: 80, minWidth: 70 },
+      { id: "%", name: "% Complete", field: "percentComplete", width: 90, formatter: Slick.Formatters.PercentComplete },
+      { id: "start", name: "Start", field: "start", width: 80 },
+      { id: "finish", name: "Finish", field: "finish", width: 80 },
+      { id: "effort-driven", name: "Effort Driven", field: "effortDriven", width: 100, minWidth: 60 },
+      { id: "priority", name: "Priority", field: "priority", width: 80 },
+      { id: "status", name: "Status", field: "status" },
+      { id: "completed", name: "Completed", field: "completed" }
+    ];
+
+    var options = {
+      enableCellNavigation: true,
+      enableColumnReorder: false,
+      autoHeaderHeight: true,
+      frozenColumn: -1
+    };
+
+    var data = [];
+    var statuses = ['Not Started', 'In Progress', 'Review', 'Completed', 'On Hold'];
+    var priorities = ['Low', 'Medium', 'High', 'Critical'];
+
+    for (var i = 0; i < 1000; i++) {
+      var startDate = new Date(2025, Math.floor(Math.random() * 12), Math.floor(Math.random() * 28) + 1);
+      var finishDate = new Date(startDate);
+      finishDate.setDate(finishDate.getDate() + Math.floor(Math.random() * 14) + 3);
+
+      data[i] = {
+        num: i,
+        title: "Task " + (i + 1),
+        duration: (Math.floor(Math.random() * 10) + 2) + " days",
+        percentComplete: Math.round(Math.random() * 100),
+        start: startDate.toLocaleDateString('en-US'),
+        finish: finishDate.toLocaleDateString('en-US'),
+        effortDriven: (i % 5 == 0),
+        priority: priorities[Math.floor(Math.random() * priorities.length)],
+        status: statuses[Math.floor(Math.random() * statuses.length)],
+        completed: (i % 3 == 0) ? 'Yes' : 'No'
+      };
+    }
+
+    grid = new Slick.Grid("#myGrid", data, columns, options);
+
+    document.querySelector('#setAutoHeaderHeight').addEventListener('click', function () {
+      var val = document.querySelector('#autoHeaderHeight').checked;
+      grid.setOptions({ 'autoHeaderHeight': val });
+    });
+
+    document.querySelector('#setFrozenColumn').addEventListener('click', function () {
+      var val = -1;
+
+      if (document.querySelector('#frozenColumn').value != '') {
+        val = parseInt(document.querySelector('#frozenColumn').value);
+      }
+
+      grid.setOptions({ 'frozenColumn': val });
+    });
+  </script>
+</body>
+
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -109,6 +109,7 @@
       <li><a href="./example-variable-row-height.html">Variable row height (rowHeightProvider)</a></li>
       <li><a href="./example-variable-row-height-spans.html">Variable row height with cell spans (rowHeightProvider + enableCellRowSpan)</a></li>
       <li><a href="./example-variable-row-height-frozen.html">Variable row height with frozen columns/rows (rowHeightProvider + frozenColumn/frozenRow)</a></li>
+      <li><a href="./example-auto-header-height.html">Auto header height</a></li>
     </ul>
   </div>
   <h2>Data-Centric</h2>

--- a/examples/index.html
+++ b/examples/index.html
@@ -109,7 +109,8 @@
       <li><a href="./example-variable-row-height.html">Variable row height (rowHeightProvider)</a></li>
       <li><a href="./example-variable-row-height-spans.html">Variable row height with cell spans (rowHeightProvider + enableCellRowSpan)</a></li>
       <li><a href="./example-variable-row-height-frozen.html">Variable row height with frozen columns/rows (rowHeightProvider + frozenColumn/frozenRow)</a></li>
-      <li><a href="./example-auto-header-height.html">Auto header height</a></li>
+      <li><a href="./example-auto-header-height.html">Auto header height - Layout</a></li>
+      <li><a href="./example-auto-header-height-autosize.html">Auto header height - Autosize </a></li>
     </ul>
   </div>
   <h2>Data-Centric</h2>

--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -353,6 +353,9 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   /** Defaults to 400, duration to show the row highlight (e.g. after CRUD executions) */
   rowHighlightDuration?: number;
 
+  /** Defaults to false, when enabled the header row will automatically resize its height to fit multi-line column titles */
+  autoHeaderHeight?: boolean;
+
   /** Defaults to false, sets the grid direction to RTL (Right-to-Left) for proper rendering of RTL languages */
   rtl?: boolean;
 

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -923,6 +923,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.setupColumnSort();
       this.createCssRules();
       this.resizeCanvas();
+
+      if (this._options.autoHeaderHeight) {
+        this.recalculateHeaderHeight();
+      }
+
       this.bindAncestorScrollEvents();
 
       this._bindingEventService.bind(this._container, 'resize', this.resizeCanvas.bind(this));
@@ -1983,15 +1988,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this._clearAutoHeaderHeightStyles(headers);
       return;
     }
-
-    setTimeout(() => this.recalculateHeaderHeight(), 0);
   }
 
   /**
    * Measures natural header heights and applies one common height to all header panes.
    */
   protected recalculateHeaderHeight() {
-    if (!this._options.autoHeaderHeight || !this._headerScrollerL) {
+    if (!this._headerScrollerL) {
       return;
     }
 
@@ -2007,8 +2010,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       return;
     }
 
-    const extra = this._getHeaderColumnVerticalExtra(this._headerL);
-    this._setAutoHeaderHeightStyles(maxHeight, extra, headers);
+    this._setAutoHeaderHeightStyles(maxHeight, headers);
 
     // Recalculate viewport and pane dimensions from the current header height.
     this.resizeCanvas();
@@ -2020,7 +2022,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   private _clearAutoHeaderHeightStyles(headers: HTMLDivElement[]) {
     headers.forEach(header => {
       header.style.removeProperty('--slick-auto-header-height');
-      header.style.removeProperty('--slick-auto-header-height-extra');
       header.style.height = '';
     });
   }
@@ -2028,33 +2029,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   /**
    * Applies the calculated automatic header height styles.
    */
-  private _setAutoHeaderHeightStyles(height: number, extra: number, headers: HTMLDivElement[]) {
-    const heightValue = `${height}px`;
-    const extraValue = `${extra}px`;
+  private _setAutoHeaderHeightStyles(height: number, headers: HTMLDivElement[]) {
 
     headers.forEach(header => {
-      header.style.setProperty('--slick-auto-header-height', heightValue);
-      header.style.setProperty('--slick-auto-header-height-extra', extraValue);
-      header.style.height = heightValue;
+      header.style.setProperty('--slick-auto-header-height', `${height}px`);
+      header.style.height = `${height}px`;
     });
-  }
-
-  /**
-   * Returns the vertical padding and border size of a header column.
-   */
-  private _getHeaderColumnVerticalExtra(header: HTMLElement): number {
-    const column = header.querySelector<HTMLElement>('.slick-header-column');
-
-    if (!column) {
-      return 0;
-    }
-
-    const style = getComputedStyle(column);
-
-    return (
-      (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0) +
-      (parseFloat(style.borderTopWidth) || 0) + (parseFloat(style.borderBottomWidth) || 0)
-    );
   }
 
   /**
@@ -3642,6 +3622,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.updateCanvasWidth();
       this.applyColumnHeaderWidths();
       this.applyColumnWidths();
+
+      if (this._options.autoHeaderHeight) {
+        this.recalculateHeaderHeight();
+      }
+
       this.handleScroll();
       this.getSelectionModel()?.refreshSelections();
     }

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -339,6 +339,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     shadowRoot: undefined,
     colAutosizeTreatAsLockedBelowWidth: 100,
     autoScrollOnColumnResize: true,
+    autoHeaderHeight: false,
     rtl: false
   };
 
@@ -1962,6 +1963,98 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         this.setupColumnReorder();
       }
     }
+
+    this.handleAutoHeaderHeightChange();
+  }
+
+  /**
+   * Enables or disables automatic header height handling.
+   */
+  protected handleAutoHeaderHeightChange() {
+    const enabled = !!this._options.autoHeaderHeight;
+    const headers = [this._headerScrollerL, this._headerScrollerR]
+      .filter((header): header is HTMLDivElement => !!header);
+
+    headers.forEach(header => {
+      header.classList.toggle('slick-header-auto-height', enabled);
+    });
+
+    if (!enabled) {
+      this._clearAutoHeaderHeightStyles(headers);
+      return;
+    }
+
+    setTimeout(() => this.recalculateHeaderHeight(), 0);
+  }
+
+  /**
+   * Measures natural header heights and applies one common height to all header panes.
+   */
+  protected recalculateHeaderHeight() {
+    if (!this._options.autoHeaderHeight || !this._headerScrollerL) {
+      return;
+    }
+
+    const headers = [this._headerScrollerL, this._headerScrollerR]
+      .filter((header): header is HTMLDivElement => !!header);
+
+    // Remove previously calculated values so CSS can determine the natural height.
+    this._clearAutoHeaderHeightStyles(headers);
+
+    const maxHeight = Math.max(...headers.map(header => header.getBoundingClientRect().height));
+
+    if (maxHeight <= 0) {
+      return;
+    }
+
+    const extra = this._getHeaderColumnVerticalExtra(this._headerL);
+    this._setAutoHeaderHeightStyles(maxHeight, extra, headers);
+
+    // Recalculate viewport and pane dimensions from the current header height.
+    this.resizeCanvas();
+  }
+
+  /**
+   * Clears calculated automatic header height styles.
+   */
+  private _clearAutoHeaderHeightStyles(headers: HTMLDivElement[]) {
+    headers.forEach(header => {
+      header.style.removeProperty('--slick-auto-header-height');
+      header.style.removeProperty('--slick-auto-header-height-extra');
+      header.style.height = '';
+    });
+  }
+
+  /**
+   * Applies the calculated automatic header height styles.
+   */
+  private _setAutoHeaderHeightStyles(height: number, extra: number, headers: HTMLDivElement[]) {
+    const heightValue = `${height}px`;
+    const extraValue = `${extra}px`;
+
+    headers.forEach(header => {
+      header.style.setProperty('--slick-auto-header-height', heightValue);
+      header.style.setProperty('--slick-auto-header-height-extra', extraValue);
+      header.style.height = heightValue;
+    });
+  }
+
+  /**
+   * Returns the vertical padding and border size of a header column.
+   */
+  private _getHeaderColumnVerticalExtra(header: HTMLElement): number {
+    const column = header.querySelector<HTMLElement>('.slick-header-column');
+
+    if (!column) {
+      return 0;
+    }
+
+    const style = getComputedStyle(column);
+
+    return (
+      (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0) +
+      (parseFloat(style.borderTopWidth) || 0) + (parseFloat(style.borderBottomWidth) || 0)
+    );
   }
 
   /**
@@ -2536,7 +2629,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
               }
             }
             this.updateCanvasWidth(true);
-            this.render();
+
+            if (this._options.autoHeaderHeight) {
+              this.recalculateHeaderHeight();
+            } else {
+              this.render();
+            }
+
             this.trigger(this.onColumnsResized, { triggeredByColumn });
             window.clearTimeout(this._columnResizeTimer);
             this._columnResizeTimer = window.setTimeout(() => { this.columnResizeDragging = false; }, 300);

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -2010,7 +2010,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const maxHeight = Math.max(...headers.map(header => header.getBoundingClientRect().height));
 
     if (maxHeight > 0) {
-      this.setAutoHeaderHeightStyles(maxHeight, headers);
+      this._setAutoHeaderHeightStyles(maxHeight, headers);
 
       // A viewport resize is only necessary when the calculated height actually changed.
       if (Math.abs(maxHeight - currentHeight) > 0.5) {

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -2009,15 +2009,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     const maxHeight = Math.max(...headers.map(header => header.getBoundingClientRect().height));
 
-    if (maxHeight <= 0) {
-      return;
-    }
+    if (maxHeight > 0) {
+      this.setAutoHeaderHeightStyles(maxHeight, headers);
 
-    this._setAutoHeaderHeightStyles(maxHeight, headers);
-
-    // Only resize if the height actually changed
-    if (Math.abs(maxHeight - currentHeight) > 0.5) {
-      this.resizeCanvas();
+      // A viewport resize is only necessary when the calculated height actually changed.
+      if (Math.abs(maxHeight - currentHeight) > 0.5) {
+        this.resizeCanvas();
+      }
     }
   }
 

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -2000,6 +2000,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const headers = [this._headerScrollerL, this._headerScrollerR]
       .filter((header): header is HTMLDivElement => !!header);
 
+    const currentHeight = parseFloat(
+      this._headerScrollerL.style.getPropertyValue('--slick-auto-header-height') || '0'
+    );
+
     // Remove previously calculated values so CSS can determine the natural height.
     this._clearAutoHeaderHeightStyles(headers);
 
@@ -2011,8 +2015,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     this._setAutoHeaderHeightStyles(maxHeight, headers);
 
-    // Recalculate viewport and pane dimensions from the current header height.
-    this.resizeCanvas();
+    // Only resize if the height actually changed
+    if (Math.abs(maxHeight - currentHeight) > 0.5) {
+      this.resizeCanvas();
+    }
   }
 
   /**
@@ -3335,6 +3341,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   reRenderColumns(reRender?: boolean) {
     this.applyColumnHeaderWidths();
     this.updateCanvasWidth(true);
+
+    if (this._options.autoHeaderHeight) {
+      this.recalculateHeaderHeight();
+    }
 
     this.trigger(this.onAutosizeColumns, { columns: this.columns });
 

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -1986,7 +1986,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     if (!enabled) {
       this._clearAutoHeaderHeightStyles(headers);
-      return;
     }
   }
 

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -61,6 +61,8 @@ $alpine-headerrow-input-height:                   25px !default;
 $alpine-sort-indicator-color:                     #3490dc !default;
 $alpine-sort-indicator-margin:                    5px 0 0 3px !default;
 $alpine-sort-numbered-font-size:                  10px !default;
+$alpine-auto-header-height:                       auto !default;
+$alpine-auto-header-height-extra:                 8px !default;
 
 // the following 2 vars must equal 100% (or 0%) at all time (or height of 0 to never show)
 $alpine-header-resizable-handle-height:           50% !default;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -61,7 +61,6 @@ $alpine-headerrow-input-height:                   25px !default;
 $alpine-sort-indicator-color:                     #3490dc !default;
 $alpine-sort-indicator-margin:                    5px 0 0 3px !default;
 $alpine-sort-numbered-font-size:                  10px !default;
-$alpine-auto-header-height:                       auto !default;
 $alpine-auto-header-height-extra:                 8px !default;
 
 // the following 2 vars must equal 100% (or 0%) at all time (or height of 0 to never show)

--- a/src/styles/slick-alpine-theme.scss
+++ b/src/styles/slick-alpine-theme.scss
@@ -612,16 +612,18 @@
   .slick-header-columns,
   .slick-header-columns-left,
   .slick-header-columns-right {
-    height: var(--slick-auto-header-height, v.$alpine-auto-header-height);
+    height: var(--slick-auto-header-height);
     white-space: normal;
     overflow: visible;
   }
 
   .slick-header-column {
+    height: auto;
     height: calc(
-      var(--slick-auto-header-height, v.$alpine-auto-header-height) -
+      var(--slick-auto-header-height) -
       var(--alpine-auto-header-height-extra, v.$alpine-auto-header-height-extra)
     );
+    overflow: visible;
   }
 
   .slick-column-name {

--- a/src/styles/slick-alpine-theme.scss
+++ b/src/styles/slick-alpine-theme.scss
@@ -609,20 +609,18 @@
 }
 
 .slick-header-auto-height {
-  --alpine-header-align-items: center;
-
   .slick-header-columns,
   .slick-header-columns-left,
   .slick-header-columns-right {
-    height: var(--slick-auto-header-height);
+    height: var(--slick-auto-header-height, v.$alpine-auto-header-height);
     white-space: normal;
     overflow: visible;
   }
 
   .slick-header-column {
     height: calc(
-      var(--slick-auto-header-height) -
-      var(--slick-auto-header-height-extra, 0px)
+      var(--slick-auto-header-height, v.$alpine-auto-header-height) -
+      var(--alpine-auto-header-height-extra, v.$alpine-auto-header-height-extra)
     );
   }
 

--- a/src/styles/slick-alpine-theme.scss
+++ b/src/styles/slick-alpine-theme.scss
@@ -608,6 +608,31 @@
   display: block;
 }
 
+.slick-header-auto-height {
+  --alpine-header-align-items: center;
+
+  .slick-header-columns,
+  .slick-header-columns-left,
+  .slick-header-columns-right {
+    height: var(--slick-auto-header-height);
+    white-space: normal;
+    overflow: visible;
+  }
+
+  .slick-header-column {
+    height: calc(
+      var(--slick-auto-header-height) -
+      var(--slick-auto-header-height-extra, 0px)
+    );
+  }
+
+  .slick-column-name {
+    white-space: pre-wrap;
+    overflow: visible;
+    text-overflow: clip;
+  }
+}
+
 // Pager Styles
 .slick-pager {
   display: inline-flex;

--- a/src/styles/slick.grid.scss
+++ b/src/styles/slick.grid.scss
@@ -278,15 +278,17 @@ classes should alter those!
   .slick-header-columns,
   .slick-header-columns-left,
   .slick-header-columns-right {
-    height: var(--slick-auto-header-height, auto);
+    height: var(--slick-auto-header-height);
     white-space: normal;
     overflow: visible;
   }
 
   .slick-header-column {
-    height: calc(var(--slick-auto-header-height, auto) - 8px);
+    height: auto;
+    height: calc(var(--slick-auto-header-height) - 8px);
+    overflow: visible;
   }
-  
+
   .slick-column-name {
     white-space: pre-wrap;
     overflow: visible;

--- a/src/styles/slick.grid.scss
+++ b/src/styles/slick.grid.scss
@@ -274,6 +274,29 @@ classes should alter those!
   width: 100%;
 }
 
+.slick-header-auto-height {
+  .slick-header-columns,
+  .slick-header-columns-left,
+  .slick-header-columns-right {
+    height: var(--slick-auto-header-height);
+    white-space: normal;
+    overflow: visible;
+  }
+
+  .slick-header-column {
+    height: calc(
+      var(--slick-auto-header-height) - 
+      var(--slick-auto-header-height-extra, 0px)
+    );
+  }
+  
+  .slick-column-name {
+    white-space: pre-wrap;
+    overflow: visible;
+    text-overflow: clip;
+  }
+}
+
 /* RTL (Right-to-Left) Support  */
 .slick-rtl .slick-resizable-handle {
   right: auto;

--- a/src/styles/slick.grid.scss
+++ b/src/styles/slick.grid.scss
@@ -278,16 +278,13 @@ classes should alter those!
   .slick-header-columns,
   .slick-header-columns-left,
   .slick-header-columns-right {
-    height: var(--slick-auto-header-height);
+    height: var(--slick-auto-header-height, auto);
     white-space: normal;
     overflow: visible;
   }
 
   .slick-header-column {
-    height: calc(
-      var(--slick-auto-header-height) - 
-      var(--slick-auto-header-height-extra, 0px)
-    );
+    height: calc(var(--slick-auto-header-height, auto) - 8px);
   }
   
   .slick-column-name {


### PR DESCRIPTION

## Add `autoHeaderHeight` option for multi-line column headers

This PR adds a new `autoHeaderHeight` grid option that allows column headers to auto-size based on their content.

Closes #1272 

### Features
- Disabled by default to preserve existing behavior.
- Recalculate the header height:
  - after column headers are created
  - after a column resize is completed
  - when `autoHeaderHeight` is enabled or disabled through `setOptions`
- Supports frozen columns by keeping left and right header panes aligned.
- Adds a dedicated example and Cypress test coverage.

The grid core handles measuring and synchronizing the required header height. The calculated dimensions are passed to the themes through CSS custom properties, allowing to retain their respective header layout behavior.

### Demo
A short demo video and screenshots  are attached below.


https://github.com/user-attachments/assets/b9fab68a-8cab-4f29-87cc-ce817f213468


<img width="1199" height="587" alt="example-auto-header-height" src="https://github.com/user-attachments/assets/860f0534-e341-43c7-bfee-b5d21eab124d" />
