### PR TITLE
fix(security): harden dynamic object maps against prototype pollution

### DIFF
--- a/src/controls/slick.gridmenu.ts
+++ b/src/controls/slick.gridmenu.ts
@@ -209,7 +209,7 @@ export class SlickGridMenu {
 
   protected createGridMenu() {
     const gridMenuWidth = (this._gridMenuOptions?.menuWidth) || this._defaults.menuWidth;
-    if (this._gridOptions && this._gridOptions.hasOwnProperty('frozenColumn') && this._gridOptions.frozenColumn! >= 0) {
+    if (this._gridOptions && Object.prototype.hasOwnProperty.call(this._gridOptions, 'frozenColumn') && this._gridOptions.frozenColumn! >= 0) {
       this._headerElm = document.querySelector(`.${this._gridUid} .slick-header-right`);
     } else {
       this._headerElm = document.querySelector(`.${this._gridUid} .slick-header-left`);

--- a/src/plugins/slick.cellcopymanager.ts
+++ b/src/plugins/slick.cellcopymanager.ts
@@ -71,10 +71,10 @@ export class SlickCellCopyManager implements SlickPlugin {
 
   protected markCopySelection(ranges: SlickRange[]) {
     const columns = this._grid.getColumns();
-    const hash: CssStyleHash = {};
+    const hash: CssStyleHash = Object.create(null);
     for (let i = 0; i < ranges.length; i++) {
       for (let j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {
-        hash[j] = {};
+        hash[j] = Object.create(null);
         for (let k = ranges[i].fromCell; k <= ranges[i].toCell; k++) {
           hash[j][columns[k].id] = 'copied';
         }

--- a/src/plugins/slick.cellexternalcopymanager.ts
+++ b/src/plugins/slick.cellexternalcopymanager.ts
@@ -502,10 +502,10 @@ export class SlickCellExternalCopyManager implements SlickPlugin {
     this.clearCopySelection();
 
     const columns = this._grid.getColumns();
-    const hash: CssStyleHash = {};
+    const hash: CssStyleHash = Object.create(null);
     for (let i = 0; i < ranges.length; i++) {
       for (let j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {
-        hash[j] = {};
+        hash[j] = Object.create(null);
         for (let k = ranges[i].fromCell; k <= ranges[i].toCell && k < columns.length; k++) {
           hash[j][columns[k].id] = this._copiedCellStyle;
         }

--- a/src/plugins/slick.customtooltip.ts
+++ b/src/plugins/slick.customtooltip.ts
@@ -206,7 +206,7 @@ export class SlickCustomTooltip {
             return;
           }
 
-          const value = item.hasOwnProperty(columnDef.field) ? item[columnDef.field] : null;
+          const value = Object.prototype.hasOwnProperty.call(item, columnDef.field) ? item[columnDef.field] : null;
 
           if (this._cellTooltipOptions.useRegularTooltip || !this._cellTooltipOptions.formatter) {
             this.renderRegularTooltip(columnDef.formatter, cell, value, columnDef, item);

--- a/src/plugins/slick.rowdetailview.ts
+++ b/src/plugins/slick.rowdetailview.ts
@@ -597,22 +597,25 @@ export class SlickRowDetailView {
   /** Get the Row Detail padding (which are the rows dedicated to the detail panel) */
   protected getPaddingItem(parent: any, offset: any) {
     const item: any = {};
+    const setItemProperty = (property: string, value: any) => {
+      Object.defineProperty(item, property, { configurable: true, enumerable: true, writable: true, value });
+    };
 
     // copy the parent's columns' field values so that padding rows can follow the parent's group and be filtered/sorted with it
     this._grid.getColumns().forEach(({ field }) => {
-        item[field] = parent[field];
+        setItemProperty(field, parent[field]);
     });
 
     Object.keys(this._dataView).forEach(prop => {
-      item[prop] = null;
+      setItemProperty(prop, null);
     });
-    item[this._dataViewIdProperty] = parent[this._dataViewIdProperty] + '.' + offset;
+    setItemProperty(this._dataViewIdProperty, parent[this._dataViewIdProperty] + '.' + offset);
 
     // additional hidden padding metadata fields
-    item[`${this._keyPrefix}collapsed`] = true;
-    item[`${this._keyPrefix}isPadding`] = true;
-    item[`${this._keyPrefix}parent`] = parent;
-    item[`${this._keyPrefix}offset`] = offset;
+    setItemProperty(`${this._keyPrefix}collapsed`, true);
+    setItemProperty(`${this._keyPrefix}isPadding`, true);
+    setItemProperty(`${this._keyPrefix}parent`, parent);
+    setItemProperty(`${this._keyPrefix}offset`, offset);
 
     return item;
   };
@@ -812,4 +815,3 @@ if (IIFE_ONLY && window.Slick) {
     }
   });
 }
-

--- a/src/slick.compositeeditor.ts
+++ b/src/slick.compositeeditor.ts
@@ -5,6 +5,26 @@ import { Utils as Utils_ } from './slick.core.js';
 const Utils = IIFE_ONLY ? Slick.Utils : Utils_;
 
 /**
+ * Create a prototype-free dynamic map while retaining the historical
+ * `map.hasOwnProperty(key)` compatibility used by some composite-editor consumers.
+ */
+function createSafeDynamicMap<T extends Record<string, any>>(initialValues?: T): T {
+  const target = Object.create(null) as Record<string, any>;
+  Object.keys(initialValues ?? {}).forEach((key) => {
+    target[key] = initialValues![key];
+  });
+
+  return new Proxy(target, {
+    get(map, property, receiver) {
+      if (property === 'hasOwnProperty' && !Object.prototype.hasOwnProperty.call(map, property)) {
+        return Object.prototype.hasOwnProperty.bind(map);
+      }
+      return Reflect.get(map, property, receiver);
+    }
+  }) as T;
+}
+
+/**
  * A composite SlickGrid editor factory.
  * Generates an editor that is composed of multiple editors for given columns.
  * Individual editors are provided given containers instead of the original cell.
@@ -40,7 +60,7 @@ export function SlickCompositeEditor(columns: Column[], containers: Array<HTMLDi
     hide: null,
     position: null,
     destroy: null,
-    formValues: Object.create(null),
+    formValues: createSafeDynamicMap(),
     editors: Object.create(null)
   };
 
@@ -49,6 +69,7 @@ export function SlickCompositeEditor(columns: Column[], containers: Array<HTMLDi
   let firstInvalidEditor: Editor | null = null;
 
   options = Utils.extend({}, defaultOptions, options);
+  options.formValues = createSafeDynamicMap(options.formValues);
 
   function getContainerBox(i: number) {
     const c = containers[i];
@@ -85,7 +106,7 @@ export function SlickCompositeEditor(columns: Column[], containers: Array<HTMLDi
           newArgs.commitChanges = noop;
           newArgs.cancelChanges = noop;
           newArgs.compositeEditorOptions = options;
-          newArgs.formValues = Object.create(null);
+          newArgs.formValues = createSafeDynamicMap();
 
           const currentEditor = new (column.editor as any)(newArgs) as Editor & { args: EditorArguments };
           options.editors[column.id] = currentEditor; // add every Editor instance refs

--- a/src/slick.compositeeditor.ts
+++ b/src/slick.compositeeditor.ts
@@ -40,8 +40,8 @@ export function SlickCompositeEditor(columns: Column[], containers: Array<HTMLDi
     hide: null,
     position: null,
     destroy: null,
-    formValues: {},
-    editors: {}
+    formValues: Object.create(null),
+    editors: Object.create(null)
   };
 
   const noop = function () { };
@@ -85,7 +85,7 @@ export function SlickCompositeEditor(columns: Column[], containers: Array<HTMLDi
           newArgs.commitChanges = noop;
           newArgs.cancelChanges = noop;
           newArgs.compositeEditorOptions = options;
-          newArgs.formValues = {};
+          newArgs.formValues = Object.create(null);
 
           const currentEditor = new (column.editor as any)(newArgs) as Editor & { args: EditorArguments };
           options.editors[column.id] = currentEditor; // add every Editor instance refs

--- a/src/slick.core.ts
+++ b/src/slick.core.ts
@@ -1145,7 +1145,7 @@ export class Utils {
   public static applyDefaults(targetObj: any, srcObj: any) {
     if (typeof srcObj === 'object') {
       Object.keys(srcObj).forEach(key => {
-        if (srcObj.hasOwnProperty(key) && !targetObj.hasOwnProperty(key)) {
+        if (Object.prototype.hasOwnProperty.call(srcObj, key) && !Object.prototype.hasOwnProperty.call(targetObj, key)) {
           targetObj[key] = srcObj[key];
         }
       });

--- a/src/slick.dataview.ts
+++ b/src/slick.dataview.ts
@@ -451,7 +451,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
         gi.compiledAccumulators[idx] = this.compileAccumulatorLoopCSPSafe(gi.aggregators[idx]);
       }
 
-      this.toggledGroupsByLevel[i] = {};
+      this.toggledGroupsByLevel[i] = Object.create(null);
     }
 
     this.refresh();
@@ -469,10 +469,11 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
 
   protected ensureRowsByIdCache() {
     if (!this.rowsById) {
-      this.rowsById = {};
+      const rowsById: { [id: DataIdType]: number } = Object.create(null);
       for (let i = 0, l = this.rows.length; i < l; i++) {
-        this.rowsById[this.rows[i][this.idProperty as keyof TData] as DataIdType] = i;
+        rowsById[this.rows[i][this.idProperty as keyof TData] as DataIdType] = i;
       }
+      this.rowsById = rowsById;
     }
   }
 
@@ -573,9 +574,9 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     // Also update the rows? no need since the `refresh()`, further down, blows away the `rows[]` cache and recalculates it via `recalc()`!
 
     if (!this.updated) {
-      this.updated = {};
+      this.updated = Object.create(null);
     }
-    this.updated[id] = true;
+    this.updated![id] = true;
   }
 
   /**
@@ -808,7 +809,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   protected expandCollapseAllGroups(level?: number, collapse?: boolean) {
     if (!Utils.isDefined(level)) {
       for (let i = 0; i < this.groupingInfos.length; i++) {
-        this.toggledGroupsByLevel[i] = {};
+        this.toggledGroupsByLevel[i] = Object.create(null);
         this.groupingInfos[i].collapsed = collapse;
 
         if (collapse === true) {
@@ -818,7 +819,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
         }
       }
     } else {
-      this.toggledGroupsByLevel[level] = {};
+      this.toggledGroupsByLevel[level] = Object.create(null);
       this.groupingInfos[level].collapsed = collapse;
 
       if (collapse === true) {
@@ -927,7 +928,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     let group: SlickGroup_;
     let val: any;
     const groups: SlickGroup_[] = [];
-    const groupsByVal: any = {};
+    const groupsByVal: Record<string, SlickGroup_> = Object.create(null);
     let r;
     const level = parentGroup ? parentGroup.level + 1 : 0;
     const gi = this.groupingInfos[level];
@@ -1610,7 +1611,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     let inHandler: boolean;
 
     const storeCellCssStyles = (hash: CssStyleHash) => {
-      hashById = {};
+      hashById = Object.create(null);
       if (typeof hash === 'object') {
         Object.keys(hash).forEach(row => {
           if (hash) {
@@ -1629,7 +1630,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
       if (typeof hashById === 'object') {
         inHandler = true;
         this.ensureRowsByIdCache();
-        const newHash: CssStyleHash = {};
+        const newHash: CssStyleHash = Object.create(null);
         Object.keys(hashById).forEach(id => {
           const row = this.rowsById?.[id];
           if (Utils.isDefined(row)) {
@@ -1680,7 +1681,7 @@ export class AvgAggregator<T = any> implements Aggregator {
   }
 
   accumulate(item: T) {
-    const val: any = (item?.hasOwnProperty(this._field)) ? item[this._field as keyof T] : null;
+    const val: any = (item && Object.prototype.hasOwnProperty.call(item, this._field)) ? item[this._field as keyof T] : null;
     if (val !== null && val !== '' && !isNaN(val)) {
       this._nonNullCount++;
       this._sum += parseFloat(val);
@@ -1689,7 +1690,7 @@ export class AvgAggregator<T = any> implements Aggregator {
 
   storeResult(groupTotals: SlickGroupTotals_ & { avg: Record<number | string, number>; }) {
     if (!groupTotals || groupTotals[this._type] === undefined) {
-      (groupTotals as any)[this._type] = {};
+      (groupTotals as any)[this._type] = Object.create(null);
     }
     if (this._nonNullCount !== 0) {
       groupTotals[this._type][this._field] = this._sum / this._nonNullCount;
@@ -1719,7 +1720,7 @@ export class MinAggregator<T = any> implements Aggregator {
   }
 
   accumulate(item: T) {
-    const val: any = (item?.hasOwnProperty(this._field)) ? item[this._field as keyof T] : null;
+    const val: any = (item && Object.prototype.hasOwnProperty.call(item, this._field)) ? item[this._field as keyof T] : null;
     if (val !== null && val !== '' && !isNaN(val)) {
       if (this._min === null || val < this._min) {
         this._min = parseFloat(val);
@@ -1729,7 +1730,7 @@ export class MinAggregator<T = any> implements Aggregator {
 
   storeResult(groupTotals: SlickGroupTotals_ & { min: Record<number | string, number | null>; }) {
     if (!groupTotals || groupTotals[this._type] === undefined) {
-      groupTotals[this._type] = {};
+      groupTotals[this._type] = Object.create(null);
     }
     groupTotals[this._type][this._field] = this._min;
   }
@@ -1757,7 +1758,7 @@ export class MaxAggregator<T = any> implements Aggregator {
   }
 
   accumulate(item: T) {
-    const val: any = (item?.hasOwnProperty(this._field)) ? item[this._field as keyof T] : null;
+    const val: any = (item && Object.prototype.hasOwnProperty.call(item, this._field)) ? item[this._field as keyof T] : null;
     if (val !== null && val !== '' && !isNaN(val)) {
       if (this._max === null || val > this._max) {
         this._max = parseFloat(val);
@@ -1767,7 +1768,7 @@ export class MaxAggregator<T = any> implements Aggregator {
 
   storeResult(groupTotals: SlickGroupTotals_ & { max: Record<number | string, number | null>; }) {
     if (!groupTotals || groupTotals[this._type] === undefined) {
-      groupTotals[this._type] = {};
+      groupTotals[this._type] = Object.create(null);
     }
     groupTotals[this._type][this._field] = this._max;
   }
@@ -1795,7 +1796,7 @@ export class SumAggregator<T = any> implements Aggregator {
   }
 
   accumulate(item: T) {
-    const val: any = (item?.hasOwnProperty(this._field)) ? item[this._field as keyof T] : null;
+    const val: any = (item && Object.prototype.hasOwnProperty.call(item, this._field)) ? item[this._field as keyof T] : null;
     if (val !== null && val !== '' && !isNaN(val)) {
       this._sum += parseFloat(val);
     }
@@ -1803,7 +1804,7 @@ export class SumAggregator<T = any> implements Aggregator {
 
   storeResult(groupTotals: SlickGroupTotals_ & { sum: Record<number | string, number>; }) {
     if (!groupTotals || groupTotals[this._type] === undefined) {
-      groupTotals[this._type] = {};
+      groupTotals[this._type] = Object.create(null);
     }
     groupTotals[this._type][this._field] = this._sum;
   }
@@ -1830,7 +1831,7 @@ export class CountAggregator implements Aggregator {
 
   storeResult(groupTotals: SlickGroupTotals_ & { count: Record<number | string, number>; }) {
     if (!groupTotals || groupTotals[this._type] === undefined) {
-      groupTotals[this._type] = {};
+      groupTotals[this._type] = Object.create(null);
     }
     groupTotals[this._type][this._field] = groupTotals.group.rows.length;
   }

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -487,10 +487,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected selectedRanges: SlickRange_[] = [];
 
   protected plugins: SlickPlugin[] = [];
-  protected cellCssClasses: CssStyleHash = {};
-  protected cellCssClassesByCell: CssStyleHash = {};
+  protected cellCssClasses: CssStyleHash = Object.create(null);
+  protected cellCssClassesByCell: CssStyleHash = Object.create(null);
 
-  protected columnsById: Record<string, number> = {};
+  protected columnsById: Record<string, number> = Object.create(null);
   protected sortColumns: ColumnSort[] = [];
   protected columnPosLeft: number[] = [];
   protected columnPosRight: number[] = [];
@@ -1888,9 +1888,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         this._bindingEventService.bind(header, 'mouseleave', this.handleHeaderMouseHoverOff.bind(this) as EventListener);
       }
 
-      if (m.hasOwnProperty('headerCellAttrs') && m.headerCellAttrs instanceof Object) {
+      if (Object.prototype.hasOwnProperty.call(m, 'headerCellAttrs') && m.headerCellAttrs instanceof Object) {
         Object.keys(m.headerCellAttrs).forEach(key => {
-          if (m.headerCellAttrs.hasOwnProperty(key)) {
+          if (Object.prototype.hasOwnProperty.call(m.headerCellAttrs, key)) {
             header.setAttribute(key, m.headerCellAttrs[key]);
           }
         });
@@ -3327,7 +3327,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * the width if it is less than minWidth or greater than maxWidth.
    */
   protected updateColumnProps() {
-    this.columnsById = {};
+    this.columnsById = Object.create(null);
     for (let i = 0; i < this.columns.length; i++) {
       let m: C = this.columns[i];
       if (m.width) {
@@ -4072,12 +4072,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.dragReplaceEl.removeEl();
 
     this.selectedRows = [];
-    const hash: CssStyleHash = {};
+    const hash: CssStyleHash = Object.create(null);
     for (let i = 0; i < ranges.length; i++) {
       for (let j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {
         if (!hash[j]) {  // prevent duplicates
           this.selectedRows.push(j);
-          hash[j] = {};
+          hash[j] = Object.create(null);
         }
         for (let k = ranges[i].fromCell; k <= ranges[i].toCell; k++) {
           if (this.canCellBeSelected(j, k)) {
@@ -5591,9 +5591,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       cellDiv.style.height = `${cellHeight || 0}px`;
     }
 
-    if (m.hasOwnProperty('cellAttrs') && m.cellAttrs instanceof Object) {
+    if (Object.prototype.hasOwnProperty.call(m, 'cellAttrs') && m.cellAttrs instanceof Object) {
       Object.keys(m.cellAttrs).forEach(key => {
-        if (m.cellAttrs.hasOwnProperty(key)) {
+        if (Object.prototype.hasOwnProperty.call(m.cellAttrs, key)) {
           cellDiv.setAttribute(key, m.cellAttrs[key]);
         }
       });
@@ -5853,7 +5853,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const d = this.getDataItem(row);
 
     Object.keys(cacheEntry.cellNodesByColumnIdx).forEach(colIdx => {
-      if (!cacheEntry.cellNodesByColumnIdx.hasOwnProperty(colIdx)) {
+      if (!Object.prototype.hasOwnProperty.call(cacheEntry.cellNodesByColumnIdx, colIdx)) {
         return;
       }
 
@@ -6378,7 +6378,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const cellsToRemove: number[] = [];
     Object.keys(cacheEntry.cellNodesByColumnIdx).forEach(cellNodeIdx => {
       // I really hate it when people mess with Array.prototype.
-      if (!cacheEntry.cellNodesByColumnIdx.hasOwnProperty(cellNodeIdx)) {
+      if (!Object.prototype.hasOwnProperty.call(cacheEntry.cellNodesByColumnIdx, cellNodeIdx)) {
         return;
       }
 
@@ -6610,25 +6610,25 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       for (let i = 0, ii = rows.length; i < ii; i++) {
         if (this.isBottomBandRow(rows[i])) {
           if (this.hasFrozenColumns()) {
-            if (this.rowsCache?.hasOwnProperty(rows[i]) && x.firstChild && xRight.firstChild) {
+            if (Object.prototype.hasOwnProperty.call(this.rowsCache ?? {}, rows[i]) && x.firstChild && xRight.firstChild) {
               this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement, xRight.firstChild as HTMLElement];
               this._canvasBottomL.appendChild(x.firstChild as ChildNode);
               this._canvasBottomR.appendChild(xRight.firstChild as ChildNode);
             }
           } else {
-            if (this.rowsCache?.hasOwnProperty(rows[i]) && x.firstChild) {
+            if (Object.prototype.hasOwnProperty.call(this.rowsCache ?? {}, rows[i]) && x.firstChild) {
               this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement];
               this._canvasBottomL.appendChild(x.firstChild as ChildNode);
             }
           }
         } else if (this.hasFrozenColumns()) {
-          if (this.rowsCache?.hasOwnProperty(rows[i]) && x.firstChild && xRight.firstChild) {
+          if (Object.prototype.hasOwnProperty.call(this.rowsCache ?? {}, rows[i]) && x.firstChild && xRight.firstChild) {
             this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement, xRight.firstChild as HTMLElement];
             this._canvasTopL.appendChild(x.firstChild as ChildNode);
             this._canvasTopR.appendChild(xRight.firstChild as ChildNode);
           }
         } else {
-          if (this.rowsCache?.hasOwnProperty(rows[i]) && x.firstChild) {
+          if (Object.prototype.hasOwnProperty.call(this.rowsCache ?? {}, rows[i]) && x.firstChild) {
             this.rowsCache[rows[i]].rowNode = [x.firstChild as HTMLElement];
             this._canvasTopL.appendChild(x.firstChild as ChildNode);
           }
@@ -7512,7 +7512,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // store and detach node for later async cleanup
     if (typeof postProcessedRow === 'object') {
       Object.keys(postProcessedRow).forEach(columnIdx => {
-        if (postProcessedRow.hasOwnProperty(columnIdx)) {
+      if (Object.prototype.hasOwnProperty.call(postProcessedRow, columnIdx)) {
           this.postProcessedCleanupQueue.push({
             actionType: 'C',
             groupId: this.postProcessgroupId,
@@ -7619,7 +7619,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // change status of columns to be re-rendered
     if (typeof this.postProcessedRows[row] === 'object') {
       Object.keys(this.postProcessedRows[row]).forEach(columnIdx => {
-        if (this.postProcessedRows[row].hasOwnProperty(columnIdx)) {
+      if (Object.prototype.hasOwnProperty.call(this.postProcessedRows[row], columnIdx)) {
           this.postProcessedRows[row][columnIdx] = 'C';
         }
       });
@@ -7654,7 +7654,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       this.ensureCellNodesInRowsCache(row);
       Object.keys(cacheEntry.cellNodesByColumnIdx).forEach(colIdx => {
-        if (cacheEntry.cellNodesByColumnIdx.hasOwnProperty(colIdx)) {
+      if (Object.prototype.hasOwnProperty.call(cacheEntry.cellNodesByColumnIdx, colIdx)) {
           const columnIdx = +colIdx;
           const m = this.columns[columnIdx];
           const processedStatus = this.postProcessedRows[row][columnIdx]; // C=cleanup and re-render, R=rendered
@@ -7752,11 +7752,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Merges the keyed CSS overlays once on update, rather than for every rendered cell. */
   protected updateCellCssClassesByCell() {
-    this.cellCssClassesByCell = {};
+    this.cellCssClassesByCell = Object.create(null);
 
     Object.values(this.cellCssClasses).forEach(hash => {
       Object.entries(hash).forEach(([row, cellClasses]) => {
-        const mergedRowClasses = (this.cellCssClassesByCell[row] ??= {});
+        const mergedRowClasses = (this.cellCssClassesByCell[row] ??= Object.create(null));
         Object.entries(cellClasses).forEach(([columnId, cssClasses]) => {
           if (cssClasses) {
             mergedRowClasses[columnId] = mergedRowClasses[columnId]


### PR DESCRIPTION
_replicate Slickgrid-Universal [PR 2742](https://github.com/ghiscoding/slickgrid-universal/pull/2742) and [PR 2743](https://github.com/ghiscoding/slickgrid-universal/pull/2743) into SlickGrid by doing a security audit using AI_


## Summary

Harden SlickGrid's dynamic object maps against prototype pollution risks.

## Changes

- Use prototype-free maps for DataView, Grid, aggregators, CSS overlays, copy managers, and composite editors.
- Safely handle dynamic `__proto__`, `constructor`, and `toString` keys.
- Replace unsafe `hasOwnProperty()` calls with `Object.prototype.hasOwnProperty.call()`.
- Protect dynamically assigned Row Detail properties.
- Preserve generated `dist/` files as build artifacts; they are not intended for inclusion in the PR.

## Validation

- TypeScript check passed.
- ESLint passed.
- `git diff --check` passed.

## LLM

Implemented and reviewed with OpenAI GPT-5.6 Luna.