### PR TITLE
fix(selection): support Shift-click cell range selection

### DIFF
--- a/cypress/e2e/example-plugin-hybridselectionmodel.cy.ts
+++ b/cypress/e2e/example-plugin-hybridselectionmodel.cy.ts
@@ -130,6 +130,19 @@ describe('Example - Context Menu Plugin & Hybrid Selection Mode', () => {
     });
   });
 
+  it('should select a rectangular cell range when Shift-clicking another cell', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/examples/example-plugin-hybridselectionmodel.html`);
+    cy.get('#myGrid .slick-row[data-row="1"] .slick-cell.l2.r2').click();
+    cy.get('#myGrid .slick-row[data-row="3"] .slick-cell.l4.r4').click({ shiftKey: true });
+
+    cy.get('#myGrid .slick-cell.selected').should('have.length', 9);
+    cy.window().then((win: any) => {
+      const ranges = win.grid.getSelectionModel().getSelectedRanges();
+      expect(ranges).to.have.length(1);
+      expect(ranges[0]).to.include({ fromRow: 1, fromCell: 2, toRow: 3, toCell: 4 });
+    });
+  });
+
   it('should add a row range with Ctrl-drag without accumulating live preview ranges', () => {
     cy.visit(`${Cypress.config('baseUrl')}/examples/example-plugin-hybridselectionmodel.html`);
     cy.get('#myGrid .slick-row[data-row="1"] .slick-cell.l0.r0').click();

--- a/src/plugins/slick.hybridselectionmodel.ts
+++ b/src/plugins/slick.hybridselectionmodel.ts
@@ -190,13 +190,11 @@ export class SlickHybridSelectionModel implements SelectionModel {
   }
 
   protected getRowsRange(from: number, to: number) {
-    let i;
     const rows: number[] = [];
-    for (i = from; i <= to; i++) {
-      rows.push(i);
-    }
-    for (i = to; i < from; i++) {
-      rows.push(i);
+    const start = from <= to ? from : to;
+    const end = from <= to ? to : from - 1;
+    for (let row = start; row <= end; row++) {
+      rows.push(row);
     }
     return rows;
   }
@@ -235,19 +233,21 @@ export class SlickHybridSelectionModel implements SelectionModel {
     if (this._activeSelectionIsRow) {
       this._ranges = ranges;
 
-      // provide extra "caller" argument through SlickEventData event to avoid breaking the previous pubsub event structure
-      // that only accepts an array of selected range `SlickRange[]`, the SlickEventData args will be merged and used later by `onSelectedRowsChanged`
-      const eventData = new SlickEventData(new CustomEvent('click', { detail: { caller, selectionMode } }), this._ranges);
-      this.onSelectedRangesChanged.notify(this._ranges, eventData);
+      this.notifySelectedRangesChanged(caller, selectionMode);
     } else {
       this._ranges = this.removeInvalidRanges(ranges);
       if (rangeHasChanged) {
-        // provide extra "caller" argument through SlickEventData event to avoid breaking the previous pubsub event structure
-        // that only accepts an array of selected range `SlickRange[]`, the SlickEventData args will be merged and used later by `onSelectedRowsChanged`
-        const eventData = new SlickEventData(new CustomEvent('click', { detail: { caller, selectionMode, addDragHandle: true } }), this._ranges);
-        this.onSelectedRangesChanged.notify(this._ranges, eventData);
+        this.notifySelectedRangesChanged(caller, selectionMode, true);
       }
     }
+  }
+
+  protected notifySelectedRangesChanged(caller: string, selectionMode: string, addDragHandle = false): void {
+    // provide extra "caller" argument through SlickEventData event to avoid breaking the previous pubsub event structure
+    // that only accepts an array of selected range `SlickRange[]`, the SlickEventData args will be merged and used later by `onSelectedRowsChanged`
+    const detail = { caller, selectionMode, ...(addDragHandle ? { addDragHandle: true } : {}) };
+    const eventData = new SlickEventData(new CustomEvent('click', { detail }), this._ranges);
+    this.onSelectedRangesChanged.notify(this._ranges, eventData);
   }
 
   currentSelectionModeIsRow() {
@@ -493,62 +493,88 @@ export class SlickHybridSelectionModel implements SelectionModel {
   }
 
   protected handleClick(e: SlickEventData_): boolean | void {
-    if (!this._activeSelectionIsRow) {
-      if (!this._options.enableMultiSelection || (!e.ctrlKey && !e.metaKey)) {
-        return;
+    if (this._activeSelectionIsRow) {
+      const cell = this._grid.getCellFromEvent(e);
+      if (!cell || !this._grid.canCellBeActive(cell.row, cell.cell)) {
+        return false;
       }
 
+      if (!this._grid.getOptions().multiSelect || (
+        !e.ctrlKey && !e.shiftKey && !e.metaKey)) {
+        return false;
+      }
+
+      let selection = this.rangesToRows(this._ranges);
+      const idx = selection.indexOf(cell.row);
+      let shouldSetActiveCell = false;
+
+      if (idx === -1 && (e.ctrlKey || e.metaKey)) {
+        selection.push(cell.row);
+        shouldSetActiveCell = true;
+      } else if (idx !== -1 && (e.ctrlKey || e.metaKey)) {
+        selection = selection.filter((o) => o !== cell.row);
+        shouldSetActiveCell = true;
+      } else if (selection.length && e.shiftKey) {
+        const last = selection.pop() as number;
+        const from = Math.min(cell.row, last);
+        const to = Math.max(cell.row, last);
+        selection = [];
+        for (let i = from; i <= to; i++) {
+          if (i !== last) {
+            selection.push(i);
+          }
+        }
+        selection.push(last);
+        shouldSetActiveCell = true;
+      }
+
+      if (shouldSetActiveCell) {
+        this._grid.setActiveCell(cell.row, cell.cell);
+      }
+      const tempRanges = this.rowsToRanges(selection);
+      this.handleClickSelection(e, tempRanges);
+
+      return true;
+    } else if (e.shiftKey) {
+      const cell = this._grid.getCellFromEvent(e);
+      const activeCell = this._grid.getActiveCell();
+      if (!cell || !activeCell || !this._grid.canCellBeActive(cell.row, cell.cell)) {
+        return false;
+      }
+
+      this.handleCellClickSelection(e, cell, [new SlickRange(activeCell.row, activeCell.cell, cell.row, cell.cell)], true);
+
+      return true;
+    } else if (this._options.enableMultiSelection && (e.ctrlKey || e.metaKey)) {
       const cell = this._grid.getCellFromEvent(e);
       if (!cell || !this._grid.canCellBeSelected(cell.row, cell.cell)) {
         return false;
       }
 
       const ranges = this.toggleCellSelectionRange(this.getSelectedRanges().slice(), new SlickRange(cell.row, cell.cell));
-      this._grid.setActiveCell(cell.row, cell.cell, false, false, true);
-      this.setSelectedRanges(ranges);
-      e.stopImmediatePropagation();
+      this.handleCellClickSelection(e, cell, ranges);
 
       return true;
     }
+  }
 
-    const cell = this._grid.getCellFromEvent(e);
-    if (!cell || !this._grid.canCellBeActive(cell.row, cell.cell)) {
-      return false;
+  protected handleCellClickSelection(
+    e: SlickEventData_,
+    cell: { row: number; cell: number },
+    ranges: SlickRange_[],
+    setActiveCellAfterSelection = false
+  ): void {
+    const setActiveCell = () => this._grid.setActiveCell(cell.row, cell.cell, false, false, true);
+    if (!setActiveCellAfterSelection) {
+      setActiveCell();
     }
+    this.handleClickSelection(e, ranges, setActiveCellAfterSelection ? setActiveCell : undefined);
+  }
 
-    if (!this._grid.getOptions().multiSelect || (
-      !e.ctrlKey && !e.shiftKey && !e.metaKey)) {
-      return false;
-    }
-
-    let selection = this.rangesToRows(this._ranges);
-    const idx = selection.indexOf(cell.row);
-
-    if (idx === -1 && (e.ctrlKey || e.metaKey)) {
-      selection.push(cell.row);
-      this._grid.setActiveCell(cell.row, cell.cell);
-    } else if (idx !== -1 && (e.ctrlKey || e.metaKey)) {
-      selection = selection.filter((o) => o !== cell.row);
-      this._grid.setActiveCell(cell.row, cell.cell);
-    } else if (selection.length && e.shiftKey) {
-      const last = selection.pop() as number;
-      const from = Math.min(cell.row, last);
-      const to = Math.max(cell.row, last);
-      selection = [];
-      for (let i = from; i <= to; i++) {
-        if (i !== last) {
-          selection.push(i);
-        }
-      }
-      selection.push(last);
-      this._grid.setActiveCell(cell.row, cell.cell);
-    }
-
-    const tempRanges = this.rowsToRanges(selection);
-    this.setSelectedRanges(tempRanges);
+  protected handleClickSelection(e: SlickEventData_, ranges: SlickRange_[], afterSelection?: () => void): void {
+    this.setSelectedRanges(ranges);
+    afterSelection?.();
     e.stopImmediatePropagation();
-
-    return true;
   }
 
   protected toggleCellSelectionRange(ranges: SlickRange_[], range: SlickRange_): SlickRange_[] {


### PR DESCRIPTION

## Summary

Adds spreadsheet-style Shift-click cell range selection to `SlickHybridSelectionModel`.

## Why

Users expect Shift-clicking a second cell to select the rectangular range between the active cell and the clicked cell.

## Changes

- Added Shift-click cell-range selection.
- Preserved selection ordering when updating the active cell.
- Centralized click-selection and range-notification logic.
- Added Cypress regression coverage.
- Kept Row Detail changes out of scope.

## Validation

- `npm run lint` passed.
- `npm run build:types` passed.
- `npm run build:prod` passed.
- `git diff --check` passed.
- Cypress could not launch in the environment and exited with code 132 before producing test output.

## Comments

This change is limited to hybrid cell selection behavior.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex, GPT-5.6 Luna
  - **how was it used**: Reviewed the related upstream PR, implemented the selection behavior, added regression coverage, and ran validation checks.

## Checklist

- [x] The changes are limited to only one scope.
- [x] Tests were added or updated where appropriate.
- [ ] Documentation was updated where appropriate.