### PR TITLE
feat(grid): add auto-scroll while resizing columns

### DIFF
--- a/cypress/e2e/example-0032-row-span-many-columns.cy.ts
+++ b/cypress/e2e/example-0032-row-span-many-columns.cy.ts
@@ -1,3 +1,5 @@
+import { createMouseLikeEvent } from '../support/drag';
+
 describe('Example - colspan & rowspan spanning many columns', { retries: 0 }, () => {
   const GRID_ROW_HEIGHT = 25;
   const fullTitles = [
@@ -6,6 +8,20 @@ describe('Example - colspan & rowspan spanning many columns', { retries: 0 }, ()
     'Revenue Growth', 'Pricing Policy', 'Policy Index', 'Expense Control', 'Excess Cash', 'Net Trade Cycle', 'Cost of Capital',
     'Revenue Growth', 'Pricing Policy', 'Policy Index', 'Expense Control', 'Excess Cash', 'Net Trade Cycle', 'Cost of Capital'
   ];
+  let originalResizeWidth: number | undefined;
+
+  afterEach(function () {
+    if (this.currentTest?.title.includes('off-screen resize') && originalResizeWidth !== undefined) {
+      cy.window().then((win: any) => {
+        win.document.body.dispatchEvent(createMouseLikeEvent(win, 'mouseup', 0, 0, 0));
+        const grid = win.eval('grid');
+        const columns = grid.getColumns();
+        columns[0].width = originalResizeWidth;
+        grid.setColumns(columns);
+        grid.scrollToX(0);
+      });
+    }
+  });
 
   it('should display Example title', () => {
     cy.visit(`${Cypress.config('baseUrl')}/examples/example-0032-row-span-many-columns.html`);
@@ -18,6 +34,56 @@ describe('Example - colspan & rowspan spanning many columns', { retries: 0 }, ()
       .find('.slick-header-columns')
       .children()
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+  });
+
+  it('should clamp an off-screen resize to the viewport and continue widening at 10px per 30ms', () => {
+    let widthAtViewportEdge = 0;
+    const headerSelector = '#myGrid .slick-header-columns .slick-header-column:first-child';
+
+    cy.window().then((win) => {
+      const header = win.document.querySelector(headerSelector) as HTMLElement;
+      const handle = header.querySelector('.slick-resizable-handle') as HTMLElement;
+      const viewport = win.document.querySelector('#myGrid .slick-viewport-top.slick-viewport-left') as HTMLElement;
+      const handleRect = handle.getBoundingClientRect();
+      const startX = handleRect.left + handleRect.width / 2;
+      const viewportRight = viewport.getBoundingClientRect().right;
+      const targetX = Math.max(viewportRight + 500, startX + 500);
+      const initialWidth = header.getBoundingClientRect().width;
+      originalResizeWidth = win.eval('grid').getColumns()[0].width;
+
+      handle.dispatchEvent(createMouseLikeEvent(win, 'mousedown', startX, handleRect.top + handleRect.height / 2));
+      win.document.body.dispatchEvent(createMouseLikeEvent(win, 'mousemove', targetX, handleRect.top + handleRect.height / 2));
+
+      widthAtViewportEdge = header.getBoundingClientRect().width;
+      expect(widthAtViewportEdge).to.be.at.most(initialWidth + viewportRight - startX + 5);
+    });
+
+    cy.wait(50);
+    cy.window().then((win) => {
+      const widthAfterFirstInterval = (win.document.querySelector(headerSelector) as HTMLElement).getBoundingClientRect().width;
+      // A 50ms sample can include one or two 30ms callbacks. The second callback also
+      // includes the viewport-scroll offset correction from the fork implementation.
+      expect(widthAfterFirstInterval).to.be.within(widthAtViewportEdge + 9, widthAtViewportEdge + 25);
+    });
+
+    cy.wait(300);
+    cy.get('#myGrid .slick-viewport-top.slick-viewport-left').should(($viewport) => {
+      expect($viewport[0].scrollLeft).to.be.greaterThan(0);
+    });
+
+    cy.window().then((win) => {
+      win.document.body.dispatchEvent(createMouseLikeEvent(win, 'mouseup', 0, 0, 0));
+    });
+    const widthAfterMouseUp = { value: 0 };
+    cy.get(headerSelector).then(($header) => {
+      widthAfterMouseUp.value = $header.outerWidth() as number;
+    });
+    cy.wait(80);
+    cy.window().then((win) => {
+      const widthAfterStop = (win.document.querySelector(headerSelector) as HTMLElement).getBoundingClientRect().width;
+      expect(widthAfterStop).to.be.closeTo(widthAfterMouseUp.value, 1);
+    });
+
   });
 
   it('should drag Title column to swap with 2nd column "Revenue Growth" in the grid and expect rowspan to stay at same position with Task 0 to spread instead', () => {

--- a/cypress/e2e/example-0070-plugin-state.cy.ts
+++ b/cypress/e2e/example-0070-plugin-state.cy.ts
@@ -1,3 +1,5 @@
+import { createMouseLikeEvent } from '../support/drag';
+
 describe('Example 0070 - Grid State using Local Storage', () => {
   const originalTitles = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];
 
@@ -53,13 +55,18 @@ describe('Example 0070 - Grid State using Local Storage', () => {
       .children('.slick-header-column:nth(1)')
       .should('contain', 'C');
 
-    cy.get('.slick-resizable-handle:nth(1)')
-      .trigger('mousedown', { which: 1, force: true })
-      .trigger('mousemove', 'bottomRight');
+    cy.window().then((win) => {
+      const header = win.document.querySelector('.slick-header-columns .slick-header-column:nth-child(2)') as HTMLElement;
+      const handle = header.querySelector('.slick-resizable-handle') as HTMLElement;
+      const handleRect = handle.getBoundingClientRect();
+      const startX = handleRect.left + handleRect.width / 2;
+      const y = handleRect.top + handleRect.height / 2;
 
-    cy.get('.slick-header-column:nth(2)')
-      .trigger('mousemove', 'bottomRight')
-      .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+      handle.dispatchEvent(createMouseLikeEvent(win, 'mousedown', startX, y));
+      const targetX = startX + 88;
+      win.document.body.dispatchEvent(createMouseLikeEvent(win, 'mousemove', targetX, y));
+      win.document.body.dispatchEvent(createMouseLikeEvent(win, 'mouseup', targetX, y, 0));
+    });
 
     cy.get('.slick-header-column:nth(1)')
       .should(($el) => {

--- a/cypress/e2e/example-frozen-columns-reorder.cy.ts
+++ b/cypress/e2e/example-frozen-columns-reorder.cy.ts
@@ -158,7 +158,7 @@ describe('Example - Frozen Columns - Column Header Reorder (characterization)', 
     });
     expectHeaderTitles(RIGHT_HEADERS, initialRightTitles);
     expectReorderCallCount(6);
-    cy.get(RIGHT_VIEWPORT).scrollTo(0, 0, { ensureScrollable: false });
+    cy.window().then((win: any) => win.grid.scrollToX(0));
   });
 
   it('should clamp and pace resize auto-scroll for a column in the non-frozen section', () => {
@@ -209,11 +209,11 @@ describe('Example - Frozen Columns - Column Header Reorder (characterization)', 
       expect(widthAfterStop).to.be.closeTo(widthAfterMouseUp.value, 1);
     });
 
-    cy.get(RIGHT_VIEWPORT).scrollTo(0, 0, { ensureScrollable: false });
+    cy.window().then((win: any) => win.grid.scrollToX(0));
   });
 
   it('should auto-scroll the right viewport when a header drag moves past the right edge of the grid', () => {
-    cy.get(RIGHT_VIEWPORT).scrollTo(0, 0, { ensureScrollable: false });
+    cy.window().then((win: any) => win.grid.scrollToX(0));
     cy.wait(50);
     cy.get(RIGHT_VIEWPORT).should(($v) => expect($v[0].scrollLeft).to.eq(0));
 
@@ -242,18 +242,19 @@ describe('Example - Frozen Columns - Column Header Reorder (characterization)', 
       const dragX = gridRect.right + 100;
       const dataTransfer = new DataTransfer();
       win.document.dispatchEvent(createDragLikeEvent('drag', dragX, sy, dataTransfer));
-      win.document.dispatchEvent(createDragLikeEvent('mousemove', dragX, sy, dataTransfer));
+      win.document.dispatchEvent(createMouseLikeEvent(win, 'mousemove', dragX, sy));
     });
     cy.wait(250);
 
     cy.window().then((win: any) => {
       const finishHeader = getRightHeader(win, 'Finish');
       const rect = finishHeader.getBoundingClientRect();
+      const viewportRect = (win.document.querySelector(RIGHT_VIEWPORT) as HTMLElement).getBoundingClientRect();
       const sy = rect.top + rect.height / 2;
-      const safeX = rect.left + rect.width / 2;
+      const safeX = viewportRect.left + viewportRect.width / 2;
       const dataTransfer = new DataTransfer();
       win.document.dispatchEvent(createDragLikeEvent('drag', safeX, sy, dataTransfer));
-      win.document.dispatchEvent(createDragLikeEvent('mousemove', safeX, sy, dataTransfer));
+      win.document.dispatchEvent(createMouseLikeEvent(win, 'mousemove', safeX, sy));
     });
 
     cy.get(RIGHT_VIEWPORT).then(($v) => {
@@ -283,6 +284,6 @@ describe('Example - Frozen Columns - Column Header Reorder (characterization)', 
     expectColumnIds(initialIds);
     expectReorderCallCount(6);
 
-    cy.get(RIGHT_VIEWPORT).scrollTo(0, 0, { ensureScrollable: false });
+    cy.window().then((win: any) => win.grid.scrollToX(0));
   });
 });

--- a/cypress/e2e/example-frozen-columns-reorder.cy.ts
+++ b/cypress/e2e/example-frozen-columns-reorder.cy.ts
@@ -1,4 +1,4 @@
-import { createDragLikeEvent, pressPointer, releasePointer } from '../support/drag';
+import { createDragLikeEvent, createMouseLikeEvent, pressPointer, releasePointer } from '../support/drag';
 
 // Characterization tests for header column reordering on a frozen-columns grid (currently SortableJS).
 // These specs pin down the observable behavior that must survive the SortableJS removal refactor:
@@ -11,6 +11,20 @@ describe('Example - Frozen Columns - Column Header Reorder (characterization)', 
   const initialLeftTitles = ['#', 'Title', 'Duration'];
   const initialRightTitles = ['% Complete', 'Start', 'Finish', 'Effort Driven', 'Title1', 'Title2', 'Title3', 'Title4'];
   const initialIds = ['sel', 'title', 'duration', '%', 'start', 'finish', 'effort-driven', 'title1', 'title2', 'title3', 'title4'];
+  let originalResizeWidth: number | undefined;
+
+  afterEach(function () {
+    if (this.currentTest?.title.includes('pace resize auto-scroll') && originalResizeWidth !== undefined) {
+      cy.window().then((win: any) => {
+        win.document.body.dispatchEvent(createMouseLikeEvent(win, 'mouseup', 0, 0, 0));
+        const grid = win.grid;
+        const columns = grid.getColumns();
+        columns[1].width = originalResizeWidth;
+        grid.setColumns(columns);
+        grid.scrollToX(0);
+      });
+    }
+  });
 
   const expectHeaderTitles = (containerSelector: string, titles: string[]) => {
     cy.get(containerSelector)
@@ -144,6 +158,57 @@ describe('Example - Frozen Columns - Column Header Reorder (characterization)', 
     });
     expectHeaderTitles(RIGHT_HEADERS, initialRightTitles);
     expectReorderCallCount(6);
+    cy.get(RIGHT_VIEWPORT).scrollTo(0, 0, { ensureScrollable: false });
+  });
+
+  it('should clamp and pace resize auto-scroll for a column in the non-frozen section', () => {
+    let widthAtViewportEdge = 0;
+    const headerSelector = `${RIGHT_HEADERS} .slick-header-column:nth-child(2)`; // Start
+
+    cy.window().then((win: any) => {
+      const header = win.document.querySelector(headerSelector) as HTMLElement;
+      const handle = header.querySelector('.slick-resizable-handle') as HTMLElement;
+      const viewport = win.document.querySelector(RIGHT_VIEWPORT) as HTMLElement;
+      const handleRect = handle.getBoundingClientRect();
+      const startX = handleRect.left + handleRect.width / 2;
+      const viewportRight = viewport.getBoundingClientRect().right;
+      const targetX = Math.max(viewportRight + 500, startX + 500);
+      const initialWidth = header.getBoundingClientRect().width;
+      originalResizeWidth = win.grid.getColumns()[1].width;
+
+      handle.dispatchEvent(createMouseLikeEvent(win, 'mousedown', startX, handleRect.top + handleRect.height / 2));
+      win.document.body.dispatchEvent(createMouseLikeEvent(win, 'mousemove', targetX, handleRect.top + handleRect.height / 2));
+
+      widthAtViewportEdge = header.getBoundingClientRect().width;
+      expect(widthAtViewportEdge).to.be.at.most(initialWidth + viewportRight - startX + 5);
+    });
+
+    cy.wait(50);
+    cy.window().then((win: any) => {
+      const widthAfterFirstInterval = (win.document.querySelector(headerSelector) as HTMLElement).getBoundingClientRect().width;
+      // A 50ms sample can include one or two 30ms callbacks. The second callback also
+      // includes the viewport-scroll offset correction from the fork implementation.
+      expect(widthAfterFirstInterval).to.be.within(widthAtViewportEdge + 9, widthAtViewportEdge + 25);
+    });
+
+    cy.wait(300);
+    cy.get(RIGHT_VIEWPORT).should(($viewport) => {
+      expect($viewport[0].scrollLeft).to.be.greaterThan(0);
+    });
+
+    cy.window().then((win: any) => {
+      win.document.body.dispatchEvent(createMouseLikeEvent(win, 'mouseup', 0, 0, 0));
+    });
+    const widthAfterMouseUp = { value: 0 };
+    cy.get(headerSelector).then(($header) => {
+      widthAfterMouseUp.value = $header.outerWidth() as number;
+    });
+    cy.wait(80);
+    cy.window().then((win: any) => {
+      const widthAfterStop = (win.document.querySelector(headerSelector) as HTMLElement).getBoundingClientRect().width;
+      expect(widthAfterStop).to.be.closeTo(widthAfterMouseUp.value, 1);
+    });
+
     cy.get(RIGHT_VIEWPORT).scrollTo(0, 0, { ensureScrollable: false });
   });
 

--- a/cypress/e2e/quirk-fractional-height-bottom-render.cy.ts
+++ b/cypress/e2e/quirk-fractional-height-bottom-render.cy.ts
@@ -89,14 +89,14 @@ describe('Quirk - a fractional grid height must still render the bottom rows', {
     cy.window().then((win: any) => {
       const vp = win.viewportEl();
 
-      // precondition: the browser lets us scroll further down than the ceiling
-      // `scrollTo()` clamps to. Without that sub-pixel gap the bug cannot occur
-      // (which is exactly why an integer or `.5+` height never reproduces it).
+      // Precondition: fractional layout produces a sub-pixel difference between the
+      // DOM and grid limits. Browsers round this in opposite directions, so the
+      // functional assertion below must not depend on which limit is larger.
       vp.scrollTop = 1e9;
       const domMaxScrollTop = vp.scrollTop;
       win.grid.scrollTo(1e9);
       const gridMaxScrollTop = win.grid.scrollTop;
-      expect(domMaxScrollTop, `DOM max scrollTop vs grid clamp (${gridMaxScrollTop})`).to.be.greaterThan(gridMaxScrollTop);
+      expect(Math.abs(domMaxScrollTop - gridMaxScrollTop), 'fractional DOM/grid scroll limit difference').to.be.greaterThan(0.01);
 
       // start from a fully rendered bottom, then wheel up far enough that the render
       // buffer no longer covers the last rows - they must actually be cleaned up,

--- a/cypress/support/drag.ts
+++ b/cypress/support/drag.ts
@@ -32,6 +32,15 @@ export function createDragLikeEvent(eventName: string, x: number, y: number, dat
   return evt;
 }
 
+/** Create a mouse event with explicit page/client coordinates for resize interactions. */
+export function createMouseLikeEvent(win: Window, eventName: string, x: number, y: number, buttons = 1): MouseEvent {
+  const event = win.document.createEvent('MouseEvent');
+  event.initMouseEvent(eventName, true, true, win, 0, x, y, x, y, false, false, false, false, buttons, null);
+  Object.defineProperty(event, 'pageX', { configurable: true, value: x });
+  Object.defineProperty(event, 'pageY', { configurable: true, value: y });
+  return event;
+}
+
 /** Dispatch the pointer/mouse press that precedes a native HTML5 drag (SortableJS only arms itself from pointerdown/mousedown) */
 export function pressPointer(el: HTMLElement, x: number, y: number): void {
   const init = { bubbles: true, cancelable: true, button: 0, buttons: 1, clientX: x, clientY: y };

--- a/scripts/builds.mjs
+++ b/scripts/builds.mjs
@@ -108,7 +108,7 @@ export async function buildAllIifeFiles() {
     if (/(^|[\\/])index\.[jt]s$/i.test(file) || /src[\\/]models[\\/].*\.ts/i.test(file) || /.*\.d.ts/i.test(file)) {
       continue;
     }
-    buildIifeFile(file, false);
+    await buildIifeFile(file, false);
   }
   const endTime = new Date().getTime();
   console.log(`[${styleText('yellow', 'esbuild ⚡')}] Built ${allFiles.length} files to "iife" format in ${endTime - startTime}ms`);

--- a/src/models/gridOption.interface.ts
+++ b/src/models/gridOption.interface.ts
@@ -171,6 +171,9 @@ export interface GridOption<C extends BaseColumn = BaseColumn> {
   /** Defaults to false, which will automatically resize the column headers whenever the grid size changes */
   enableAutoSizeColumns?: boolean;
 
+  /** Defaults to true, automatically scrolls the viewport while resizing a column beyond its visible edge. */
+  autoScrollOnColumnResize?: boolean;
+
   /** Defaults to false, which will let user click on cell and navigate with arrow keys. */
   enableCellNavigation?: boolean;
 

--- a/src/slick.grid.ts
+++ b/src/slick.grid.ts
@@ -119,6 +119,9 @@ const WidthEvalMode = IIFE_ONLY ? Slick.WidthEvalMode : WidthEvalMode_;
 // body scroll range (header width is the header/body scroll-sync floor) and column
 // drag-reorder has room past the last column
 const HEADER_WIDTH_SLACK = 1000;
+const COLUMN_AUTOSCROLL_DISTANCE_PX = 10;
+const COLUMN_AUTOSCROLL_INTERVAL_MS = 30;
+const RESIZE_AUTOSCROLL_BROWSER_EDGE_PX = 1;
 const Draggable = IIFE_ONLY ? Slick.Draggable : Draggable_;
 const MouseWheel = IIFE_ONLY ? Slick.MouseWheel : MouseWheel_;
 const Resizable = IIFE_ONLY ? Slick.Resizable : Resizable_;
@@ -335,6 +338,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     mixinDefaults: true,
     shadowRoot: undefined,
     colAutosizeTreatAsLockedBelowWidth: 100,
+    autoScrollOnColumnResize: true,
     rtl: false
   };
 
@@ -372,6 +376,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   };
 
   protected _columnResizeTimer?: number;
+  protected _columnResizeAutoScrollTimer?: number;
   protected _executionBlockTimer?: number;
   protected _flashCellTimer?: number;
   protected _highlightRowTimer?: number;
@@ -1998,8 +2003,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
         if (direction) {
           columnScrollTimer = window.setInterval(() => {
-            this._viewportScrollContainerX.scrollLeft += direction * 10;
-          }, 30);
+            this._viewportScrollContainerX.scrollLeft += direction * COLUMN_AUTOSCROLL_DISTANCE_PX;
+          }, COLUMN_AUTOSCROLL_INTERVAL_MS);
         }
       }
     };
@@ -2112,7 +2117,71 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     let firstResizable: number | undefined;
     let lastResizable = -1;
     let frozenLeftColMaxWidth = 0;
+    let resizeAutoScrollDeltaX = 0;
+    let autoScrollClientX: number | undefined;
+    let autoScrollOffsetX = 0;
 
+    const stopColumnResizeAutoScroll = () => {
+      if (this._columnResizeAutoScrollTimer) {
+        window.clearInterval(this._columnResizeAutoScrollTimer);
+        this._columnResizeAutoScrollTimer = undefined;
+      }
+      autoScrollOffsetX = 0;
+    };
+
+    const scheduleColumnResizeAutoScroll = (resizeCallback: (targetPageX: number) => void) => {
+      if (this._columnResizeAutoScrollTimer) {
+        return;
+      }
+      this._columnResizeAutoScrollTimer = window.setInterval(() => {
+        const viewportOffset = Utils.offset(this._viewportScrollContainerX)!;
+        const targetPageX = autoScrollOffsetX > 0
+          ? viewportOffset.left + this._viewportScrollContainerX.clientWidth + COLUMN_AUTOSCROLL_DISTANCE_PX
+          : viewportOffset.left - COLUMN_AUTOSCROLL_DISTANCE_PX;
+        resizeCallback(targetPageX + resizeAutoScrollDeltaX);
+      }, COLUMN_AUTOSCROLL_INTERVAL_MS);
+    };
+
+    const updateColumnResizeAutoScroll = (
+      clientX: number | undefined,
+      targetPageX: number,
+      resizeCallback: (targetPageX: number) => void
+    ): number => {
+      // Auto-scroll is intentionally disabled for RTL until its scroll coordinate model is supported.
+      if (this._options.rtl || !this._options.autoScrollOnColumnResize) {
+        stopColumnResizeAutoScroll();
+        return targetPageX;
+      }
+
+      autoScrollClientX = typeof clientX === 'number' ? clientX : autoScrollClientX;
+      const left = Utils.offset(this._viewportScrollContainerX)!.left;
+      const viewportWidth = this._viewportScrollContainerX.clientWidth;
+      const right = left + viewportWidth;
+      const browserW = window.innerWidth || document.documentElement.clientWidth || 0;
+
+      if (targetPageX <= left) {
+        autoScrollOffsetX = targetPageX - left;
+      } else if (targetPageX >= right) {
+        autoScrollOffsetX = targetPageX - right;
+      } else if (typeof autoScrollClientX === 'number' && browserW > 0) {
+        autoScrollOffsetX = autoScrollClientX <= RESIZE_AUTOSCROLL_BROWSER_EDGE_PX
+          ? -1
+          : autoScrollClientX >= browserW - RESIZE_AUTOSCROLL_BROWSER_EDGE_PX
+            ? 1
+            : 0;
+      } else {
+        autoScrollOffsetX = 0;
+      }
+
+      if (autoScrollOffsetX) {
+        scheduleColumnResizeAutoScroll(resizeCallback);
+        return autoScrollOffsetX > 0 && viewportWidth ? Math.min(right, targetPageX) : targetPageX;
+      }
+      stopColumnResizeAutoScroll();
+      return targetPageX;
+    };
+
+    stopColumnResizeAutoScroll();
     const children: HTMLElement[] = this.getHeaderChildren();
     const vc = this.getVisibleColumns();
     for (let i = 0; i < children.length; i++) {
@@ -2148,6 +2217,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       const resizeableHandle = Utils.createDomElement('div', { className: 'slick-resizable-handle', role: 'separator', ariaOrientation: 'horizontal' }, colElm);
       this._bindingEventService.bind(resizeableHandle, 'dblclick', this.handleResizeableDoubleClick.bind(this) as EventListener);
+      let applyColumnResize: ((targetPageX: number, resizeElms: { resizeableElement: HTMLElement; resizeableHandleElement: HTMLElement }) => void) | undefined;
 
       this.slickResizableInstances.push(
         Resizable({
@@ -2224,148 +2294,40 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
               maxPageX = pageX + Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft);
               minPageX = pageX - Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight);
             }
+            resizeAutoScrollDeltaX = 0;
+            autoScrollClientX = (targetEvent as MouseEvent).clientX;
+            stopColumnResizeAutoScroll();
           },
           onResize: (e, resizeElms) => {
             const targetEvent = (e as TouchEvent).touches ? (e as TouchEvent).changedTouches[0] : e;
-            this.columnResizeDragging = true;
-            let actualMinWidth;
-            let d = Math.min(maxPageX, Math.max(minPageX, (targetEvent as MouseEvent).pageX)) - pageX;
-
-            if (this._options.rtl) {
-              d = -d;
+            let targetPageX = (targetEvent as MouseEvent).pageX;
+            if (!(this.hasFrozenColumns() && i <= this._options.frozenColumn!)) {
+              targetPageX = updateColumnResizeAutoScroll(
+                (targetEvent as MouseEvent).clientX,
+                targetPageX,
+                (resizePageX) => applyColumnResize?.(resizePageX, resizeElms)
+              );
             }
+            applyColumnResize = (resizePageX, resizeElements) => {
+              this.columnResizeDragging = true;
+              let actualMinWidth;
+              let d = Math.min(maxPageX, Math.max(minPageX, resizePageX)) - pageX;
 
-            let x;
-            let newCanvasWidthL = 0;
-            let newCanvasWidthR = 0;
-            const viewportWidth = this.getViewportInnerWidth();
-
-            if (d < 0) { // shrink column
-              x = d;
-
-              for (j = i; j >= 0; j--) {
-                c = vc[j];
-                if (c?.resizable && !c.hidden) {
-                  actualMinWidth = Math.max(c.minWidth || 0, this.absoluteColumnMinWidth);
-                  if (x && (c.previousWidth || 0) + x < actualMinWidth) {
-                    x += (c.previousWidth || 0) - actualMinWidth;
-                    c.width = actualMinWidth;
-                  } else {
-                    c.width = (c.previousWidth || 0) + x;
-                    x = 0;
-                  }
-                }
+              if (this._options.rtl) {
+                d = -d;
               }
 
-              for (k = 0; k <= i; k++) {
-                c = vc[k];
-                if (!c || c.hidden) { continue; }
+              let x;
+              let newCanvasWidthL = 0;
+              let newCanvasWidthR = 0;
+              const viewportWidth = this.getViewportInnerWidth();
 
-                if (this.hasFrozenColumns() && (k > this._options.frozenColumn!)) {
-                  newCanvasWidthR += c.width || 0;
-                } else {
-                  newCanvasWidthL += c.width || 0;
-                }
-              }
+              if (d < 0) { // shrink column
+                x = d;
 
-              if (this._options.forceFitColumns) {
-                x = -d;
-                for (j = i + 1; j < vc.length; j++) {
+                for (j = i; j >= 0; j--) {
                   c = vc[j];
-                  if (!c || c.hidden) { continue; }
-                  if (c.resizable) {
-                    if (x && c.maxWidth && (c.maxWidth - (c.previousWidth || 0) < x)) {
-                      x -= c.maxWidth - (c.previousWidth || 0);
-                      c.width = c.maxWidth;
-                    } else {
-                      c.width = (c.previousWidth || 0) + x;
-                      x = 0;
-                    }
-
-                    if (this.hasFrozenColumns() && (j > this._options.frozenColumn!)) {
-                      newCanvasWidthR += c.width || 0;
-                    } else {
-                      newCanvasWidthL += c.width || 0;
-                    }
-                  }
-                }
-              } else {
-                for (j = i + 1; j < vc.length; j++) {
-                  c = vc[j];
-                  if (!c || c.hidden) { continue; }
-
-                  if (this.hasFrozenColumns() && (j > this._options.frozenColumn!)) {
-                    newCanvasWidthR += c.width || 0;
-                  } else {
-                    newCanvasWidthL += c.width || 0;
-                  }
-                }
-              }
-
-              if (this._options.forceFitColumns) {
-                x = -d;
-                for (j = i + 1; j < vc.length; j++) {
-                  c = vc[j];
-                  if (!c || c.hidden) { continue; }
-                  if (c.resizable) {
-                    if (x && c.maxWidth && (c.maxWidth - (c.previousWidth || 0) < x)) {
-                      x -= c.maxWidth - (c.previousWidth || 0);
-                      c.width = c.maxWidth;
-                    } else {
-                      c.width = (c.previousWidth || 0) + x;
-                      x = 0;
-                    }
-                  }
-                }
-              }
-            } else { // stretch column
-              x = d;
-
-              newCanvasWidthL = 0;
-              newCanvasWidthR = 0;
-
-              for (j = i; j >= 0; j--) {
-                c = vc[j];
-                if (!c || c.hidden) { continue; }
-                if (c.resizable) {
-                  if (x && c.maxWidth && (c.maxWidth - (c.previousWidth || 0) < x)) {
-                    x -= c.maxWidth - (c.previousWidth || 0);
-                    c.width = c.maxWidth;
-                  } else {
-                    const newWidth = (c.previousWidth || 0) + x;
-                    const resizedCanvasWidthL = this.canvasWidthL + x;
-
-                    if (this.hasFrozenColumns() && (j <= this._options.frozenColumn!)) {
-                      // if we're on the left frozen side, we need to make sure that our left section width never goes over the total viewport width
-                      if (newWidth > frozenLeftColMaxWidth && resizedCanvasWidthL < (viewportWidth - this._options.frozenRightViewportMinWidth!)) {
-                        frozenLeftColMaxWidth = newWidth; // keep max column width ref, if we go over the limit this number will stop increasing
-                      }
-                      c.width = ((resizedCanvasWidthL + this._options.frozenRightViewportMinWidth!) > viewportWidth) ? frozenLeftColMaxWidth : newWidth;
-                    } else {
-                      c.width = newWidth;
-                    }
-                    x = 0;
-                  }
-                }
-              }
-
-              for (k = 0; k <= i; k++) {
-                c = vc[k];
-                if (!c || c.hidden) { continue; }
-
-                if (this.hasFrozenColumns() && (k > this._options.frozenColumn!)) {
-                  newCanvasWidthR += c.width || 0;
-                } else {
-                  newCanvasWidthL += c.width || 0;
-                }
-              }
-
-              if (this._options.forceFitColumns) {
-                x = -d;
-                for (j = i + 1; j < vc.length; j++) {
-                  c = vc[j];
-                  if (!c || c.hidden) { continue; }
-                  if (c.resizable) {
+                  if (c?.resizable && !c.hidden) {
                     actualMinWidth = Math.max(c.minWidth || 0, this.absoluteColumnMinWidth);
                     if (x && (c.previousWidth || 0) + x < actualMinWidth) {
                       x += (c.previousWidth || 0) - actualMinWidth;
@@ -2374,6 +2336,45 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
                       c.width = (c.previousWidth || 0) + x;
                       x = 0;
                     }
+                  }
+                }
+
+                for (k = 0; k <= i; k++) {
+                  c = vc[k];
+                  if (!c || c.hidden) { continue; }
+
+                  if (this.hasFrozenColumns() && (k > this._options.frozenColumn!)) {
+                    newCanvasWidthR += c.width || 0;
+                  } else {
+                    newCanvasWidthL += c.width || 0;
+                  }
+                }
+
+                if (this._options.forceFitColumns) {
+                  x = -d;
+                  for (j = i + 1; j < vc.length; j++) {
+                    c = vc[j];
+                    if (!c || c.hidden) { continue; }
+                    if (c.resizable) {
+                      if (x && c.maxWidth && (c.maxWidth - (c.previousWidth || 0) < x)) {
+                        x -= c.maxWidth - (c.previousWidth || 0);
+                        c.width = c.maxWidth;
+                      } else {
+                        c.width = (c.previousWidth || 0) + x;
+                        x = 0;
+                      }
+
+                      if (this.hasFrozenColumns() && (j > this._options.frozenColumn!)) {
+                        newCanvasWidthR += c.width || 0;
+                      } else {
+                        newCanvasWidthL += c.width || 0;
+                      }
+                    }
+                  }
+                } else {
+                  for (j = i + 1; j < vc.length; j++) {
+                    c = vc[j];
+                    if (!c || c.hidden) { continue; }
 
                     if (this.hasFrozenColumns() && (j > this._options.frozenColumn!)) {
                       newCanvasWidthR += c.width || 0;
@@ -2382,36 +2383,142 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
                     }
                   }
                 }
-              } else {
-                for (j = i + 1; j < vc.length; j++) {
+
+                if (this._options.forceFitColumns) {
+                  x = -d;
+                  for (j = i + 1; j < vc.length; j++) {
+                    c = vc[j];
+                    if (!c || c.hidden) { continue; }
+                    if (c.resizable) {
+                      if (x && c.maxWidth && (c.maxWidth - (c.previousWidth || 0) < x)) {
+                        x -= c.maxWidth - (c.previousWidth || 0);
+                        c.width = c.maxWidth;
+                      } else {
+                        c.width = (c.previousWidth || 0) + x;
+                        x = 0;
+                      }
+                    }
+                  }
+                }
+              } else { // stretch column
+                x = d;
+
+                newCanvasWidthL = 0;
+                newCanvasWidthR = 0;
+
+                for (j = i; j >= 0; j--) {
                   c = vc[j];
                   if (!c || c.hidden) { continue; }
+                  if (c.resizable) {
+                    if (x && c.maxWidth && (c.maxWidth - (c.previousWidth || 0) < x)) {
+                      x -= c.maxWidth - (c.previousWidth || 0);
+                      c.width = c.maxWidth;
+                    } else {
+                      const newWidth = (c.previousWidth || 0) + x;
+                      const resizedCanvasWidthL = this.canvasWidthL + x;
 
-                  if (this.hasFrozenColumns() && (j > this._options.frozenColumn!)) {
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                      if (this.hasFrozenColumns() && (j <= this._options.frozenColumn!)) {
+                        // if we're on the left frozen side, we need to make sure that our left section width never goes over the total viewport width
+                        if (newWidth > frozenLeftColMaxWidth && resizedCanvasWidthL < (viewportWidth - this._options.frozenRightViewportMinWidth!)) {
+                          frozenLeftColMaxWidth = newWidth; // keep max column width ref, if we go over the limit this number will stop increasing
+                        }
+                        c.width = ((resizedCanvasWidthL + this._options.frozenRightViewportMinWidth!) > viewportWidth) ? frozenLeftColMaxWidth : newWidth;
+                      } else {
+                        c.width = newWidth;
+                      }
+                      x = 0;
+                    }
+                  }
+                }
+
+                for (k = 0; k <= i; k++) {
+                  c = vc[k];
+                  if (!c || c.hidden) { continue; }
+
+                  if (this.hasFrozenColumns() && (k > this._options.frozenColumn!)) {
                     newCanvasWidthR += c.width || 0;
                   } else {
                     newCanvasWidthL += c.width || 0;
                   }
                 }
+
+                if (this._options.forceFitColumns) {
+                  x = -d;
+                  for (j = i + 1; j < vc.length; j++) {
+                    c = vc[j];
+                    if (!c || c.hidden) { continue; }
+                    if (c.resizable) {
+                      actualMinWidth = Math.max(c.minWidth || 0, this.absoluteColumnMinWidth);
+                      if (x && (c.previousWidth || 0) + x < actualMinWidth) {
+                        x += (c.previousWidth || 0) - actualMinWidth;
+                        c.width = actualMinWidth;
+                      } else {
+                        c.width = (c.previousWidth || 0) + x;
+                        x = 0;
+                      }
+
+                      if (this.hasFrozenColumns() && (j > this._options.frozenColumn!)) {
+                        newCanvasWidthR += c.width || 0;
+                      } else {
+                        newCanvasWidthL += c.width || 0;
+                      }
+                    }
+                  }
+                } else {
+                  for (j = i + 1; j < vc.length; j++) {
+                    c = vc[j];
+                    if (!c || c.hidden) { continue; }
+
+                    if (this.hasFrozenColumns() && (j > this._options.frozenColumn!)) {
+                      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                      newCanvasWidthR += c.width || 0;
+                    } else {
+                      newCanvasWidthL += c.width || 0;
+                    }
+                  }
+                }
               }
-            }
 
-            if (this.hasFrozenColumns() && newCanvasWidthL !== this.canvasWidthL) {
-              Utils.width(this._headerL, newCanvasWidthL + 1000);
-              Utils.setStyleSize(this._paneHeaderR, 'left', newCanvasWidthL);
-            }
+              if (this.hasFrozenColumns() && newCanvasWidthL !== this.canvasWidthL) {
+                Utils.width(this._headerL, newCanvasWidthL + 1000);
+                Utils.setStyleSize(this._paneHeaderR, 'left', newCanvasWidthL);
+              }
 
-            this.applyColumnHeaderWidths();
-            if (this._options.syncColumnCellResize) {
-              this.applyColumnWidths();
-            }
-            this.trigger(this.onColumnsDrag, {
-              triggeredByColumn: resizeElms.resizeableElement,
-              resizeHandle: resizeElms.resizeableHandleElement
-            });
+              this.applyColumnHeaderWidths();
+              if (this._options.syncColumnCellResize) {
+                this.applyColumnWidths();
+              }
+              this.updateCanvasWidth();
+
+              if (
+                this._options.autoScrollOnColumnResize &&
+                !this._options.rtl &&
+                !this._options.forceFitColumns &&
+                !(this.hasFrozenColumns() && i <= this._options.frozenColumn!)
+              ) {
+                const columnRight = this.columnPosRight[i];
+                const previousScrollLeft = this._viewportScrollContainerX.scrollLeft;
+                const viewportWidth = this._viewportScrollContainerX.clientWidth;
+                const isLastVisibleColumn = i === vc.length - 1;
+
+                if (isLastVisibleColumn) {
+                  const maxScrollLeft = Math.max(0, this._viewportScrollContainerX.scrollWidth - viewportWidth);
+                  this.scrollToX(maxScrollLeft);
+                } else if (columnRight > previousScrollLeft + viewportWidth) {
+                  this.scrollToX(columnRight - viewportWidth);
+                }
+                resizeAutoScrollDeltaX += this._viewportScrollContainerX.scrollLeft - previousScrollLeft;
+              }
+              this.trigger(this.onColumnsDrag, {
+                triggeredByColumn: resizeElements.resizeableElement,
+                resizeHandle: resizeElements.resizeableHandleElement
+              });
+            };
+            applyColumnResize(targetPageX + resizeAutoScrollDeltaX, resizeElms);
           },
           onResizeEnd: (_e, resizeElms) => {
+            stopColumnResizeAutoScroll();
+            resizeAutoScrollDeltaX = 0;
             resizeElms.resizeableElement.classList.remove('slick-header-column-active');
 
             const triggeredByColumn = resizeElms.resizeableElement.id.replace(this.uid, '');
@@ -8124,6 +8231,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   /** Clear all highlight timers that might have been left opened */
   protected clearAllTimers() {
     window.clearTimeout(this._columnResizeTimer);
+    if (this._columnResizeAutoScrollTimer) {
+      window.clearInterval(this._columnResizeAutoScrollTimer);
+      this._columnResizeAutoScrollTimer = undefined;
+    }
     window.clearTimeout(this._executionBlockTimer);
     window.clearTimeout(this._flashCellTimer);
     window.clearTimeout(this._highlightRowTimer);


### PR DESCRIPTION
_replicate Slickgrid-Universal [PR 2633](https://github.com/ghiscoding/slickgrid-universal/pull/2633) and [PR 2773](https://github.com/ghiscoding/slickgrid-universal/pull/2773) into SlickGrid. You can see the included ChatGPT summary below._

**## Summary**

Add horizontal auto-scroll when widening a column past the visible viewport edge.

**## Why**

Column-resize auto-scroll already exists in the Slickgrid-Universal fork and improves resizing large grids where the target column extends beyond the visible viewport.

**## Changes**

- Added the `autoScrollOnColumnResize` grid option, enabled by default.
- Added 10px-per-30ms horizontal auto-scroll during column resize.
- Applied scroll-offset correction so the resized column does not jump while the viewport scrolls.
- Disabled resize auto-scroll for RTL and frozen-column resize cases where it is not supported.
- Added Cypress coverage for regular and frozen-grid resize auto-scroll behavior.
- Added test cleanup for altered column widths and horizontal scroll position.
- Stabilized a fractional-height Cypress assertion for browser-specific sub-pixel rounding.
- Updated the IIFE build loop to await each generated bundle.

**## Validation**

- `npx eslint src/slick.grid.ts src/models/gridOption.interface.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- Rebuilt `dist/browser/slick.grid.js`
- Cypress coverage updated for row-span and frozen-grid examples.

**## Comments**

This ports the column-resize auto-scroll behavior from Slickgrid-Universal, adapted to this codebase.

**## AI / LLM assistance**

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: Codex GPT-5.6 Luna
  - **how was it used**: Assisted with porting the upstream behavior and adding/updating Cypress coverage.

**## Checklist**

- [x] The changes are limited to only one scope (if not please explain why in the comments above).
- [x] Tests were added or updated where appropriate.
- [ ] Documentation was updated where appropriate.
