### PR TITLE
feat(grid): improve column reorder auto-scroll

### DIFF
--- a/cypress/e2e/example-frozen-columns-reorder.cy.ts
+++ b/cypress/e2e/example-frozen-columns-reorder.cy.ts
@@ -158,30 +158,38 @@ describe('Example - Frozen Columns - Column Header Reorder (characterization)', 
       const finishHeader = getRightHeader(win, 'Finish');
       expect(finishHeader).to.exist;
       const rect = finishHeader.getBoundingClientRect();
-      const gridRect = (win.document.querySelector('#myGrid') as HTMLElement).getBoundingClientRect();
       const startX = rect.left + rect.width / 2;
       const sy = rect.top + rect.height / 2;
-      const dragX = gridRect.right + 100;
       const dataTransfer = new DataTransfer();
 
       pressPointer(finishHeader, startX, sy);
       finishHeader.dispatchEvent(createDragLikeEvent('dragstart', startX, sy, dataTransfer));
-      win.document.dispatchEvent(createDragLikeEvent('drag', startX, sy, dataTransfer));
-      win.document.dispatchEvent(createDragLikeEvent('drag', dragX, sy, dataTransfer));
     });
 
-    cy.wait(250);
+    // SortableJS dispatches its start callback on the next macrotask. Yield so the
+    // grid can bind its document-level auto-scroll listeners before moving outside.
+    cy.wait(50);
     cy.window().then((win: any) => {
       const finishHeader = getRightHeader(win, 'Finish');
       const rect = finishHeader.getBoundingClientRect();
       const gridRect = (win.document.querySelector('#myGrid') as HTMLElement).getBoundingClientRect();
-      const safeX = rect.left + rect.width / 2;
       const sy = rect.top + rect.height / 2;
       const dragX = gridRect.right + 100;
-      win.document.dispatchEvent(createDragLikeEvent('drag', dragX, sy, new DataTransfer()));
-      win.document.dispatchEvent(createDragLikeEvent('drag', safeX, sy, new DataTransfer()));
+      const dataTransfer = new DataTransfer();
+      win.document.dispatchEvent(createDragLikeEvent('drag', dragX, sy, dataTransfer));
+      win.document.dispatchEvent(createDragLikeEvent('mousemove', dragX, sy, dataTransfer));
     });
     cy.wait(250);
+
+    cy.window().then((win: any) => {
+      const finishHeader = getRightHeader(win, 'Finish');
+      const rect = finishHeader.getBoundingClientRect();
+      const sy = rect.top + rect.height / 2;
+      const safeX = rect.left + rect.width / 2;
+      const dataTransfer = new DataTransfer();
+      win.document.dispatchEvent(createDragLikeEvent('drag', safeX, sy, dataTransfer));
+      win.document.dispatchEvent(createDragLikeEvent('mousemove', safeX, sy, dataTransfer));
+    });
 
     cy.get(RIGHT_VIEWPORT).then(($v) => {
       expect($v[0].scrollLeft).to.be.greaterThan(10);

--- a/cypress/e2e/example-frozen-columns-reorder.cy.ts
+++ b/cypress/e2e/example-frozen-columns-reorder.cy.ts
@@ -147,46 +147,57 @@ describe('Example - Frozen Columns - Column Header Reorder (characterization)', 
     cy.get(RIGHT_VIEWPORT).scrollTo(0, 0, { ensureScrollable: false });
   });
 
-  it('should auto-scroll the right viewport when a header drag starts beyond the right edge of the grid', () => {
+  it('should auto-scroll the right viewport when a header drag moves past the right edge of the grid', () => {
     cy.get(RIGHT_VIEWPORT).scrollTo(0, 0, { ensureScrollable: false });
     cy.wait(50);
     cy.get(RIGHT_VIEWPORT).should(($v) => expect($v[0].scrollLeft).to.eq(0));
 
-    // start a drag on "Finish" with the pointer already past the grid's right edge, then also fire a
-    // document-level `drag` event at those coordinates (that is what a real browser does continuously
-    // during a native drag, and what the future native reorder engine listens to for auto-scrolling)
+    // Start the drag inside the viewport first, then move past the grid's right edge via document-level
+    // drag events. This characterizes the live drag tracking behavior rather than a start-outside shortcut.
     cy.window().then((win: any) => {
       const finishHeader = getRightHeader(win, 'Finish');
       expect(finishHeader).to.exist;
       const rect = finishHeader.getBoundingClientRect();
+      const gridRect = (win.document.querySelector('#myGrid') as HTMLElement).getBoundingClientRect();
+      const startX = rect.left + rect.width / 2;
       const sy = rect.top + rect.height / 2;
-      const dragX = (win.document.querySelector('#myGrid') as HTMLElement).clientWidth + 100;
+      const dragX = gridRect.right + 100;
       const dataTransfer = new DataTransfer();
 
-      pressPointer(finishHeader, rect.left + rect.width / 2, sy);
-      finishHeader.dispatchEvent(createDragLikeEvent('dragstart', dragX, sy, dataTransfer));
+      pressPointer(finishHeader, startX, sy);
+      finishHeader.dispatchEvent(createDragLikeEvent('dragstart', startX, sy, dataTransfer));
+      win.document.dispatchEvent(createDragLikeEvent('drag', startX, sy, dataTransfer));
       win.document.dispatchEvent(createDragLikeEvent('drag', dragX, sy, dataTransfer));
     });
 
     cy.wait(250);
     cy.window().then((win: any) => {
       const finishHeader = getRightHeader(win, 'Finish');
-      const sy = finishHeader.getBoundingClientRect().top;
-      const dragX = (win.document.querySelector('#myGrid') as HTMLElement).clientWidth + 100;
+      const rect = finishHeader.getBoundingClientRect();
+      const gridRect = (win.document.querySelector('#myGrid') as HTMLElement).getBoundingClientRect();
+      const safeX = rect.left + rect.width / 2;
+      const sy = rect.top + rect.height / 2;
+      const dragX = gridRect.right + 100;
       win.document.dispatchEvent(createDragLikeEvent('drag', dragX, sy, new DataTransfer()));
+      win.document.dispatchEvent(createDragLikeEvent('drag', safeX, sy, new DataTransfer()));
     });
     cy.wait(250);
 
-    cy.get(RIGHT_VIEWPORT).should(($v) => expect($v[0].scrollLeft).to.be.greaterThan(10));
+    cy.get(RIGHT_VIEWPORT).then(($v) => {
+      expect($v[0].scrollLeft).to.be.greaterThan(10);
+      const scrollLeftAfterSafeZone = $v[0].scrollLeft;
+      cy.wait(250);
+      cy.get(RIGHT_VIEWPORT).should(($v2) => expect($v2[0].scrollLeft).to.eq(scrollLeftAfterSafeZone));
+    });
 
-    // end the drag on the source itself: no reorder, and the auto-scroll must stop
+    // end the drag on the source itself: no reorder, and the auto-scroll must remain stopped
     cy.window().then((win: any) => {
       const finishHeader = getRightHeader(win, 'Finish');
       const rect = finishHeader.getBoundingClientRect();
       const sy = rect.top + rect.height / 2;
-      const dragX = (win.document.querySelector('#myGrid') as HTMLElement).clientWidth + 100;
-      finishHeader.dispatchEvent(createDragLikeEvent('dragend', dragX, sy, new DataTransfer()));
-      releasePointer(finishHeader, dragX, sy);
+      const safeX = rect.left + rect.width / 2;
+      finishHeader.dispatchEvent(createDragLikeEvent('dragend', safeX, sy, new DataTransfer()));
+      releasePointer(finishHeader, safeX, sy);
     });
 
     cy.get(RIGHT_VIEWPORT).then(($v) => {

--- a/cypress/e2e/example14-column-reorder.cy.ts
+++ b/cypress/e2e/example14-column-reorder.cy.ts
@@ -137,7 +137,7 @@ describe('Example 14 - Column Header Reorder (characterization)', { retries: 1 }
   // get no header element rendered and the SortableJS toArray() read-back therefore omits them.
   // The native reorder engine (PR 2 of the SortableJS removal) fixes this with column-map reconciliation.
   // Enable this test when that engine lands.
-  it.skip('should keep hidden columns in the column set when reordering', () => {
+  it('should keep hidden columns in the column set when reordering', () => {
     cy.window().then((win: any) => {
       const cols = win.grid.getColumns();
       cols[2].hidden = true; // hide "CPU1"

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -1951,13 +1951,41 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.sortableSideLeftInstance?.destroy();
     this.sortableSideRightInstance?.destroy();
 
-    let columnScrollTimer: any = null;
-
-    const scrollColumnsRight = () => this._viewportScrollContainerX.scrollLeft = this._viewportScrollContainerX.scrollLeft + 10;
-    const scrollColumnsLeft = () => this._viewportScrollContainerX.scrollLeft = this._viewportScrollContainerX.scrollLeft - 10;
+    let columnScrollTimer: number | undefined;
+    let columnScrollDirection = 0;
     let prevColumnIds: Array<string | number> = [];
+    let hiddenColumns = new Map<string | number, C>();
 
-    let canDragScroll = false;
+    const stopAutoScroll = () => {
+      if (columnScrollTimer) {
+        clearInterval(columnScrollTimer);
+        columnScrollTimer = undefined;
+      }
+      columnScrollDirection = 0;
+    };
+
+    const autoScrollHandler = (event: DragEvent | MouseEvent) => {
+      const { clientX, clientY, pageX } = event;
+      if (!clientX || !clientY) {
+        return;
+      }
+
+      const viewportLeft = Utils.offset(this._viewportScrollContainerX)!.left;
+      const containerRight = Utils.offset(this._container)!.left + this._container.clientWidth;
+      const direction = pageX > containerRight ? 1 : pageX < viewportLeft ? -1 : 0;
+
+      if (direction !== columnScrollDirection) {
+        stopAutoScroll();
+        columnScrollDirection = direction;
+
+        if (direction) {
+          columnScrollTimer = window.setInterval(() => {
+            this._viewportScrollContainerX.scrollLeft += direction * 10;
+          }, 30);
+        }
+      }
+    };
+
     const sortableOptions = {
       animation: 50,
       direction: 'horizontal',
@@ -1975,42 +2003,38 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       },
       onStart: (e: SortableEvent) => {
         e.item.classList.add('slick-header-column-active');
-        canDragScroll = !this.hasFrozenColumns() || Utils.offset(e.item)!.left > Utils.offset(this._viewportScrollContainerX)!.left;
+        this._bindingEventService.unbindAll('colreorder');
+        stopAutoScroll();
 
-        if (canDragScroll && e.originalEvent.pageX > this._container.clientWidth) {
-          if (!(columnScrollTimer)) {
-            columnScrollTimer = window.setInterval(scrollColumnsRight, 100);
-          }
-        } else if (canDragScroll && e.originalEvent.pageX < Utils.offset(this._viewportScrollContainerX)!.left) {
-          if (!(columnScrollTimer)) {
-            columnScrollTimer = window.setInterval(scrollColumnsLeft, 100);
-          }
-        } else {
-          window.clearInterval(columnScrollTimer);
-          columnScrollTimer = null;
+        if (!this.hasFrozenColumns() || this._headerR.contains(e.item)) {
+          this._bindingEventService.bind(document, 'drag', autoScrollHandler as EventListener, {}, 'colreorder');
+          this._bindingEventService.bind(document, 'mousemove', autoScrollHandler as EventListener, {}, 'colreorder');
         }
+
         prevColumnIds = this.columns.map((c) => c.id);
+        hiddenColumns = new Map(this.columns.filter((column) => column.hidden).map((column) => [column.id, column] as [string | number, C]));
       },
       onEnd: (e: SortableEvent) => {
         e.item.classList.remove('slick-header-column-active');
-        clearInterval(columnScrollTimer);
+        stopAutoScroll();
+        this._bindingEventService.unbindAll('colreorder');
         const prevScrollLeft = this.scrollLeft;
 
         if (!this.getEditorLock()?.commitCurrentEdit()) {
           return;
         }
 
-        let reorderedIds = this.sortableSideLeftInstance?.toArray() ?? [];
-        reorderedIds = reorderedIds.concat(this.sortableSideRightInstance?.toArray() ?? []);
-
-        const reorderedColumns: C[] = [];
-        for (let i = 0; i < reorderedIds.length; i++) {
-          reorderedColumns.push(this.columns[this.getColumnIndex(reorderedIds[i])]);
-        }
+        const reorderedIds = [
+          ...(this.sortableSideLeftInstance?.toArray() ?? []),
+          ...(this.sortableSideRightInstance?.toArray() ?? []),
+        ];
+        const reorderedColumns = reorderedIds.map((columnId) => this.columns[this.getColumnIndex(columnId)]);
+        let visibleColumnIdx = 0;
+        const finalColumns = this.columns.map((column) => hiddenColumns.get(column.id) ?? reorderedColumns[visibleColumnIdx++]);
 
         e.stopPropagation();
         if (!this.arrayEquals(prevColumnIds, reorderedIds)) {
-          this.setColumns(reorderedColumns);
+          this.setColumns(finalColumns);
           // reapply previous scroll position since it might move back to x=0 after calling `setColumns()` (especially when `frozenColumn` is set)
           this.scrollToX(prevScrollLeft);
           this.trigger(this.onColumnsReordered, { impactedColumns: this.columns, previousColumnOrder: prevColumnIds });


### PR DESCRIPTION
_replicate Slickgrid-Universal [PR 2772](https://github.com/ghiscoding/slickgrid-universal/pull/2772) into SlickGrid. You can see the included ChatGPT summary below._

## Summary

Improve and simplify column reorder auto-scroll behavior while preserving existing drag, resize, frozen-column, pointer, and event handling.

## Why

Large grids with many columns benefit from responsive horizontal scrolling when columns are dragged outside the viewport. The existing implementation also had opportunities to reduce duplicated state and simplify timer handling without changing supported behavior.

## Changes

- Simplified column reorder and resize auto-scroll state management.
- Increased column reorder auto-scroll frequency from 100ms to 30ms while retaining the 10px scroll step.
- Preserved direct direction reversal, safe-zone stopping, frozen-pane behavior, and missing-coordinate handling.
- Simplified mouse, touch, and pointer interaction handling.
- Added focused unit coverage for auto-scroll directions, stopping, reversal, frozen panes, resizing, and interaction callbacks.
- Added Cypress auto-scroll coverage to:
  - Vanilla Example 33
  - Angular Example 44
  - Aurelia Example 44
  - React Example 44
  - Vue Example 44
- Updated repository guidance to require 100% coverage for changed production code and adherence to the PR template.

## Validation

- Scoped Vitest run: 5,963 tests passed.
- Changed production code has 100% statement, branch, function, and line coverage.
- Common package TypeScript `--noEmit` check passed.
- Vanilla Example 33 Cypress test passed in the Cypress UI.
- Prettier checks passed.
- Oxlint checks passed.
- `git diff --check` passed.

## Comments

The framework Example 44 Cypress tests were added but were not browser-run in this session.

The standalone Cypress TypeScript project check still reports pre-existing type errors in shared Cypress support files unrelated to this change.

Although the tests span the shared core and framework demos, they cover the single scope of column reorder auto-scroll behavior.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex GPT-5.6 Luna
  - **how was it used**: Reviewed and simplified the implementation, added unit and Cypress coverage, and performed scoped validation.

## Checklist

- [x] The changes are limited to only one scope (if not please explain why in the comments above).
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate.

[Screencast_20260827_212013.webm](https://github.com/user-attachments/assets/a37314ce-79b0-4995-b2dd-cacab9b57a29)
