### PR TITLE
fix(interactions): ignore secondary-button cell range drags

### DIFF
--- a/cypress/e2e/example-plugin-hybridselectionmodel.cy.ts
+++ b/cypress/e2e/example-plugin-hybridselectionmodel.cy.ts
@@ -32,6 +32,21 @@ describe('Example - Context Menu Plugin & Hybrid Selection Mode', () => {
     cy.get('#myGrid .slick-cell.selected').should('have.length', 4);
   });
 
+  it('should preserve cell selection when dragging with the secondary mouse button', () => {
+    cy.get('#myGrid .slick-cell.selected').should('have.length', 4);
+
+    cy.get('#myGrid .slick-row[data-row="1"] .slick-cell.l1.r1').trigger('mousedown', {
+      button: 2,
+      which: 3,
+      force: true,
+    });
+    cy.get('#myGrid .slick-row[data-row="3"] .slick-cell.l3.r3')
+      .trigger('mousemove', 'bottomRight')
+      .trigger('mouseup', 'bottomRight', { button: 2, which: 3, force: true });
+
+    cy.get('#myGrid .slick-cell.selected').should('have.length', 4);
+  });
+
   it('should be able to expand the cell selections further to the right', () => {
     cy.get('#myGrid .slick-cell.selected').should('have.length', 4);
     cy.get('#myGrid .slick-row[data-row="2"] .slick-cell.l2.r2')

--- a/src/slick.interactions.ts
+++ b/src/slick.interactions.ts
@@ -84,6 +84,13 @@ export function Draggable(options: DraggableOption) {
   }
 
   function userPressed(event: MouseEvent | TouchEvent | KeyboardEvent) {
+    // Dragging is a primary-button action; allow secondary clicks to continue
+    // to context-menu handling without starting a drag.
+    // Keep synthetic mousedown CustomEvents compatible (they have no `button`).
+    if (event.type === 'mousedown' && 'button' in event && (event as MouseEvent).button !== 0) {
+      return;
+    }
+
     if (!preventDrag(event)) {
       element = event.target as HTMLElement;
       const targetEvent: MouseEvent | Touch = (event as TouchEvent)?.touches?.[0] ?? event;


### PR DESCRIPTION
_replicate Slickgrid-Universal [PR 2756](https://github.com/ghiscoding/slickgrid-universal/pull/2756) into SlickGrid. You can see the included ChatGPT summary below._

**## Summary**

Fixes unintended cell-range drags triggered by secondary mouse-button actions.

**## Why**

Right-clicking or using another secondary mouse button on a selected cell could unexpectedly start a drag operation and alter the selection.

**## Changes**

- Ignore non-primary `mousedown` events in `Draggable`.
- Preserve compatibility with synthetic `mousedown` `CustomEvent` usage.
- Add Cypress regression coverage for secondary-button cell drags.

**## Validation**

- All Cypress tests passed.
- `npm run lint`
- `npm run build:types`
- `npm run build:prod`
- `git diff --check`

**## Comments**

This is the core SlickGrid equivalent of the upstream Universal fix:
https://github.com/ghiscoding/slickgrid-universal/pull/2756

No documentation update is required because this is an internal behavior fix.

**## AI / LLM assistance**

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex / GPT-5.6 Luna
  - **how was it used**: Reviewed the upstream fix, implemented the core SlickGrid change, added regression coverage, and validated the build and tests.

**## Checklist**

- [x] The changes are limited to only one scope.
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate.