### PR TITLE
feat(selection): support multi-range selection with drag previews

### DIFF
--- a/cypress/e2e/example-excel-compatible-spreadsheet.cy.ts
+++ b/cypress/e2e/example-excel-compatible-spreadsheet.cy.ts
@@ -60,7 +60,7 @@ describe('Example - Excel-compatible spreadsheet and Cell Selection', { retries:
       cy.get('#myGrid [data-row=99] > .slick-cell.l26.r26.active').should('have.length', 1);
     });
 
-    it('should ignore pasted cells outside grid column bounds when clipboard data exceeds available grid columns', () => {
+  it('should ignore pasted cells outside grid column bounds when clipboard data exceeds available grid columns', () => {
       cy.get('#myGrid .slick-viewport-top.slick-viewport-left').scrollTo(200, 0).wait(10);
       cy.get('#myGrid [data-row=0] .slick-cell.l22.r22').click();
 
@@ -76,7 +76,32 @@ describe('Example - Excel-compatible spreadsheet and Cell Selection', { retries:
       });
 
       cy.get('#myGrid [data-row=0] .slick-cell.l22.r22').should('have.text', 'p1');
-      cy.get('#myGrid [data-row=0] .slick-cell.l26.r26').should('have.text', 'p5');
+    cy.get('#myGrid [data-row=0] .slick-cell.l26.r26').should('have.text', 'p5');
+  });
+
+  it('should preserve gaps when copying multiple non-contiguous ranges', () => {
+    cy.window().then((win: any) => {
+      const previousClipboardData = win.clipboardData;
+      let copiedText = '';
+      Object.defineProperty(win, 'clipboardData', {
+        configurable: true,
+        value: {
+          setData: (_format: string, text: string) => { copiedText = text; }
+        }
+      });
+
+    const selectionModel = win.grid.getSelectionModel();
+    selectionModel.setSelectedRanges([
+      new win.Slick.Range(1, 1, 1, 2),
+      new win.Slick.Range(2, 3, 2, 3)
+    ]);
+      const copyEvent = new win.KeyboardEvent('keydown', { key: 'c', code: 'KeyC', ctrlKey: true, bubbles: true });
+      Object.defineProperty(copyEvent, 'which', { value: 67 });
+      win.grid.getCanvasNode().dispatchEvent(copyEvent);
+
+    expect(copiedText).to.eq('1\t2\t\r\n\t\t4\r\n');
+      Object.defineProperty(win, 'clipboardData', { configurable: true, value: previousClipboardData });
     });
   });
+});
 });

--- a/cypress/e2e/example-plugin-hybridselectionmodel.cy.ts
+++ b/cypress/e2e/example-plugin-hybridselectionmodel.cy.ts
@@ -79,4 +79,74 @@ describe('Example - Context Menu Plugin & Hybrid Selection Mode', () => {
     cy.get('#myGrid .slick-row[data-row="6"] .slick-cell.l0.r0').click({ shiftKey: true }).should('have.class', 'selected');
     cy.get('#myGrid .slick-cell.selected').should('have.length', 7 * 3);
   });
+
+  it('should add and toggle non-contiguous cell ranges with Ctrl-click', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-plugin-hybridselectionmodel.html`);
+    cy.get('#myGrid .slick-row[data-row="1"] .slick-cell.l1.r1').click();
+    cy.get('#myGrid .slick-row[data-row="3"] .slick-cell.l1.r1').click({ ctrlKey: true });
+
+    cy.get('#myGrid .slick-row[data-row="1"] .slick-cell.l1.r1').should('have.class', 'selected');
+    cy.get('#myGrid .slick-row[data-row="3"] .slick-cell.l1.r1').should('have.class', 'selected');
+    cy.get('#myGrid .slick-row[data-row="2"] .slick-cell.l1.r1').should('not.have.class', 'selected');
+    cy.get('#myGrid .slick-cell.selected').should('have.length', 2);
+
+    cy.get('#myGrid .slick-row[data-row="1"] .slick-cell.l1.r1').click({ ctrlKey: true });
+    cy.get('#myGrid .slick-row[data-row="1"] .slick-cell.l1.r1').should('not.have.class', 'selected');
+    cy.get('#myGrid .slick-row[data-row="3"] .slick-cell.l1.r1').should('have.class', 'selected');
+    cy.get('#myGrid .slick-cell.selected').should('have.length', 1);
+  });
+
+  it('should split a rectangular cell range when Ctrl-clicking an interior cell', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-plugin-hybridselectionmodel.html`);
+    cy.get('#myGrid .slick-row[data-row="1"] .slick-cell.l1.r1').click();
+    cy.get('#myGrid .slick-row[data-row="1"] .slick-cell.l1.r1')
+      .find('.slick-drag-replace-handle')
+      .trigger('mousedown', { which: 1, force: true });
+    cy.get('#myGrid .slick-row[data-row="3"] .slick-cell.l3.r3')
+      .trigger('mousemove', 'bottomRight')
+      .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+    cy.get('#myGrid .slick-cell.selected').should('have.length', 9);
+
+    cy.get('#myGrid .slick-row[data-row="2"] .slick-cell.l2.r2').click({ ctrlKey: true });
+    cy.get('#myGrid .slick-row[data-row="2"] .slick-cell.l2.r2').should('not.have.class', 'selected');
+    cy.get('#myGrid .slick-cell.selected').should('have.length', 8);
+    cy.window().then((win: any) => {
+      expect(win.grid.getSelectionModel().getSelectedRanges()).to.have.length(4);
+    });
+  });
+
+  it('should add a row range with Ctrl-drag without accumulating live preview ranges', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-plugin-hybridselectionmodel.html`);
+    cy.get('#myGrid .slick-row[data-row="1"] .slick-cell.l0.r0').click();
+    cy.get('#myGrid .slick-row[data-row="3"] .slick-cell.l0.r0').as('secondRowCell');
+    cy.get('@secondRowCell').trigger('mousedown', { which: 1, ctrlKey: true, force: true });
+    cy.get('@secondRowCell').trigger('mousemove', 30, 10, { ctrlKey: true, force: true });
+    cy.get('@secondRowCell').trigger('mousemove', 30, 52, { ctrlKey: true, force: true });
+
+    cy.window().then((win: any) => {
+      const ranges = win.grid.getSelectionModel().getSelectedRanges();
+      expect(ranges).to.have.length(2);
+      expect(ranges[0]).to.include({ fromRow: 1, toRow: 1 });
+      expect(ranges[1]).to.include({ fromRow: 3, toRow: 4 });
+    });
+
+    cy.dragEnd('#myGrid');
+
+    cy.get('#myGrid .slick-row[data-row="1"] .slick-cell.selected').should('have.length', 7);
+    cy.get('#myGrid .slick-row[data-row="2"] .slick-cell.selected').should('have.length', 0);
+    cy.get('#myGrid .slick-row[data-row="3"] .slick-cell.selected').should('have.length', 7);
+    cy.get('#myGrid .slick-row[data-row="4"] .slick-cell.selected').should('have.length', 7);
+    cy.get('#myGrid .slick-cell.selected').should('have.length', 7 * 3);
+  });
+
+  it('should synchronize the selected cell when selectActiveRow is disabled in cell mode', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-plugin-hybridselectionmodel.html`);
+    cy.window().then((win: any) => {
+      const selectionModel = win.grid.getSelectionModel();
+      selectionModel.setOptions({ selectionType: 'cell', selectActiveRow: false, selectActiveCell: true });
+      win.grid.setActiveCell(5, 1, false, false);
+      expect(selectionModel.getSelectedRanges()).to.have.length(1);
+      expect(selectionModel.getSelectedRanges()[0]).to.include({ fromRow: 5, fromCell: 1, toRow: 5, toCell: 1 });
+    });
+  });
 });

--- a/examples/example-plugin-hybridselectionmodel.html
+++ b/examples/example-plugin-hybridselectionmodel.html
@@ -328,7 +328,7 @@
     document.addEventListener("DOMContentLoaded", function () {
       dataView = new Slick.Data.DataView();
       grid = new Slick.Grid("#myGrid", dataView, columns, gridOptions);
-      grid.setSelectionModel(new Slick.HybridSelectionModel({ selectActiveRow: true, rowSelectColumnIds: ['id'] }));
+      grid.setSelectionModel(new Slick.HybridSelectionModel({ selectActiveRow: true, rowSelectColumnIds: ['id'], enableMultiSelection: true }));
       contextMenuPlugin = new Slick.Plugins.ContextMenu(contextMenuOptions);
       var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, gridOptions);
 

--- a/src/models/selectionModel.type.ts
+++ b/src/models/selectionModel.type.ts
@@ -1,10 +1,11 @@
 import type { SlickEvent, SlickRange } from '../slick.core.js';
 import type { SlickPlugin } from './index.js';
 
-export type SelectionModel = SlickPlugin & {
+export type SelectionModel<T = any> = SlickPlugin & {
   refreshSelections: () => void;
   onSelectedRangesChanged: SlickEvent<SlickRange[]>;
-  getOptions: () => any;
+  getOptions: () => T;
+  setOptions: (options: Partial<T>) => void;
   getSelectedRanges: () => SlickRange[];
   setSelectedRanges: (ranges: SlickRange[], caller?: string, selectionMode?: string) => void;
 };

--- a/src/models/selectionModelOption.interface.ts
+++ b/src/models/selectionModelOption.interface.ts
@@ -24,6 +24,9 @@ export interface HybridSelectionModelOption {
   /** Defaults to False, should we select when dragging? */
   dragToSelect?: boolean;
 
+  /** Defaults to False, should Ctrl/Cmd interactions add or toggle multiple cell or row selection ranges? */
+  enableMultiSelection?: boolean;
+
   /**
    * Defaults to True, controls the visibility of the Excel-style cell selection drag handle.
    * Set to `false` to disable the handle, or to `'hover'` to show it only while hovering the selected cell.

--- a/src/plugins/slick.cellexternalcopymanager.ts
+++ b/src/plugins/slick.cellexternalcopymanager.ts
@@ -400,40 +400,49 @@ export class SlickCellExternalCopyManager implements SlickPlugin {
           this.onCopyCells.notify({ ranges });
 
           const columns = this._grid.getColumns();
+          const fromRow = Math.min(...ranges.map((range) => range.fromRow));
+          const fromCell = Math.min(...ranges.map((range) => range.fromCell));
+          const toRow = Math.max(...ranges.map((range) => range.toRow));
+          const toCell = Math.max(...ranges.map((range) => range.toCell));
           let clipText = '';
 
-          for (let rg = 0; rg < ranges.length; rg++) {
-            const range = ranges[rg];
-            const clipTextRows: string[] = [];
-            for (let i = range.fromRow; i < range.toRow + 1; i++) {
-              const clipTextCells: string[] = [];
-              const dt = this._grid.getDataItem(i);
-
-              if (clipTextRows.length === 0 && this._options.includeHeaderWhenCopying) {
-                const clipTextHeaders: string[] = [];
-                for (let j = range.fromCell; j < range.toCell + 1; j++) {
-                  const colName: string = columns[j].name instanceof HTMLElement
-                    ? (columns[j].name as HTMLElement).innerHTML
-                    : columns[j].name as string;
-                  if (colName.length > 0 && !columns[j].hidden) {
-                    clipTextHeaders.push(this.getHeaderValueForColumn(columns[j]) || '');
-                  }
-                }
-                clipTextRows.push(clipTextHeaders.join('\t'));
-              }
-
-              for (let j = range.fromCell; j < range.toCell + 1; j++) {
-                const colName: string = columns[j].name instanceof HTMLElement
-                  ? (columns[j].name as HTMLElement).innerHTML
-                  : columns[j].name as string;
-                if (colName.length > 0 && !columns[j].hidden) {
-                  clipTextCells.push(this.getDataItemValueForColumn(dt, columns[j], e));
+          const clipTextRows: string[] = [];
+          if (this._options.includeHeaderWhenCopying) {
+            const clipTextHeaders: string[] = [];
+            for (let j = fromCell; j <= toCell; j++) {
+              const column = columns[j];
+              const isSelectedColumn = ranges.some((range) => j >= range.fromCell && j <= range.toCell);
+              if (column) {
+                const colName: string = column.name instanceof HTMLElement
+                  ? (column.name as HTMLElement).innerHTML
+                  : column.name as string;
+                if (colName.length > 0 && !column.hidden) {
+                  clipTextHeaders.push(isSelectedColumn ? this.getHeaderValueForColumn(column) || '' : '');
                 }
               }
-              clipTextRows.push(clipTextCells.join('\t'));
             }
-            clipText += clipTextRows.join('\r\n') + '\r\n';
+            clipTextRows.push(clipTextHeaders.join('\t'));
           }
+
+          for (let i = fromRow; i <= toRow; i++) {
+            const clipTextCells: string[] = [];
+            const dt = this._grid.getDataItem(i);
+            for (let j = fromCell; j <= toCell; j++) {
+              const column = columns[j];
+              if (column) {
+                const colName: string = column.name instanceof HTMLElement
+                  ? (column.name as HTMLElement).innerHTML
+                  : column.name as string;
+                if (colName.length > 0 && !column.hidden) {
+                  clipTextCells.push(
+                    ranges.some((range) => range.contains(i, j)) ? this.getDataItemValueForColumn(dt, column, e) : ''
+                  );
+                }
+              }
+            }
+            clipTextRows.push(clipTextCells.join('\t'));
+          }
+          clipText += clipTextRows.join('\r\n') + '\r\n';
 
           if ((window as any).clipboardData) {
             (window as any).clipboardData.setData('Text', clipText);

--- a/src/plugins/slick.cellrangeselector.ts
+++ b/src/plugins/slick.cellrangeselector.ts
@@ -19,8 +19,8 @@ export class SlickCellRangeSelector implements SlickPlugin {
   // public API
   pluginName = 'CellRangeSelector' as const;
   onBeforeCellRangeSelected = new SlickEvent<{ row: number; cell: number; }>('onBeforeCellRangeSelected');
-  onCellRangeSelected = new SlickEvent<{ range: SlickRange_; selectionMode: string; allowAutoEdit: boolean; }>('onCellRangeSelected');
-  onCellRangeSelecting = new SlickEvent<{ range: SlickRange_; selectionMode: string; allowAutoEdit: boolean; }>('onCellRangeSelecting');
+  onCellRangeSelected = new SlickEvent<{ range: SlickRange_; selectionMode: string; allowAutoEdit: boolean; addToSelection?: boolean; }>('onCellRangeSelected');
+  onCellRangeSelecting = new SlickEvent<{ range: SlickRange_; selectionMode: string; allowAutoEdit: boolean; addToSelection?: boolean; }>('onCellRangeSelecting');
 
   // --
   // protected props
@@ -36,6 +36,7 @@ export class SlickCellRangeSelector implements SlickPlugin {
   protected _options: CellRangeSelectorOption;
   protected _selectionMode: string = CellSelectionMode.Select;
   protected _dragReplaceHandleActive = false;
+  protected _addToSelection = false;
   protected _dragReplaceHandleCell:  { row : number, cell: number } | null = null;
   protected _defaults = {
     autoScroll: true,
@@ -152,8 +153,12 @@ export class SlickCellRangeSelector implements SlickPlugin {
       }
     }
 
-      this._dragReplaceHandleActive = (dd.matchClassTag === 'dragReplaceHandle');
-      if (this._dragReplaceHandleActive) {
+    this._dragReplaceHandleActive = (dd.matchClassTag === 'dragReplaceHandle');
+    this._addToSelection =
+      !this._dragReplaceHandleActive &&
+      this._grid.getSelectionModel()?.getOptions()?.enableMultiSelection === true &&
+      (!!e.ctrlKey || !!e.metaKey);
+    if (this._dragReplaceHandleActive) {
         this._dragReplaceHandleCell = this._grid.getCellFromEvent(e);
       } else {
         this._previousSelectedRange = null;
@@ -165,6 +170,12 @@ export class SlickCellRangeSelector implements SlickPlugin {
   }
 
   protected handleDragStart(e: SlickEventData, dd: DragRowMove) {
+    // Keep detecting the modifier during the drag as well as during mousedown.
+    // This is important for browsers and synthetic pointer events that do not
+    // preserve modifier flags on the initial event.
+    if (!this._dragReplaceHandleActive && this._grid.getSelectionModel()?.getOptions()?.enableMultiSelection === true) {
+      this._addToSelection ||= !!e.ctrlKey || !!e.metaKey;
+    }
     let cell = this._grid.getCellFromEvent(e);
     if (this._dragReplaceHandleActive) { cell = this._dragReplaceHandleCell; }
     if (cell && this.onBeforeCellRangeSelected.notify(cell).getReturnValue() !== false && this._grid.canCellBeSelected(cell.row, cell.cell)) {
@@ -211,6 +222,9 @@ export class SlickCellRangeSelector implements SlickPlugin {
     }
 
     const e = evt.getNativeEvent<MouseEvent>();
+    if (!this._dragReplaceHandleActive && this._grid.getSelectionModel()?.getOptions()?.enableMultiSelection === true) {
+      this._addToSelection ||= !!e?.ctrlKey || !!e?.metaKey;
+    }
     if (this._options.autoScroll) {
       this._draggingMouseOffset = this.getMouseOffsetViewport(e, dd);
       if (this._draggingMouseOffset.isOutsideViewport) {
@@ -389,8 +403,10 @@ export class SlickCellRangeSelector implements SlickPlugin {
 
       this._decorator.show(range, this._dragReplaceHandleActive);
       this.onCellRangeSelecting.notify({
-        range, selectionMode: '',
-        allowAutoEdit: false
+        range,
+        selectionMode: '',
+        allowAutoEdit: false,
+        ...(this._addToSelection ? { addToSelection: true } : {})
       });
     }
   }
@@ -431,7 +447,13 @@ export class SlickCellRangeSelector implements SlickPlugin {
         dd.range.end.cell
       );
 
-    this.onCellRangeSelected.notify({ range: r, selectionMode: this._selectionMode, allowAutoEdit: (this._selectionMode === "SEL" && r.isSingleCell()) });
+    this.onCellRangeSelected.notify({
+      range: r,
+      selectionMode: this._selectionMode,
+      allowAutoEdit: (this._selectionMode === "SEL" && r.isSingleCell()),
+      ...(this._addToSelection ? { addToSelection: true } : {})
+    });
+    this._addToSelection = false;
     // keep the resulting range (not the raw drag range) so that a next drag-extend anchors on the real selection
     this._previousSelectedRange = SelectionUtils.normaliseDragRange({
       start: { row: r.fromRow, cell: r.fromCell },

--- a/src/plugins/slick.cellselectionmodel.ts
+++ b/src/plugins/slick.cellselectionmodel.ts
@@ -73,6 +73,10 @@ export class SlickCellSelectionModel implements SelectionModel {
     return this._options;
   }
 
+  setOptions(options: Partial<CellSelectionModelOption>) {
+    this._options = Utils.extend(true, {}, this._options ?? this._defaults, options);
+  }
+
   protected removeInvalidRanges(ranges: SlickRange_[]) {
     const result: SlickRange_[] = [];
 

--- a/src/plugins/slick.hybridselectionmodel.ts
+++ b/src/plugins/slick.hybridselectionmodel.ts
@@ -47,6 +47,7 @@ export class SlickHybridSelectionModel implements SelectionModel {
   protected _selector?: SlickCellRangeSelector_;
   protected _isRowMoveManagerHandler: any;
   protected _activeSelectionIsRow = false;
+  protected _multiSelectionBaseRanges?: SlickRange_[];
   protected _options: HybridSelectionModelOption;
   protected _defaults: HybridSelectionModelOption = {
     selectActiveCell: true,
@@ -128,6 +129,10 @@ export class SlickHybridSelectionModel implements SelectionModel {
 
   getOptions(): HybridSelectionModelOption {
     return this._options;
+  }
+
+  setOptions(options: Partial<HybridSelectionModelOption>) {
+    this._options = Utils.extend(true, {}, this._options, options);
   }
 
   // Region: CellSelectionModel Members
@@ -251,7 +256,9 @@ export class SlickHybridSelectionModel implements SelectionModel {
 
   refreshSelections() {
     if (this._activeSelectionIsRow) {
-      this.setSelectedRows(this.getSelectedRows());
+      const lastCell = this._grid.getColumns().length - 1;
+      const ranges = this.getSelectedRanges().map((range) => new SlickRange(range.fromRow, 0, range.toRow, lastCell));
+      this.setSelectedRanges(ranges, undefined, '');
     } else {
       this.setSelectedRanges(this.getSelectedRanges(), undefined, '');
     }
@@ -300,7 +307,7 @@ export class SlickHybridSelectionModel implements SelectionModel {
     } else {
       if (this._options?.selectActiveCell && isRowDefined && isCellDefined) {
         // if any row selections are visible, leave them untouched unless `selectActiveCell` is enabled
-        if (this._options.selectActiveRow) {
+        if (this._options.selectionType === 'cell' || this._options.selectActiveRow) {
           this.setSelectedRanges([new SlickRange(args.row, args.cell)], undefined, '');
         }
       } else if (!this._options?.selectActiveCell || (!isRowDefined && !isCellDefined)) {
@@ -486,7 +493,23 @@ export class SlickHybridSelectionModel implements SelectionModel {
   }
 
   protected handleClick(e: SlickEventData_): boolean | void {
-    if (!this._activeSelectionIsRow) { return; }
+    if (!this._activeSelectionIsRow) {
+      if (!this._options.enableMultiSelection || (!e.ctrlKey && !e.metaKey)) {
+        return;
+      }
+
+      const cell = this._grid.getCellFromEvent(e);
+      if (!cell || !this._grid.canCellBeSelected(cell.row, cell.cell)) {
+        return false;
+      }
+
+      const ranges = this.toggleCellSelectionRange(this.getSelectedRanges().slice(), new SlickRange(cell.row, cell.cell));
+      this._grid.setActiveCell(cell.row, cell.cell, false, false, true);
+      this.setSelectedRanges(ranges);
+      e.stopImmediatePropagation();
+
+      return true;
+    }
 
     const cell = this._grid.getCellFromEvent(e);
     if (!cell || !this._grid.canCellBeActive(cell.row, cell.cell)) {
@@ -528,7 +551,59 @@ export class SlickHybridSelectionModel implements SelectionModel {
     return true;
   }
 
+  protected toggleCellSelectionRange(ranges: SlickRange_[], range: SlickRange_): SlickRange_[] {
+    const exactRangeIndex = ranges.findIndex((selectedRange) =>
+      selectedRange.fromRow === range.fromRow &&
+      selectedRange.fromCell === range.fromCell &&
+      selectedRange.toRow === range.toRow &&
+      selectedRange.toCell === range.toCell
+    );
+    if (exactRangeIndex !== -1) {
+      ranges.splice(exactRangeIndex, 1);
+      return ranges;
+    }
+
+    if (!range.isSingleCell()) {
+      ranges.push(range);
+      return ranges;
+    }
+
+    let wasSelected = false;
+    const result: SlickRange_[] = [];
+    for (const selectedRange of ranges) {
+      if (!selectedRange.contains(range.fromRow, range.fromCell)) {
+        result.push(selectedRange);
+        continue;
+      }
+
+      wasSelected = true;
+      if (selectedRange.fromRow < range.fromRow) {
+        result.push(new SlickRange(selectedRange.fromRow, selectedRange.fromCell, range.fromRow - 1, selectedRange.toCell));
+      }
+      if (selectedRange.toRow > range.toRow) {
+        result.push(new SlickRange(range.toRow + 1, selectedRange.fromCell, selectedRange.toRow, selectedRange.toCell));
+      }
+      if (selectedRange.fromCell < range.fromCell) {
+        result.push(new SlickRange(range.fromRow, selectedRange.fromCell, range.fromRow, range.fromCell - 1));
+      }
+      if (selectedRange.toCell > range.toCell) {
+        result.push(new SlickRange(range.fromRow, range.toCell + 1, range.fromRow, selectedRange.toCell));
+      }
+    }
+
+    if (!wasSelected) {
+      result.push(range);
+    }
+    return result;
+  }
+
   protected handleBeforeCellRangeSelected(e: SlickEventData_, cell: { row: number; cell: number; }): boolean | void {
+    // Changing the active cell below can update the selection when row selection is
+    // active. Preserve the ranges that existed before the drag so a modifier drag
+    // can append its live preview to them instead of replacing them.
+    this._multiSelectionBaseRanges = this._activeSelectionIsRow && this._options.enableMultiSelection
+      ? this.getSelectedRanges().slice()
+      : undefined;
     if (this._activeSelectionIsRow) {
       if (!this._isRowMoveManagerHandler) {
         const rowMoveManager = this._grid.getPluginByName<SlickRowMoveManager_>('RowMoveManager') || this._grid.getPluginByName<SlickCrossGridRowMoveManager_>('CrossGridRowMoveManager');
@@ -547,19 +622,37 @@ export class SlickHybridSelectionModel implements SelectionModel {
     }
   }
 
-  protected handleCellRangeSelected(_e: SlickEventData_, args: { range: SlickRange_; selectionMode: string; allowAutoEdit?: boolean; caller: 'onCellRangeSelecting' | 'onCellRangeSelected' }) {
+  protected handleCellRangeSelected(_e: SlickEventData_, args: { range: SlickRange_; selectionMode: string; allowAutoEdit?: boolean; addToSelection?: boolean; caller: 'onCellRangeSelecting' | 'onCellRangeSelected' }) {
     //console.log('hybridSelectionModel.handleCellRangeSelected: ' + JSON.stringify(args.range) + '/' + args.selectionMode);
     if (this._activeSelectionIsRow) {
       if (!this._grid.getOptions().multiSelect || (!this._options?.selectActiveRow && this._options?.selectionType !== 'row')) {
         return false;
       }
-      this.setSelectedRanges([new SlickRange(args.range.fromRow, 0, args.range.toRow, this._grid.getColumns().length - 1)], undefined, args.selectionMode);
+      const selectedRange = new SlickRange(args.range.fromRow, 0, args.range.toRow, this._grid.getColumns().length - 1);
+      const isMultiSelection = args.addToSelection && this._options.enableMultiSelection;
+      let currentRanges = this.getSelectedRanges();
+      if (isMultiSelection) {
+        this._multiSelectionBaseRanges ??= currentRanges.slice();
+        currentRanges = this._multiSelectionBaseRanges;
+      }
+      const ranges = isMultiSelection ? [...currentRanges, selectedRange] : [selectedRange];
+      if (args.caller === 'onCellRangeSelected') {
+        this._multiSelectionBaseRanges = undefined;
+      }
+      this.setSelectedRanges(ranges, undefined, args.selectionMode);
     } else {
       if (args.caller === 'onCellRangeSelecting') {
         return false;
       }
       this._grid.setActiveCell(args.range.fromRow, args.range.fromCell, (args.allowAutoEdit ? undefined : false), false, true);
-      this.setSelectedRanges([args.range], undefined, args.selectionMode);
+      const currentRanges = this.getSelectedRanges();
+      const ranges =
+        args.selectionMode === 'REP' && currentRanges.length
+          ? [...currentRanges.slice(0, -1), args.range]
+          : args.addToSelection && this._options.enableMultiSelection
+            ? this.toggleCellSelectionRange(currentRanges.slice(), args.range)
+            : [args.range];
+      this.setSelectedRanges(ranges, undefined, args.selectionMode);
     }
     return true;
   }

--- a/src/plugins/slick.rowselectionmodel.ts
+++ b/src/plugins/slick.rowselectionmodel.ts
@@ -98,6 +98,10 @@ export class SlickRowSelectionModel implements SelectionModel {
     return this._options;
   }
 
+  setOptions(options: Partial<RowSelectionModelOption>) {
+    this._options = Utils.extend(true, {}, this._options, options);
+  }
+
   protected wrapHandler(handler: (...args: any) => void) {
     return (...args: any) => {
       if (!this._inHandler) {
@@ -278,4 +282,3 @@ if (IIFE_ONLY && window.Slick) {
     }
   });
 }
-

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -977,25 +977,36 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         this._bindingEventService.bind(element, 'mouseout', this.handleCellMouseOut.bind(this) as EventListener);
       });
 
-      if (Draggable) {
-        this.slickDraggableInstance = Draggable({
-          containerElement: this._container,
-          allowDragFrom: `div.slick-cell, div.${this.dragReplaceEl.cssClass}`,
-          dragFromClassDetectArr: [{ tag: 'dragReplaceHandle', id: this.dragReplaceEl.id }],
-          // the slick cell parent must always contain `.dnd` and/or `.cell-reorder` class to be identified as draggable
-          allowDragFromClosest: 'div.slick-cell.dnd, div.slick-cell.cell-reorder',
-          preventDragFromKeys: this._options.preventDragFromKeys,
-          onDragInit: this.handleDragInit.bind(this),
-          onDragStart: this.handleDragStart.bind(this),
-          onDrag: this.handleDrag.bind(this),
-          onDragEnd: this.handleDragEnd.bind(this)
-        });
-      }
+      this.createDraggable();
 
       if (!this._options.suppressCssChangesOnHiddenInit) {
         this.restoreCssFromHiddenInit();
       }
     }
+  }
+
+  /** Create or recreate the cell drag interaction using the current selection model options. */
+  protected createDraggable() {
+    if (!Draggable) {
+      return;
+    }
+
+    this.slickDraggableInstance?.destroy();
+    const preventDragFromKeys = this.getSelectionModel()?.getOptions()?.enableMultiSelection === true
+      ? this._options.preventDragFromKeys?.filter((key) => key !== 'ctrlKey' && key !== 'metaKey')
+      : this._options.preventDragFromKeys;
+    this.slickDraggableInstance = Draggable({
+      containerElement: this._container,
+      allowDragFrom: `div.slick-cell, div.${this.dragReplaceEl.cssClass}`,
+      dragFromClassDetectArr: [{ tag: 'dragReplaceHandle', id: this.dragReplaceEl.id }],
+      // the slick cell parent must always contain `.dnd` and/or `.cell-reorder` class to be identified as draggable
+      allowDragFromClosest: 'div.slick-cell.dnd, div.slick-cell.cell-reorder',
+      preventDragFromKeys,
+      onDragInit: this.handleDragInit.bind(this),
+      onDragStart: this.handleDragStart.bind(this),
+      onDrag: this.handleDrag.bind(this),
+      onDragEnd: this.handleDragEnd.bind(this)
+    });
   }
 
   /**
@@ -1494,6 +1505,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (this.selectionModel) {
       this.selectionModel.init(this as unknown as SlickGridModel);
       this.selectionModel.onSelectedRangesChanged.subscribe(this.handleSelectedRangesChanged.bind(this));
+    }
+
+    // The grid normally finishes initialization from its constructor, before
+    // applications assign a selection model. Recreate the draggable interaction
+    // so modifier-drag selection options are applied to the initialized grid.
+    if (this.initialized) {
+      this.createDraggable();
     }
   }
 
@@ -4081,16 +4099,34 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const prevSelectedRanges = this.selectedRanges.slice(0);
     this.selectedRanges = ranges;
 
-    if (selectionMode === CellSelectionMode.Replace
-      && prevSelectedRanges && prevSelectedRanges.length === 1
-      && this.selectedRanges && this.selectedRanges.length === 1) {
-      const prevSelectedRange = prevSelectedRanges[0];
-      const selectedRange = this.selectedRanges[0];
+    if (selectionMode === CellSelectionMode.Replace && prevSelectedRanges.length === this.selectedRanges.length && prevSelectedRanges.length > 0) {
+      let changedRangeIndex = -1;
+      for (let i = 0; i < this.selectedRanges.length; i++) {
+        const previousRange = prevSelectedRanges[i];
+        const selectedRange = this.selectedRanges[i];
+        if (
+          previousRange.fromRow !== selectedRange.fromRow ||
+          previousRange.fromCell !== selectedRange.fromCell ||
+          previousRange.toRow !== selectedRange.toRow ||
+          previousRange.toCell !== selectedRange.toCell
+        ) {
+          if (changedRangeIndex !== -1) {
+            changedRangeIndex = -1;
+            break;
+          }
+          changedRangeIndex = i;
+        }
+      }
 
-      // check range has expanded
-      if (SelectionUtils.copyRangeIsLarger(prevSelectedRange, selectedRange)) {
-        this.trigger(this.onDragReplaceCells, { prevSelectedRange, selectedRange });
-        this.invalidate();
+      if (changedRangeIndex !== -1) {
+        const prevSelectedRange = prevSelectedRanges[changedRangeIndex];
+        const selectedRange = this.selectedRanges[changedRangeIndex];
+
+        // check range has expanded
+        if (SelectionUtils.copyRangeIsLarger(prevSelectedRange, selectedRange)) {
+          this.trigger(this.onDragReplaceCells, { prevSelectedRange, selectedRange });
+          this.invalidate();
+        }
       }
     }
 
@@ -4114,8 +4150,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           }
         }
       }
-      if (this.selectionBottomRow < ranges[i].toRow) { this.selectionBottomRow = ranges[i].toRow; }
-      if (this.selectionRightCell < ranges[i].toCell) { this.selectionRightCell = ranges[i].toCell; }
+    }
+
+    const activeRange = ranges[ranges.length - 1];
+    if (activeRange) {
+      this.selectionBottomRow = activeRange.toRow;
+      this.selectionRightCell = activeRange.toCell;
     }
 
     this.setCellCssStyles(this._options.selectedCellCssClass || '', hash);


### PR DESCRIPTION
**## Summary**

This PR selectively ports the multi-range selection functionality and related fixes from upstream PRs [#2748](https://github.com/ghiscoding/slickgrid-universal/pull/2748), [#2759](https://github.com/ghiscoding/slickgrid-universal/pull/2759), and [#2777](https://github.com/ghiscoding/slickgrid-universal/pull/2777).

**## Why**

Users can select multiple non-contiguous cell or row ranges using Excel-like Ctrl/Cmd interactions.

**## Changes**

- Added the `enableMultiSelection` selection option.
- Added `SelectionModel.setOptions()`.
- Added Ctrl/Cmd-click range toggling and rectangular range splitting.
- Added Ctrl/Cmd-drag range additions for cells and rows.
- Preserved existing ranges during live drag previews.
- Synchronized the active cell when `selectActiveRow` is disabled.
- Preserved gaps when copying non-contiguous ranges.
- Updated the draggable interaction to support selection-model options after initialization.
- Added and updated Cypress coverage and the Hybrid Selection Model example.

PR #2757 is intentionally excluded because Shift-click range extension is a separate scope.

**## Validation**

- Cypress E2E tests passed in Cypress UI/dev-watch mode.
- `npx tsc --noEmit --incremental false`
- `npm run lint`
- `npm run build:prod`
- `git diff --check`

**## Comments**

The changes are limited to the core SlickGrid selection behavior and related Vanilla example/test coverage.

The local `npm run cypress:ci` command could not be used for final validation because the browser process exits with code 132 in the current environment.

**## AI / LLM assistance**

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex / GPT-5
  - **how was it used**: Reviewed the upstream PRs, implemented the corresponding SlickGrid changes, added Cypress coverage, investigated test failures, and validated the implementation.

**## Checklist**

- [x] The changes are limited to only one scope.
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate.

<img width="1633" height="1449" alt="image" src="https://github.com/user-attachments/assets/ddbfd105-5d27-47b2-90aa-68356503f638" />
