### PR TITLE
chore(demo): fix RTL column reordering example

### DIFF
--- a/cypress/e2e/example-rtl.cy.ts
+++ b/cypress/e2e/example-rtl.cy.ts
@@ -79,6 +79,29 @@ describe('Example - RTL (Right-to-Left) Support', () => {
                 .children()
                 .each(($child, index) => expect($child.text()).to.eq(titles[index]));
         });
+
+        it('should allow columns to be reordered in both directions in RTL mode', () => {
+            const reorderedTitles = [
+                'Title', '% Complete', 'Start', 'Finish', 'Duration', 'Effort Driven',
+                'Priority', 'Status', 'Assignee', 'Department', 'Project', 'Completed'
+            ];
+
+            // Move Duration after Finish
+            cy.contains('#myGrid .slick-header-column', 'Finish').then(($target) => {
+                cy.contains('#myGrid .slick-header-column', 'Duration').drag($target);
+            });
+
+            cy.get('#myGrid').find('.slick-header-columns').children()
+                .each(($child, index) => expect($child.text()).to.eq(reorderedTitles[index]));
+
+            // Move Duration back
+            cy.contains('#myGrid .slick-header-column', '% Complete').then(($target) => {
+                cy.contains('#myGrid .slick-header-column', 'Duration').drag($target);
+            });
+
+            cy.get('#myGrid').find('.slick-header-columns').children()
+                .each(($child, index) => expect($child.text()).to.eq(titles[index]));
+        });
     });
 
     // Section 4: Scrolling Behavior

--- a/examples/example1-simple-rtl.html
+++ b/examples/example1-simple-rtl.html
@@ -8,7 +8,7 @@
   <title>SlickGrid example 1: Basic grid (RTL)</title>
   <link rel="stylesheet" href="../dist/styles/css/example-demo.css" type="text/css" />
   <link rel="stylesheet" href="../dist/styles/css/slick-alpine-theme.css" type="text/css" />
-  </head>
+</head>
 
 <body>
   <h2 class="title">Example 1 Simple Grid (RTL) - ESM</h2>
@@ -27,6 +27,7 @@
         <ul>
           <li>basic grid with minimal configuration</li>
           <li>RTL (right-to-left) support enabled</li>
+          <li>column reordering in RTL mode</li>
         </ul>
         <h2>View Source:</h2>
         <ul>
@@ -38,7 +39,8 @@
     </tr>
   </table>
 
-  <script src="https://cdn.jsdelivr.net/npm/sortablejs/Sortable.min.js"></script>
+  <!-- SortableJS RTL fork: required for column reordering in RTL mode. -->
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs-rtl/Sortable.min.js"></script>
   <script src="sortable-cdn-fallback.js"></script>
 
   <script src="../dist/browser/slick.core.js"></script>
@@ -49,7 +51,7 @@
     var grid;
     var columns = [
       { id: "title", name: "Title", field: "title", width: 90 },
-      { id: "duration", name: "Duration", field: "duration", with: 80 },
+      { id: "duration", name: "Duration", field: "duration", width: 80 },
       { id: "%", name: "% Complete", field: "percentComplete", width: 90 },
       { id: "start", name: "Start", field: "start", width: 80 },
       { id: "finish", name: "Finish", field: "finish", width: 80 },
@@ -64,7 +66,7 @@
 
     var options = {
       enableCellNavigation: true,
-      enableColumnReorder: false,
+      enableColumnReorder: true,
       rtl: true
     };
 


### PR DESCRIPTION
## Summary

This PR enables and verifies column reordering in the RTL example.

* Use the existing `sortablejs-rtl` distribution for the RTL example.
* Enable column reordering in the RTL example.
* Add a note indicating that the RTL-compatible SortableJS distribution is required.
* Add Cypress coverage for column reordering in both directions.

## Implementation

Since SlickGrid consumes SortableJS as an external dependency and the examples already load SortableJS from CDN, I chose to use the existing `sortablejs-rtl` distribution for the RTL example instead of introducing a patched SortableJS dependency through pnpm.

This keeps the change isolated to the RTL example while providing working RTL column reordering with Cypress coverage.